### PR TITLE
Critical-Patch: Fix API-Version variable (Runtime Error)

### DIFF
--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: Towny
 main: com.palmergames.bukkit.towny.Towny
 version: ${project.version}
-api-version: ${project.bukkitAPI}
+api-version: ${project.bukkitAPIVersion}
 author: Shade, Modified by FuzzeWuzze. Forked by ElgarL. Forked by LlmDl.
 website: http://towny.palmergames.com/
 description: >
@@ -86,7 +86,7 @@ permissions:
         default: false
         children:
             towny.command.town.outpost.list: true
-            
+
     towny.nation.spawn.*:
         description: Grants all Nation Spawn travel nodes
         default: false


### PR DESCRIPTION
So, uh... Yeah.
Fixes an issue with runtime: Plugin won't load due to the api-version being called wrong.
This is due to a properties variable change in the pom file from commit https://github.com/TownyAdvanced/Towny/pull/3269/commits/a5274227a90d40d2750489e08c46af8f7df7a8a2

![The failure](https://user-images.githubusercontent.com/2712890/62679661-cb54ed00-b97a-11e9-8bec-1247edc22f2d.png)

(Unnecessarily large diff due to growing pains with EditorConfig. File is just changing to use CRLF line endings. Only change is line 4.)
