### PR TITLE
Nation Distance Recheck & The New Chat Support

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -23,6 +23,7 @@
 		<get src="http://palmergames.com/file-repo/libs/PermissionsEx.jar" dest="${env.LIB}/PermissionsEx.jar" skipexisting="true" />
 		<get src="http://palmergames.com/file-repo/libs/iConomy.jar" dest="${env.LIB}/iConomy.jar" skipexisting="true" />
 		<get src="http://palmergames.com/file-repo/libs/Reserve.jar" dest="${env.LIB}/Reserve.jar" skipexisting="true" />
+		<get src="http://palmergames.com/file-repo/libs/TheNewChat.jar" dest="${env.LIB}/TheNewChat.jar" skipexisting="true" />
 		<get src="http://palmergames.com/file-repo/libs/Vault.jar" dest="${env.LIB}/Vault.jar" skipexisting="true" />
 		<get src="http://palmergames.com/file-repo/libs/citizensapi-2_0-SNAPSHOT.jar" dest="${env.LIB}/citizensapi-2.0-SNAPSHOT.jar" skipexisting="true" />
 	</target>
@@ -39,6 +40,7 @@
 				<pathelement location="${env.LIB}/PermissionsBukkit.jar" />
 				<pathelement location="${env.LIB}/iConomy.jar" />
 				<pathelement location="${env.LIB}/Reserve.jar" />
+				<pathelement location="${env.LIB}/TheNewChat.jar" />
 				<pathelement location="${env.LIB}/Vault.jar" />
 				<pathelement location="${env.LIB}/citizensapi-2.0-SNAPSHOT.jar" />
 			</classpath>

