### PR TITLE
Stopped Mob Removal from loading chunks

### DIFF
--- a/src/com/palmergames/bukkit/towny/tasks/MobRemovalTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/MobRemovalTimerTask.java
@@ -71,8 +71,6 @@ public class MobRemovalTimerTask extends TownyTimerTask {
 			//
 			for (LivingEntity livingEntity : world.getLivingEntities()) {
 				Location livingEntityLoc = livingEntity.getLocation();
-				if (!livingEntityLoc.getChunk().isLoaded())
-					continue;
 
 				Coord coord = Coord.parseCoord(livingEntityLoc);
 				

--- a/src/com/palmergames/bukkit/towny/tasks/MobRemovalTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/MobRemovalTimerTask.java
@@ -71,6 +71,9 @@ public class MobRemovalTimerTask extends TownyTimerTask {
 			//
 			for (LivingEntity livingEntity : world.getLivingEntities()) {
 				Location livingEntityLoc = livingEntity.getLocation();
+				
+				if(!livingEntityLoc.getWorld().isChunkLoaded(livingEntityLoc.getBlockX() >> 4, livingEntityLoc.getBlockZ() >> 4))
+				    continue;
 
 				Coord coord = Coord.parseCoord(livingEntityLoc);
 				


### PR DESCRIPTION
Removed redundant check, as World#getLivingEntities appears to only bring back mobs in loaded chunks.
#3240 