### PR TITLE
Small Refactor for Deprecated Usages

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -2238,7 +2238,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 							chunk.load();
 						// Cause an essentials exception if in cooldown.
 						teleport.cooldown(true);
-						teleport.teleport(spawnLoc, null);
+						teleport.teleport(spawnLoc, null, TeleportCause.COMMAND);
 					}
 				} catch (Exception e) {
 					TownyMessaging.sendErrorMsg(player, "Error: " + e.getMessage());

--- a/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
@@ -585,7 +585,7 @@ public class TownyEntityListener implements Listener {
 		 * TODO: Make this conditional, if bukkit version < 1.11.2 - use the old code.
 		 */
 		// Entity passenger = entity.getPassenger();
-		List<Entity> passenger = entity.getPassengers(); // This seems to be a new addition to Bukkit with 1.13.x
+		List<Entity> passenger = entity.getPassengers();
 
 		TownyWorld World = null;
 

--- a/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
@@ -579,7 +579,13 @@ public class TownyEntityListener implements Listener {
 
 		Block block = event.getBlock();
 		Entity entity = event.getEntity();
-		Entity passenger = entity.getPassenger();
+		/*
+		 * Legacy Code, Deprecated in Bukkit Commit a17b015899f (1.11.2)
+		 * Commit: https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/commits/a17b015899fd9a82d63b61c5a37a52ecbfb89b9e#src/main/java/org/bukkit/entity/Entity.java
+		 * TODO: Make this conditional, if bukkit version < 1.11.2 - use the old code.
+		 */
+		// Entity passenger = entity.getPassenger();
+		List<Entity> passenger = entity.getPassengers(); // This seems to be a new addition to Bukkit with 1.13.x
 
 		TownyWorld World = null;
 

--- a/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -174,7 +174,7 @@ public class TownyPlayerListener implements Listener {
 		
 		// Test against the item in hand as we need to test the bucket contents
 		// we are trying to empty.
-		event.setCancelled(onPlayerInteract(event.getPlayer(), event.getBlockClicked().getRelative(event.getBlockFace()), event.getPlayer().getItemInHand()));
+		event.setCancelled(onPlayerInteract(event.getPlayer(), event.getBlockClicked().getRelative(event.getBlockFace()), event.getPlayer().getInventory().getItemInMainHand()));
 
 		// Test on the resulting empty bucket to see if we have permission to
 		// empty a bucket.
@@ -243,7 +243,7 @@ public class TownyPlayerListener implements Listener {
 			/*
 			 * Info Tool
 			 */
-			if (event.getPlayer().getItemInHand().getType() == Material.getMaterial(TownySettings.getTool())) {
+			if (event.getPlayer().getInventory().getItemInMainHand().getType() == Material.getMaterial(TownySettings.getTool())) {
 
 				if (TownyUniverse.getPermissionSource().isTownyAdmin(player)) {
 					if (event.getClickedBlock() instanceof Block) {
@@ -388,12 +388,12 @@ public class TownyPlayerListener implements Listener {
 			/*
 			 * Item_use protection.
 			 */
-			if (event.getPlayer().getItemInHand() != null) {
+			if (event.getPlayer().getInventory().getItemInMainHand() != null) {
 
 				/*
 				 * Info Tool
 				 */
-				if (event.getPlayer().getItemInHand().getType() == Material.getMaterial(TownySettings.getTool())) {
+				if (event.getPlayer().getInventory().getItemInMainHand().getType() == Material.getMaterial(TownySettings.getTool())) {
 
 					Entity entity = event.getRightClicked();
 
@@ -406,8 +406,8 @@ public class TownyPlayerListener implements Listener {
 
 				}
 
-				if (TownySettings.isItemUseMaterial(event.getPlayer().getItemInHand().getType().name())) {
-					event.setCancelled(onPlayerInteract(event.getPlayer(), null, event.getPlayer().getItemInHand()));
+				if (TownySettings.isItemUseMaterial(event.getPlayer().getInventory().getItemInMainHand().getType().name())) {
+					event.setCancelled(onPlayerInteract(event.getPlayer(), null, event.getPlayer().getInventory().getItemInMainHand()));
 				}
 			}
 		}
@@ -553,12 +553,12 @@ public class TownyPlayerListener implements Listener {
 			/*
 			 * Item_use protection.
 			 */
-			if (event.getPlayer().getItemInHand() != null) {
+			if (event.getPlayer().getInventory().getItemInMainHand() != null) {
 
 				/*
 				 * Info Tool
 				 */
-				if (event.getPlayer().getItemInHand().getType() == Material.getMaterial(TownySettings.getTool())) {
+				if (event.getPlayer().getInventory().getItemInMainHand().getType() == Material.getMaterial(TownySettings.getTool())) {
 
 					Entity entity = event.getRightClicked();
 
@@ -571,8 +571,8 @@ public class TownyPlayerListener implements Listener {
 
 				}
 
-				if (TownySettings.isItemUseMaterial(event.getPlayer().getItemInHand().getType().name())) {
-					event.setCancelled(onPlayerInteract(event.getPlayer(), null, event.getPlayer().getItemInHand()));
+				if (TownySettings.isItemUseMaterial(event.getPlayer().getInventory().getItemInMainHand().getType().name())) {
+					event.setCancelled(onPlayerInteract(event.getPlayer(), null, event.getPlayer().getInventory().getItemInMainHand()));
 				}
 			}
 		}


### PR DESCRIPTION
The intent of this PR is to update some deprecated code. I got distracted while tinkering with flag war, so commits were cherry-picked. All changes have been tested on a clean local server with an unprivileged account.

**Changes**:
- [x] (`/Town Spawn`) Adds TeleportCause to command.
-  [x] (_Affects Players in vehicles activating switches [?]._) Gets entity passengers as a list, instead of the primary passenger - limits usefulness to later 1.11.2 builds and on-wards. (Single-passenger is deprecated and may not run with api-level 1.13[?])
- [x] (_TownyPlayerListener_) Changed all uses of  getItemInHand to getInventory.getItemInMainHand. Old use is deprecated - expect break from 1.8.x.

**Test Environment**:
- Linux (Kernel 4.20.0)
- OpenJDK 11
- Bukkit Implementation: Paper 1.13.2 (Build 495)
- Other Plugins: EssentialsX 2.16.0.16, LuckPerms 4.3.18, Vault 1.7.1-b91 (Default Configs)