### PR TITLE
ConsoleConfirmations

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -927,12 +927,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 
 			return;
 		}
-		Resident resident = null;
-		try {
-			resident = TownyUniverse.getInstance().getDataSource().getResident(player.getName());
-		} catch (TownyException e) {
-			TownyMessaging.sendErrorMsg(player, e.getMessage());
-		}
+		
 		int days = 1;
 
 		try {
@@ -941,14 +936,28 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			TownyMessaging.sendErrorMsg(getSender(), TownySettings.getLangString("msg_error_must_be_int"));
 			return;
 		}
-		if (resident != null) {
-			try {
-				ConfirmationHandler.addConfirmation(resident, ConfirmationType.PURGE, days); // It takes the senders town & nation, an admin deleting another town has no confirmation.
-				TownyMessaging.sendConfirmationMessage(player, null, null, null, null);
 
+		if (!isConsole) {
+
+			Resident resident = null;
+			try {
+				resident = TownyUniverse.getInstance().getDataSource().getResident(player.getName());
 			} catch (TownyException e) {
 				TownyMessaging.sendErrorMsg(player, e.getMessage());
 			}
+			
+			if (resident != null) {
+				try {
+					ConfirmationHandler.addConfirmation(resident, ConfirmationType.PURGE, days); // It takes the senders town & nation, an admin deleting another town has no confirmation.
+					TownyMessaging.sendConfirmationMessage(player, null, null, null, null);
+
+				} catch (TownyException e) {
+					TownyMessaging.sendErrorMsg(player, e.getMessage());
+				}
+			}
+		} else { // isConsole
+			ConfirmationHandler.addConfirmation(ConfirmationType.PURGE, days);
+			TownyMessaging.sendConfirmationMessage(Bukkit.getConsoleSender(), null, null, null, null);
 		}
 	}
 

--- a/src/com/palmergames/bukkit/towny/command/commandobjects/CancelCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/commandobjects/CancelCommand.java
@@ -36,6 +36,15 @@ public class CancelCommand extends BukkitCommand {
 					return true;
 				}
 			}
+		} else {
+			// Must be a console.
+			if (ConfirmationHandler.consoleConfirmationType != null) {
+				ConfirmationHandler.removeConfirmation(ConfirmationHandler.consoleConfirmationType, false);
+				return true;
+			} else { 
+				TownyMessaging.sendMsg(TownySettings.getLangString("no_confirmations_open"));
+				return true;
+			}
 		}
 		return true;
 	}

--- a/src/com/palmergames/bukkit/towny/command/commandobjects/CancelCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/commandobjects/CancelCommand.java
@@ -4,6 +4,7 @@ import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.confirmations.ConfirmationHandler;
+import com.palmergames.bukkit.towny.confirmations.ConfirmationType;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Resident;
 import org.bukkit.command.CommandSender;
@@ -38,7 +39,7 @@ public class CancelCommand extends BukkitCommand {
 			}
 		} else {
 			// Must be a console.
-			if (ConfirmationHandler.consoleConfirmationType != null) {
+			if (!ConfirmationHandler.consoleConfirmationType.equals(ConfirmationType.NULL)) {
 				ConfirmationHandler.removeConfirmation(ConfirmationHandler.consoleConfirmationType, false);
 				return true;
 			} else { 

--- a/src/com/palmergames/bukkit/towny/command/commandobjects/ConfirmCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/commandobjects/ConfirmCommand.java
@@ -4,6 +4,7 @@ import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.confirmations.ConfirmationHandler;
+import com.palmergames.bukkit.towny.confirmations.ConfirmationType;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Resident;
 
@@ -45,7 +46,7 @@ public class ConfirmCommand extends BukkitCommand {
 			}
 		} else {
 			// Must be a console.
-			if (ConfirmationHandler.consoleConfirmationType != null) {
+			if (!ConfirmationHandler.consoleConfirmationType.equals(ConfirmationType.NULL)) {
 				try {
 					ConfirmationHandler.handleConfirmation(ConfirmationHandler.consoleConfirmationType);
 				} catch (TownyException e) {

--- a/src/com/palmergames/bukkit/towny/command/commandobjects/ConfirmCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/commandobjects/ConfirmCommand.java
@@ -6,6 +6,8 @@ import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.confirmations.ConfirmationHandler;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Resident;
+
+import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.defaults.BukkitCommand;
 import org.bukkit.entity.Player;
@@ -40,6 +42,20 @@ public class ConfirmCommand extends BukkitCommand {
 					TownyMessaging.sendErrorMsg(player, TownySettings.getLangString("no_confirmations_open"));
 					return true;
 				}
+			}
+		} else {
+			// Must be a console.
+			if (ConfirmationHandler.consoleConfirmationType != null) {
+				try {
+					ConfirmationHandler.handleConfirmation(ConfirmationHandler.consoleConfirmationType);
+				} catch (TownyException e) {
+					TownyMessaging.sendErrorMsg(Bukkit.getConsoleSender(), e.getMessage());
+					return true;
+				}
+				return true;
+			} else { 
+				TownyMessaging.sendMsg(TownySettings.getLangString("no_confirmations_open"));
+				return true;
 			}
 		}
 		return true;

--- a/src/com/palmergames/bukkit/towny/confirmations/ConfirmationHandler.java
+++ b/src/com/palmergames/bukkit/towny/confirmations/ConfirmationHandler.java
@@ -209,6 +209,8 @@ public class ConfirmationHandler {
 						removeConfirmation(type, false);
 					}
 				}.runTaskLater(plugin, 400);
+			} else {
+				TownyMessaging.sendMsg("Unable to start a new confirmation, one already exists of type: " + consoleConfirmationType.toString());
 			}
 		}
 		

--- a/src/com/palmergames/bukkit/towny/confirmations/ConfirmationType.java
+++ b/src/com/palmergames/bukkit/towny/confirmations/ConfirmationType.java
@@ -6,4 +6,5 @@ public enum ConfirmationType {
 	UNCLAIMALL,
 	PURGE, 
 	NATIONMERGE,
+	NULL
 }


### PR DESCRIPTION
- Adds console confirmations.
  - /confirm and /cancel can now handle being run from the console.
  - currently only being used by the /ta purge command.