### PR TITLE
Remove iConomy5 from dependencies

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -5,7 +5,6 @@
 	<classpathentry kind="lib" path="../lib/bpermissions.jar"/>
 	<classpathentry kind="lib" path="../lib/Essentials.jar"/>
 	<classpathentry kind="lib" path="../lib/EssentialsGroupManager.jar"/>
-	<classpathentry kind="lib" path="../lib/iConomy.jar"/>
 	<classpathentry kind="lib" path="../lib/PermissionsEx.jar"/>
 	<classpathentry kind="lib" path="../lib/bukkit.jar" sourcepath="/lib/bukkit.jar">
 		<attributes>

--- a/build.xml
+++ b/build.xml
@@ -21,7 +21,6 @@
 		<get src="http://palmergames.com/file-repo/libs/Essentials.jar" dest="${env.LIB}/Essentials.jar" skipexisting="true" />
 		<get src="http://palmergames.com/file-repo/libs/EssentialsGroupManager.jar" dest="${env.LIB}/EssentialsGroupManager.jar" skipexisting="true" />
 		<get src="http://palmergames.com/file-repo/libs/PermissionsEx.jar" dest="${env.LIB}/PermissionsEx.jar" skipexisting="true" />
-		<get src="http://palmergames.com/file-repo/libs/iConomy.jar" dest="${env.LIB}/iConomy.jar" skipexisting="true" />
 		<get src="http://palmergames.com/file-repo/libs/Reserve.jar" dest="${env.LIB}/Reserve.jar" skipexisting="true" />
 		<get src="http://palmergames.com/file-repo/libs/TheNewChat.jar" dest="${env.LIB}/TheNewChat.jar" skipexisting="true" />
 		<get src="http://palmergames.com/file-repo/libs/Vault.jar" dest="${env.LIB}/Vault.jar" skipexisting="true" />
@@ -38,7 +37,6 @@
 				<pathelement location="${env.LIB}/EssentialsGroupManager.jar" />
 				<pathelement location="${env.LIB}/PermissionsEx.jar" />
 				<pathelement location="${env.LIB}/PermissionsBukkit.jar" />