--- a/src/com/palmergames/bukkit/towny/Towny.java
+++ b/src/com/palmergames/bukkit/towny/Towny.java
@@ -184,11 +184,6 @@ public class Towny extends JavaPlugin {
 			TownyLogger.log.info("[Towny] Version: " + version + " - Mod Enabled");
 		TownyLogger.log.info("=============================================================");
 
-		//Add our chat handler to TheNewChat via the API.
-		if(Bukkit.getPluginManager().isPluginEnabled("TheNewChat")) {
-			TNCRegister.initialize();
-		}
-
 		if (!isError()) {
 			// Re login anyone online. (In case of plugin reloading)
 			for (Player player : BukkitTools.getOnlinePlayers())
@@ -380,6 +375,12 @@ public class Towny extends JavaPlugin {
 
 		if (using.size() > 0)
 			TownyLogger.log.info("[Towny] Using: " + StringMgmt.join(using, ", "));
+
+
+		//Add our chat handler to TheNewChat via the API.
+		if(Bukkit.getPluginManager().isPluginEnabled("TheNewChat")) {
+			TNCRegister.initialize();
+		}
 		
 		/*
 		 * Leaving this out for the time being, at the request of the authors of EssentialsX

--- a/src/com/palmergames/bukkit/towny/Towny.java
+++ b/src/com/palmergames/bukkit/towny/Towny.java
@@ -1,8 +1,9 @@
 package com.palmergames.bukkit.towny;
 
 import com.earth2me.essentials.Essentials;
-import com.palmergames.bukkit.metrics.MCStats;
 import com.palmergames.bukkit.metrics.BStats;
+import com.palmergames.bukkit.metrics.MCStats;
+import com.palmergames.bukkit.towny.chat.TNCRegister;
 import com.palmergames.bukkit.towny.command.InviteCommand;
 import com.palmergames.bukkit.towny.command.NationCommand;
 import com.palmergames.bukkit.towny.command.PlotCommand;
@@ -53,7 +54,6 @@ import com.palmergames.bukkit.util.BukkitTools;
 import com.palmergames.util.FileMgmt;
 import com.palmergames.util.JavaUtil;
 import com.palmergames.util.StringMgmt;
-
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.World;
@@ -183,6 +183,11 @@ public class Towny extends JavaPlugin {
 		else
 			TownyLogger.log.info("[Towny] Version: " + version + " - Mod Enabled");
 		TownyLogger.log.info("=============================================================");
+
+		//Add our chat handler to TheNewChat via the API.
+		if(Bukkit.getPluginManager().isPluginEnabled("TheNewChat")) {
+			TNCRegister.initialize();
+		}
 
 		if (!isError()) {
 			// Re login anyone online. (In case of plugin reloading)

--- a/src/com/palmergames/bukkit/towny/chat/TNCRegister.java
+++ b/src/com/palmergames/bukkit/towny/chat/TNCRegister.java
@@ -1,0 +1,13 @@
+package com.palmergames.bukkit.towny.chat;
+
+import net.tnemc.tnc.core.common.api.TNCAPI;
+
+/**
+ * @author creatorfromhell
+ */
+public class TNCRegister {
+
+	public static void initialize() {
+		TNCAPI.addHandler(new TheNewChatHandler());
+	}
+}

--- a/src/com/palmergames/bukkit/towny/chat/TheNewChatHandler.java
+++ b/src/com/palmergames/bukkit/towny/chat/TheNewChatHandler.java
@@ -1,0 +1,35 @@
+package com.palmergames.bukkit.towny.chat;
+
+import com.palmergames.bukkit.towny.chat.checks.KingCheck;
+import com.palmergames.bukkit.towny.chat.checks.MayorCheck;
+import com.palmergames.bukkit.towny.chat.types.AllyType;
+import com.palmergames.bukkit.towny.chat.types.NationType;
+import com.palmergames.bukkit.towny.chat.types.TownType;
+import com.palmergames.bukkit.towny.chat.variables.NationVariable;
+import com.palmergames.bukkit.towny.chat.variables.TitleVariable;
+import com.palmergames.bukkit.towny.chat.variables.TownVariable;
+import net.tnemc.tnc.core.common.chat.ChatHandler;
+
+/**
+ * @author creatorfromhell
+ */
+public class TheNewChatHandler extends ChatHandler {
+
+	public TheNewChatHandler() {
+
+		addType(new AllyType());
+		addType(new NationType());
+		addType(new TownType());
+
+		addVariable(new NationVariable());
+		addVariable(new TownVariable());
+		addVariable(new TitleVariable());
+
+		addCheck(new KingCheck());
+		addCheck(new MayorCheck());
+	}
+	@Override
+	public String getName() {
+		return "towny";
+	}
+}

--- a/src/com/palmergames/bukkit/towny/chat/checks/KingCheck.java
+++ b/src/com/palmergames/bukkit/towny/chat/checks/KingCheck.java
@@ -1,0 +1,27 @@
+package com.palmergames.bukkit.towny.chat.checks;
+
+import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
+import com.palmergames.bukkit.towny.object.TownyUniverse;
+import net.tnemc.tnc.core.common.chat.ChatCheck;
+import org.bukkit.entity.Player;
+
+/**
+ * @author creatorfromhell
+ */
+public class KingCheck extends ChatCheck {
+	@Override
+	public String name() {
+		return "isking";
+	}
+
+	@Override
+	public boolean runCheck(Player player, String checkString) {
+		try {
+			if(TownyUniverse.getDataSource().getResident(player.getName()).hasNation()) {
+				return TownyUniverse.getDataSource().getResident(player.getName()).getTown().getNation().isKing(TownyUniverse.getDataSource().getResident(player.getName()));
+			}
+		} catch(NotRegisteredException ignore) {
+		}
+		return false;
+	}
+}

--- a/src/com/palmergames/bukkit/towny/chat/checks/MayorCheck.java
+++ b/src/com/palmergames/bukkit/towny/chat/checks/MayorCheck.java
@@ -1,0 +1,27 @@
+package com.palmergames.bukkit.towny.chat.checks;
+
+import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
+import com.palmergames.bukkit.towny.object.TownyUniverse;
+import net.tnemc.tnc.core.common.chat.ChatCheck;
+import org.bukkit.entity.Player;
+
+/**
+ * @author creatorfromhell
+ */
+public class MayorCheck extends ChatCheck {
+	@Override
+	public String name() {
+		return "ismayor";
+	}
+
+	@Override
+	public boolean runCheck(Player player, String checkString) {
+		try {
+			if(TownyUniverse.getDataSource().getResident(player.getName()).hasTown()) {
+				return TownyUniverse.getDataSource().getResident(player.getName()).getTown().isMayor(TownyUniverse.getDataSource().getResident(player.getName()));
+			}
+		} catch(NotRegisteredException ignore) {
+		}
+		return false;
+	}
+}

--- a/src/com/palmergames/bukkit/towny/chat/types/AllyType.java
+++ b/src/com/palmergames/bukkit/towny/chat/types/AllyType.java
@@ -1,0 +1,48 @@
+package com.palmergames.bukkit.towny.chat.types;
+
+import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
+import com.palmergames.bukkit.towny.object.Nation;
+import com.palmergames.bukkit.towny.object.TownyUniverse;
+import net.tnemc.tnc.core.common.chat.ChatType;
+import org.bukkit.entity.Player;
+
+import java.util.Collection;
+import java.util.HashSet;
+
+/**
+ * @author creatorfromhell
+ */
+public class AllyType extends ChatType {
+	public AllyType() {
+		super("ally", "<gray>[<aqua>$nation<gray>]: <white>$message");
+	}
+
+	@Override
+	public boolean canChat(Player player) {
+		try {
+			return TownyUniverse.getDataSource().getResident(player.getName()).hasTown() && TownyUniverse.getDataSource().getResident(player.getName()).getTown().hasNation();
+		} catch(NotRegisteredException ignore) {
+
+		}
+		return false;
+	}
+
+	@Override
+	public Collection<Player> getRecipients(Collection<Player> recipients, Player player) {
+		try {
+			final Nation nation = TownyUniverse.getDataSource().getResident(player.getName()).getTown().getNation();
+
+			Collection<Player> newRecipients = new HashSet<>();
+
+			for(Player p : recipients) {
+				if(TownyUniverse.getDataSource().getResident(p.getName()).getTown().getNation().getUuid().equals(nation.getUuid())
+						|| TownyUniverse.getDataSource().getResident(p.getName()).getTown().getNation().hasAlly(nation)) {
+					newRecipients.add(p);
+				}
+			}
+			return newRecipients;
+		} catch(NotRegisteredException ignore) {
+		}
+		return recipients;
+	}
+}

--- a/src/com/palmergames/bukkit/towny/chat/types/NationType.java
+++ b/src/com/palmergames/bukkit/towny/chat/types/NationType.java
@@ -1,0 +1,48 @@
+package com.palmergames.bukkit.towny.chat.types;
+
+import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
+import com.palmergames.bukkit.towny.object.TownyUniverse;
+import net.tnemc.tnc.core.common.chat.ChatType;
+import org.bukkit.entity.Player;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.UUID;
+
+/**
+ * @author creatorfromhell
+ */
+public class NationType extends ChatType {
+	public NationType() {
+		super("nation", "<gray>[<aqua>$town<gray>]$display: <white>$message");
+	}
+
+	@Override
+	public boolean canChat(Player player) {
+		try {
+			return TownyUniverse.getDataSource().getResident(player.getName()).hasTown() && TownyUniverse.getDataSource().getResident(player.getName()).getTown().hasNation();
+		} catch(NotRegisteredException ignore) {
+
+		}
+		return false;
+	}
+
+	@Override
+	public Collection<Player> getRecipients(Collection<Player> recipients, Player player) {
+		try {
+			final UUID nation = TownyUniverse.getDataSource().getResident(player.getName()).getTown().getNation().getUuid();
+
+			Collection<Player> newRecipients = new HashSet<>();
+
+			for(Player p : recipients) {
+				if(TownyUniverse.getDataSource().getResident(p.getName()).getTown().getNation().getUuid().equals(nation)) {
+					newRecipients.add(p);
+				}
+			}
+			return newRecipients;
+		} catch(NotRegisteredException e) {
+			e.printStackTrace();
+		}
+		return recipients;
+	}
+}

--- a/src/com/palmergames/bukkit/towny/chat/types/TownType.java
+++ b/src/com/palmergames/bukkit/towny/chat/types/TownType.java
@@ -1,0 +1,48 @@
+package com.palmergames.bukkit.towny.chat.types;
+
+import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
+import com.palmergames.bukkit.towny.object.TownyUniverse;
+import net.tnemc.tnc.core.common.chat.ChatType;
+import org.bukkit.entity.Player;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.UUID;
+
+/**
+ * @author creatorfromhell
+ */
+public class TownType extends ChatType {
+	public TownType() {
+		super("town", "<aqua>$display: <white>$message");
+	}
+
+	@Override
+	public boolean canChat(Player player) {
+		try {
+			return TownyUniverse.getDataSource().getResident(player.getName()).hasTown();
+		} catch(NotRegisteredException ignore) {
+
+		}
+		return false;
+	}
+
+	@Override
+	public Collection<Player> getRecipients(Collection<Player> recipients, Player player) {
+		try {
+			final UUID town = TownyUniverse.getDataSource().getResident(player.getName()).getTown().getUuid();
+
+			Collection<Player> newRecipients = new HashSet<>();
+
+			for(Player p : recipients) {
+				if(TownyUniverse.getDataSource().getResident(p.getName()).getTown().getUuid().equals(town)) {
+					newRecipients.add(p);
+				}
+			}
+			return newRecipients;
+		} catch(NotRegisteredException e) {
+			e.printStackTrace();
+		}
+		return recipients;
+	}
+}

--- a/src/com/palmergames/bukkit/towny/chat/variables/NationVariable.java
+++ b/src/com/palmergames/bukkit/towny/chat/variables/NationVariable.java
@@ -1,0 +1,25 @@
+package com.palmergames.bukkit.towny.chat.variables;
+
+import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
+import com.palmergames.bukkit.towny.object.TownyUniverse;
+import net.tnemc.tnc.core.common.chat.ChatVariable;
+import org.bukkit.entity.Player;
+
+/**
+ * @author creatorfromhell
+ */
+public class NationVariable extends ChatVariable {
+	@Override
+	public String name() {
+		return "$nation";
+	}
+
+	@Override
+	public String parse(Player player, String message) {
+		try {
+			return TownyUniverse.getDataSource().getResident(player.getName()).getTown().getNation().getName();
+		} catch(NotRegisteredException ignore) {
+			return "";
+		}
+	}
+}

--- a/src/com/palmergames/bukkit/towny/chat/variables/TitleVariable.java
+++ b/src/com/palmergames/bukkit/towny/chat/variables/TitleVariable.java
@@ -1,0 +1,25 @@
+package com.palmergames.bukkit.towny.chat.variables;
+
+import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
+import com.palmergames.bukkit.towny.object.TownyUniverse;
+import net.tnemc.tnc.core.common.chat.ChatVariable;
+import org.bukkit.entity.Player;
+
+/**
+ * @author creatorfromhell
+ */
+public class TitleVariable extends ChatVariable {
+	@Override
+	public String name() {
+		return "$title";
+	}
+
+	@Override
+	public String parse(Player player, String message) {
+		try {
+			return TownyUniverse.getDataSource().getResident(player.getName()).getTitle();
+		} catch(NotRegisteredException ignore) {
+		}
+		return "";
+	}
+}

--- a/src/com/palmergames/bukkit/towny/chat/variables/TownVariable.java
+++ b/src/com/palmergames/bukkit/towny/chat/variables/TownVariable.java
@@ -1,0 +1,25 @@
+package com.palmergames.bukkit.towny.chat.variables;
+
+import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
+import com.palmergames.bukkit.towny.object.TownyUniverse;
+import net.tnemc.tnc.core.common.chat.ChatVariable;
+import org.bukkit.entity.Player;
+
+/**
+ * @author creatorfromhell
+ */
+public class TownVariable extends ChatVariable {
+	@Override
+	public String name() {
+		return "$town";
+	}
+
+	@Override
+	public String parse(Player player, String message) {
+		try {
+			return TownyUniverse.getDataSource().getResident(player.getName()).getTown().getName();
+		} catch(NotRegisteredException ignore) {
+		}
+		return "";
+	}
+}

--- a/src/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -1648,6 +1648,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 						TownyMessaging.sendErrorMsg(player, "Eg: /nation set capital {town name}");
 					else
 							nation.setCapital(newCapital);
+							nation.recheckTownDistance();
 							plugin.resetCache();
 							TownyMessaging.sendNationMessage(nation, TownySettings.getNewKingMsg(newCapital.getMayor().getName(), nation.getName()));
 				} catch (TownyException e) {

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -1660,6 +1660,9 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 
 					try {
 						town.setSpawn(player.getLocation());
+						if(town.isCapital()) {
+							nation.recheckTownDistance();
+						}
 						TownyMessaging.sendMsg(player, TownySettings.getLangString("msg_set_town_spawn"));
 					} catch (TownyException e) {
 						TownyMessaging.sendErrorMsg(player, e.getMessage());

--- a/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -566,6 +566,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			sender.sendMessage(ChatTools.formatCommand(TownySettings.getLangString("admin_sing"), "/townyadmin nation", "[nation] add [] .. []", ""));
 			sender.sendMessage(ChatTools.formatCommand(TownySettings.getLangString("admin_sing"), "/townyadmin nation", "[nation] rename [newname]", ""));
 			sender.sendMessage(ChatTools.formatCommand(TownySettings.getLangString("admin_sing"), "/townyadmin nation", "[nation] delete", ""));
+			sender.sendMessage(ChatTools.formatCommand(TownySettings.getLangString("admin_sing"), "/townyadmin nation", "[nation] recheck", ""));
 
 			return;
 		}
@@ -592,7 +593,10 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 				TownyMessaging.sendGlobalMessage(String.format(TownySettings.getLangString("msg_del_nation"), nation.getName()));
 				TownyUniverse.getDataSource().removeNation(nation);
 
-			} else if (split[1].equalsIgnoreCase("rename")) {
+			} else if(split[1].equalsIgnoreCase("recheck")) {
+				nation.recheckTownDistance();
+				TownyMessaging.sendMessage(sender, String.format(TownySettings.getLangString("nation_rechecked_by_admin"), nation.getName()));
+			}else if (split[1].equalsIgnoreCase("rename")) {
 
 				if (!NameValidation.isBlacklistName(split[2])) {
 					TownyUniverse.getDataSource().renameNation(nation, split[2]);

--- a/src/com/palmergames/bukkit/towny/object/Nation.java
+++ b/src/com/palmergames/bukkit/towny/object/Nation.java
@@ -473,6 +473,7 @@ public class Nation extends TownyEconomyObject implements ResidentList, TownyInv
 
 					double distance = Math.sqrt(Math.pow(capitalCoord.getX() - townCoord.getX(), 2) + Math.pow(capitalCoord.getZ() - townCoord.getZ(), 2));
 					if (distance > TownySettings.getNationRequiresProximity()) {
+						town.setNation(null);
 						it.remove();
 						continue;
 					}

--- a/src/com/palmergames/bukkit/towny/object/Nation.java
+++ b/src/com/palmergames/bukkit/towny/object/Nation.java
@@ -21,13 +21,13 @@ import com.palmergames.bukkit.towny.permissions.TownyPerms;
 import com.palmergames.bukkit.towny.war.flagwar.TownyWar;
 import com.palmergames.bukkit.util.BukkitTools;
 import com.palmergames.util.StringMgmt;
-
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 
@@ -452,6 +452,33 @@ public class Nation extends TownyEconomyObject implements ResidentList, TownyInv
 		removeAllTowns();
 		capital = null;
 		//assistants.clear();
+	}
+
+	/**
+	 * Method for rechecking town distances to a new nation capital/moved nation capital homeblock.
+	 * @throws TownyException
+	 */
+	public void recheckTownDistance() throws TownyException {
+		if(capital != null) {
+			if (TownySettings.getNationRequiresProximity() > 0) {
+				final Coord capitalCoord = capital.getHomeBlock().getCoord();
+				Iterator it = towns.iterator();
+				while(it.hasNext()) {
+					Town town = (Town) it.next();
+					Coord townCoord = town.getHomeBlock().getCoord();
+					if (!capital.getHomeBlock().getWorld().getName().equals(town.getHomeBlock().getWorld().getName())) {
+						it.remove();
+						continue;
+					}
+
+					double distance = Math.sqrt(Math.pow(capitalCoord.getX() - townCoord.getX(), 2) + Math.pow(capitalCoord.getZ() - townCoord.getZ(), 2));
+					if (distance > TownySettings.getNationRequiresProximity()) {
+						it.remove();
+						continue;
+					}
+				}
+			}
+		}
 	}
 
 	public void setNeutral(boolean neutral) throws TownyException {

--- a/src/english.yml
+++ b/src/english.yml
@@ -843,3 +843,5 @@ msg_no_funds_new_nation2: '&cThe town can''t afford to start a new nation, which
 msg_no_funds_claim2: '&cTown cannot afford to claim %s town blocks costing %s. Add %s to the town bank using /t deposit %s'
 msg_err_cant_afford_blocks2: '&cTown cannot afford to claim %s town blocks costing %s. Add %s to the town bank using /t deposit %s'
 msg_err_not_enough_variables: '&cNot enough variables: '
+
+nation_rechecked_by_admin: '&bNation %s town distances have been successfully rechecked.'

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -8,7 +8,7 @@ description: >
     Resident-Town-Nation heirarchy combined with a grid based
     protection system. Including a war event.
 
-softdepend: [MultiVerse,Multiverse-Core,XcraftGate,My Worlds,Citizens,PersonalWorlds,WormholeXTremeWorlds,Vault,Reserve,MultiWorld]
+softdepend: [MultiVerse,Multiverse-Core,XcraftGate,My Worlds,Citizens,PersonalWorlds,WormholeXTremeWorlds,Vault,Reserve,MultiWorld,TheNewChat]
 
 ############################################################
 # +------------------------------------------------------+ #


### PR DESCRIPTION
- Adds support for The New Chat
- Adds /ta nation recheck - Rechecks all towns in the nation to make sure they are within the correct distance of the capital
- Added a check when the capital is moved to remove towns that are not within the correct distance of nation's new capital homeblock.