### PR TITLE
Updated .gitignore to include more IDEs and stopped tracking eclipse IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 /bin
 /.idea
 *.iml
+.classpath
+.project
+.externalToolBuilders
+# Add this for people who use IntelliJ to make Towny be in 1 directory only.
+/lib


### PR DESCRIPTION
You would need to delete the eclipse IDE files via GitHub and make a copy on your PC, so that git when it deletes them, doesn't destroy your setup - that's why i didn't delete them in this commit and just made github not track them anymore