### PR TITLE
Added Town<Create/Delete>Events

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -15,6 +15,8 @@ import com.palmergames.bukkit.towny.confirmations.ConfirmationHandler;
 import com.palmergames.bukkit.towny.confirmations.ConfirmationType;
 import com.palmergames.bukkit.towny.event.NewTownEvent;
 import com.palmergames.bukkit.towny.event.TownBlockSettingsChangedEvent;
+import com.palmergames.bukkit.towny.event.TownCreateEvent;
+import com.palmergames.bukkit.towny.event.TownDeleteEvent;
 import com.palmergames.bukkit.towny.event.TownInvitePlayerEvent;
 import com.palmergames.bukkit.towny.event.TownPreClaimEvent;
 import com.palmergames.bukkit.towny.exceptions.AlreadyRegisteredException;
@@ -1907,7 +1909,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 			if (!noCharge && TownySettings.isUsingEconomy() && !resident.pay(TownySettings.getNewTownPrice(), "New Town Cost"))
 				throw new TownyException(String.format(TownySettings.getLangString("msg_no_funds_new_town2"), (resident.getName().equals(player.getName()) ? "You" : resident.getName()), TownySettings.getNewTownPrice()));
 
-			newTown(world, name, resident, key, player.getLocation());
+			BukkitTools.getPluginManager().callEvent(new TownCreateEvent(newTown(world, name, resident, key, player.getLocation())));
 			TownyMessaging.sendGlobalMessage(TownySettings.getNewTownMsg(player.getName(), name));
 		} catch (TownyException x) {
 			TownyMessaging.sendErrorMsg(player, x.getMessage());
@@ -2355,6 +2357,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 				TownyMessaging.sendErrorMsg(player, x.getMessage());
 				return;
 			}
+			BukkitTools.getPluginManager().callEvent(new TownDeleteEvent(town));
 			TownyMessaging.sendGlobalMessage(TownySettings.getDelTownMsg(town));
 			townyUniverse.getDataSource().removeTown(town);
 		}

--- a/src/com/palmergames/bukkit/towny/event/TownCreateEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/TownCreateEvent.java
@@ -1,0 +1,43 @@
+package com.palmergames.bukkit.towny.event;
+
+import com.palmergames.bukkit.towny.object.Town;
+import org.bukkit.Bukkit;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * @author Artuto
+ *
+ * Fired after a new Town has been created.
+ */
+public class TownCreateEvent extends Event
+{
+    private static final HandlerList handlers = new HandlerList();
+
+    private Town town;
+
+    public TownCreateEvent(Town town) {
+        super(!Bukkit.getServer().isPrimaryThread());
+        this.town = town;
+    }
+
+    /**
+     *
+     * @return the new town
+     * */
+    public Town getTown()
+    {
+        return town;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+
+        return handlers;
+    }
+}

--- a/src/com/palmergames/bukkit/towny/event/TownDeleteEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/TownDeleteEvent.java
@@ -1,0 +1,43 @@
+package com.palmergames.bukkit.towny.event;
+
+import com.palmergames.bukkit.towny.object.Town;
+import org.bukkit.Bukkit;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * @author Artuto
+ *
+ * Fired before a Town is deleted.
+ */
+public class TownDeleteEvent extends Event
+{
+    private static final HandlerList handlers = new HandlerList();
+
+    private Town town;
+
+    public TownDeleteEvent(Town town) {
+        super(!Bukkit.getServer().isPrimaryThread());
+        this.town = town;
+    }
+
+    /**
+     *
+     * @return the town that is going to be deleted
+     * */
+    public Town getTown()
+    {
+        return town;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+
+        return handlers;
+    }
+}


### PR DESCRIPTION
This PR adds the `TownCreateEvent` and `TownDeleteEvent` events.

They are called after the town is created and before the town is deleted, respectively.