-				<pathelement location="${env.LIB}/iConomy.jar" />
 				<pathelement location="${env.LIB}/Reserve.jar" />
 				<pathelement location="${env.LIB}/TheNewChat.jar" />
 				<pathelement location="${env.LIB}/Vault.jar" />

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -614,8 +614,8 @@ public enum ConfigNodes {
 			"",
 			"# This enables/disables all the economy functions of Towny.",
 			"# This will first attempt to use Vault to bridge your economy plugin with Towny.",
-			"# If Vault is not present it will attempt to find the old iConomy 5.01 plugin.",
-			"# If neither Vault or iConomy 5.01 are present it will not be possible to create towns or do any operations that require money."),
+			"# If Vault is not present it will attempt to find a supported economy plugin.",
+			"# If neither Vault or supported economy are present it will not be possible to create towns or do any operations that require money."),
 	PLUGIN_USING_PERMISSIONS(
 			"plugin.interfacing.using_permissions",
 			"true",

--- a/src/com/palmergames/bukkit/towny/TownyEconomyHandler.java
+++ b/src/com/palmergames/bukkit/towny/TownyEconomyHandler.java
@@ -1,7 +1,5 @@
 package com.palmergames.bukkit.towny;
 
-import com.iConomy.iConomy;
-import com.iConomy.system.Account;
 import net.milkbowl.vault.economy.Economy;
 import net.milkbowl.vault.economy.EconomyResponse;
 import net.tnemc.core.Reserve;
@@ -14,7 +12,7 @@ import org.bukkit.plugin.RegisteredServiceProvider;
 import java.math.BigDecimal;
 
 /**
- * Economy handler to interface with Register, Vault or iConomy 5.01 directly.
+ * Economy handler to interface with Register or Vault directly.
  * 
  * @author ElgarL
  * 
@@ -32,7 +30,7 @@ public class TownyEconomyHandler {
 	private static String version = "";
 
 	public enum EcoType {
-		NONE, ICO5, VAULT, RESERVE
+		NONE, VAULT, RESERVE
 	}
 
 	public static void initialize(Towny plugin) {
@@ -86,23 +84,6 @@ public class TownyEconomyHandler {
 		Plugin economyProvider = null;
 
 		/*
-		 * Test for native iCo5 support
-		 */
-		economyProvider = plugin.getServer().getPluginManager().getPlugin("iConomy");
-
-		if (economyProvider != null) {
-			/*
-			 * Flag as using native iCo5 hooks
-			 */
-			if (economyProvider.getDescription().getVersion().matches("5.01")) {
-				setVersion(String.format("%s v%s", "iConomy", economyProvider.getDescription().getVersion()));
-				Type = EcoType.ICO5;
-				return true;
-			}
-		}
-
-
-		/*
 		 * Attempt to find Vault for Economy handling
 		 */
 		try {
@@ -149,9 +130,6 @@ public class TownyEconomyHandler {
 
 		switch (Type) {
 
-		case ICO5:
-			return iConomy.getAccount(accountName);
-
 		case RESERVE:
 			if(reserveEconomy instanceof ExtendedEconomyAPI)
 				return ((ExtendedEconomyAPI)reserveEconomy).getAccount(accountName);
@@ -175,9 +153,6 @@ public class TownyEconomyHandler {
 
 		switch (Type) {
 
-		case ICO5:
-			return iConomy.hasAccount(accountName);
-
 		case RESERVE:
 		  return reserveEconomy.hasAccount(accountName);
 			
@@ -199,10 +174,6 @@ public class TownyEconomyHandler {
 
 		try {
 			switch (Type) {
-
-			case ICO5:
-				iConomy.getAccount(accountName).remove();
-				break;
 
 			case RESERVE:
 				reserveEconomy.deleteAccount(accountName);
@@ -237,12 +208,6 @@ public class TownyEconomyHandler {
 	public static double getBalance(String accountName, World world) {
 
 		switch (Type) {
-
-		case ICO5:
-			Account icoAccount = (Account) getEconomyAccount(accountName);
-			if (icoAccount != null)
-				return icoAccount.getHoldings().balance();
-			break;
 
 		case RESERVE:
 			if (!reserveEconomy.hasAccount(accountName))
@@ -290,14 +255,6 @@ public class TownyEconomyHandler {
 
 		switch (Type) {
 
-		case ICO5:
-			Account icoAccount = (Account) getEconomyAccount(accountName);
-			if (icoAccount != null) {
-				icoAccount.getHoldings().subtract(amount);
-				return true;
-			}
-			break;
-
 		case RESERVE:
 			if (!reserveEconomy.hasAccount(accountName))
 				reserveEconomy.createAccount(accountName);
@@ -329,14 +286,6 @@ public class TownyEconomyHandler {
 
 		switch (Type) {
 
-		case ICO5:
-			Account icoAccount = (Account) getEconomyAccount(accountName);
-			if (icoAccount != null) {
-				icoAccount.getHoldings().add(amount);
-				return true;
-			}
-			break;
-
 		case RESERVE:
 			if (!reserveEconomy.hasAccount(accountName))
 				reserveEconomy.createAccount(accountName);
@@ -360,14 +309,6 @@ public class TownyEconomyHandler {
 	public static boolean setBalance(String accountName, Double amount, World world) {
 
 		switch (Type) {
-
-		case ICO5:
-			Account icoAccount = (Account) getEconomyAccount(accountName);
-			if (icoAccount != null) {
-				icoAccount.getHoldings().set(amount);
-				return true;
-			}
-			break;
 
 		case RESERVE:
 			if (!reserveEconomy.hasAccount(accountName))
@@ -398,9 +339,6 @@ public class TownyEconomyHandler {
 
 		try {
 			switch (Type) {
-
-			case ICO5:
-				return iConomy.format(balance);
 
 			case RESERVE:
 				return reserveEconomy.format(new BigDecimal(balance));

--- a/src/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -1899,7 +1899,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 
 					nation.setNeutral(choice);
 
-					// send message depending on if using IConomy and charging
+					// send message depending on if using an economy and charging
 					// for peaceful
 					if (TownySettings.isUsingEconomy() && cost > 0)
 						TownyMessaging.sendMsg(player, String.format(TownySettings.getLangString("msg_you_paid"), TownyEconomyHandler.getFormattedBalance(cost)));

--- a/src/com/palmergames/bukkit/towny/command/ResidentCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/ResidentCommand.java
@@ -353,7 +353,7 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 				}
 			}
 
-			// Show message if we are using iConomy and are charging for spawn
+			// Show message if we are using an Economy and are charging for spawn
 			// travel.
 			if (travelCost > 0 && TownySettings.isUsingEconomy() && resident.payTo(travelCost, town, String.format("Resident Spawn (%s)", townSpawnPermission))) {
 				TownyMessaging.sendMsg(player, String.format(TownySettings.getLangString("msg_cost_spawn"), TownyEconomyHandler.getFormattedBalance(travelCost))); // +


### PR DESCRIPTION
Why: iConomy5 should now be fully Vault-compliant (according to LlmDl) which should keep it compatible without necessarily building against - and there's currently no publicly facing maven repository, an issue that hinders Towny adopting it's own.