### PR TITLE
Prevent players from jailing themself.

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -3,7 +3,6 @@ package com.palmergames.bukkit.towny.command;
 import com.earth2me.essentials.Teleport;
 import com.earth2me.essentials.User;
 import com.google.common.collect.ListMultimap;
-import com.palmergames.bukkit.config.ConfigNodes;
 import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.TownyEconomyHandler;
 import com.palmergames.bukkit.towny.TownyFormatter;
@@ -50,7 +49,6 @@ import com.palmergames.bukkit.util.ChatTools;
 import com.palmergames.bukkit.util.Colors;
 import com.palmergames.bukkit.util.NameValidation;
 import com.palmergames.util.StringMgmt;
-
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
@@ -63,7 +61,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 
 import javax.naming.InvalidNameException;
-
 import java.io.InvalidObjectException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1168,6 +1165,9 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 
 							Player jailedplayer = TownyUniverse.getPlayer(jailedresident);
 							Town sendertown = resident.getTown();
+							if (jailedplayer.getUniqueId().equals(player.getUniqueId()))
+								throw new TownyException(TownySettings.getLangString("msg_no_self_jailing"));
+
 							if (jailedresident.isJailed()) {
 								Town jailTown = TownyUniverse.getDataSource().getTown(jailedresident.getJailTown());
 								if (jailTown != sendertown) {

--- a/src/english.yml
+++ b/src/english.yml
@@ -818,3 +818,5 @@ status_public2: '&2Public'
 
 # Added in 0.47:
 status_plot_type: '&2Plot Type: &a'
+
+msg_no_self_jailing: 'You cannot jail yourself.'

--- a/src/es-mx.yml
+++ b/src/es-mx.yml
@@ -807,3 +807,4 @@ status_public2: '&2Public'
 
 # Added in 0.47:
 status_plot_type: '&2Plot Type: &a'
+msg_no_self_jailing: 'You cannot jail yourself.'

--- a/src/french.yml
+++ b/src/french.yml
@@ -819,3 +819,4 @@ status_public2: '&2Public'
 
 # Added in 0.47:
 status_plot_type: '&2Plot Type: &a'
+msg_no_self_jailing: 'You cannot jail yourself.'

--- a/src/german.yml
+++ b/src/german.yml
@@ -820,3 +820,4 @@ status_public2: '&2Öffentlich'
 
 # Added in 0.47:
 status_plot_type: '&2Plot Type: &a'
+msg_no_self_jailing: 'You cannot jail yourself.'

--- a/src/italian.yml
+++ b/src/italian.yml
@@ -820,3 +820,4 @@ status_public2: '&2Public'
 
 # Added in 0.47:
 status_plot_type: '&2Plot Type: &a'
+msg_no_self_jailing: 'You cannot jail yourself.'

--- a/src/norwegian.yml
+++ b/src/norwegian.yml
@@ -818,3 +818,4 @@ status_public2: '&2Public'
 
 # Added in 0.47:
 status_plot_type: '&2Plot Type: &a'
+msg_no_self_jailing: 'You cannot jail yourself.'

--- a/src/russian.yml
+++ b/src/russian.yml
@@ -818,3 +818,4 @@ status_public2: '&2Public'
 
 # Added in 0.47:
 status_plot_type: '&2Plot Type: &a'
+msg_no_self_jailing: 'You cannot jail yourself.'

--- a/src/spanish.yml
+++ b/src/spanish.yml
@@ -818,3 +818,4 @@ status_public2: '&2Public'
 
 # Added in 0.47:
 status_plot_type: '&2Plot Type: &a'
+msg_no_self_jailing: 'You cannot jail yourself.'


### PR DESCRIPTION
Using this method players have successfully combat teleported away in an instant on EMC. I don't think anyone could create a counter argument to keep the functionality there that would be dubbed as "useful".