### PR TITLE
Small addition to .gitignore - /out directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Ant
 /bin
+
+# IntelliJ
 /.idea
 *.iml
+/out


### PR DESCRIPTION
Adds IntelliJ Idea's default build directory that it generates when using it's build tool rather than ant.
It's essentially the same thing as /bin (though includes loose files in the project directory, as well as legacy if configured, not just the com.palmergames package.)
Adding to prevent possible poisoning of the git through accidental pushes.