### PR TITLE
Exponential Town Claiming Costs

### DIFF
--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1157,7 +1157,7 @@ public enum ConfigNodes {
 	ECO_PRICE_CLAIM_TOWNBLOCK_INCREASE(
 			"economy.new_expand.price_claim_townblock_increase",
 			"1.0",
-			"How much every additionally claimed townblock increases in cost. Set to 1 to deactivate this. 1.3 means +30% to every bonus claim block cost."),
+			"# How much every additionally claimed townblock increases in cost. Set to 1 to deactivate this. 1.3 means +30% to every bonus claim block cost."),
 	ECO_PRICE_CLAIM_TOWNBLOCK_REFUND(
 			"economy.new_expand.price_claim_townblock_refund",
 			"0.0",

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1154,6 +1154,10 @@ public enum ConfigNodes {
 			"economy.new_expand.price_claim_townblock",
 			"25.0",
 			"# The price for a town to expand one townblock."),
+	ECO_PRICE_CLAIM_TOWNBLOCK_INCREASE(
+			"economy.new_expand.price_claim_townblock_increase",
+			"1.0",
+			"How much every additionally claimed townblock increases in cost. Set to 1 to deactivate this. 1.3 means +30% to every bonus claim block cost."),
 	ECO_PRICE_CLAIM_TOWNBLOCK_REFUND(
 			"economy.new_expand.price_claim_townblock_refund",
 			"0.0",

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -1519,6 +1519,11 @@ public class TownySettings {
 		return getDouble(ConfigNodes.ECO_PRICE_CLAIM_TOWNBLOCK);
 	}
 	
+	public static double getClaimPriceIncreaseValue() {
+		
+		return getDouble(ConfigNodes.ECO_PRICE_CLAIM_TOWNBLOCK_INCREASE);
+	}
+	
 	public static double getClaimRefundPrice() {
 		
 		return getDouble(ConfigNodes.ECO_PRICE_CLAIM_TOWNBLOCK_REFUND);

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -3019,7 +3019,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 						throw new TownyException(TownySettings.getLangString("msg_err_command_disable"));
 
 					if (TownySettings.isUsingEconomy())
-						blockCost = TownySettings.getClaimPrice();
+						blockCost = town.getTownBlockCost();
 				}
 
 				if ((world.getMinDistanceFromOtherTownsPlots(key, town) < TownySettings.getMinDistanceFromTownPlotblocks()))
@@ -3049,11 +3049,16 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 				if(blockedClaims > 0){
 					throw new TownyException(String.format(TownySettings.getLangString("msg_claim_error"), blockedClaims, selection.size()));
 				}
-				try {
-					double cost = blockCost * selection.size();
-					double missingAmount = cost - town.getHoldingBalance();
-					if (TownySettings.isUsingEconomy() && !town.pay(cost, String.format("Town Claim (%d)", selection.size())))
-						throw new TownyException(String.format(TownySettings.getLangString("msg_no_funds_claim2"), selection.size(), TownyEconomyHandler.getFormattedBalance(cost),  TownyEconomyHandler.getFormattedBalance(missingAmount), new DecimalFormat("#").format(missingAmount)));
+				
+				try {					
+					if (selection.size() == 1 && !outpost)
+						blockCost = town.getTownBlockCost();
+					else
+						blockCost = town.getTownBlockCostN(selection.size());
+
+					double missingAmount = blockCost - town.getHoldingBalance();
+					if (TownySettings.isUsingEconomy() && !town.pay(blockCost, String.format("Town Claim (%d)", selection.size())))
+						throw new TownyException(String.format(TownySettings.getLangString("msg_no_funds_claim2"), selection.size(), TownyEconomyHandler.getFormattedBalance(blockCost),  TownyEconomyHandler.getFormattedBalance(missingAmount), new DecimalFormat("#").format(missingAmount)));
 				} catch (EconomyException e1) {
 					throw new TownyException("Economy Error");
 				}
@@ -3161,10 +3166,14 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		}
 
 		try {
-			double cost = blockCost * selection.size();
-			double missingAmount = cost - town.getHoldingBalance();
-			if (TownySettings.isUsingEconomy() && !owner.canPayFromHoldings(cost))
-				throw new TownyException(String.format(TownySettings.getLangString("msg_err_cant_afford_blocks2"), selection.size(), TownyEconomyHandler.getFormattedBalance(cost),  TownyEconomyHandler.getFormattedBalance(missingAmount), new DecimalFormat("#").format(missingAmount)));
+			if (selection.size() == 1)
+				blockCost = town.getTownBlockCost();
+			else
+				blockCost = town.getTownBlockCostN(selection.size());
+
+			double missingAmount = blockCost - town.getHoldingBalance();
+			if (TownySettings.isUsingEconomy() && !owner.canPayFromHoldings(blockCost))
+				throw new TownyException(String.format(TownySettings.getLangString("msg_err_cant_afford_blocks2"), selection.size(), TownyEconomyHandler.getFormattedBalance(blockCost),  TownyEconomyHandler.getFormattedBalance(missingAmount), new DecimalFormat("#").format(missingAmount)));
 		} catch (EconomyException e1) {
 			throw new TownyException("Economy Error");
 		}

--- a/src/com/palmergames/bukkit/towny/command/TownyCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyCommand.java
@@ -35,6 +35,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
+import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -408,8 +409,12 @@ public class TownyCommand extends BaseCommand implements CommandExecutor {
 
 		output.add(ChatTools.formatTitle("Prices"));
 		output.add(Colors.Yellow + "[New] " + Colors.Green + "Town: " + Colors.LightGreen + TownyEconomyHandler.getFormattedBalance(TownySettings.getNewTownPrice()) + Colors.Gray + " | " + Colors.Green + "Nation: " + Colors.LightGreen + TownyEconomyHandler.getFormattedBalance(TownySettings.getNewNationPrice()));
-		if (town != null)
+		if (town != null) {
 			output.add(Colors.Yellow + "[Upkeep] " + Colors.Green + "Town: " + Colors.LightGreen + TownyEconomyHandler.getFormattedBalance(TownySettings.getTownUpkeepCost(town)) + Colors.Gray + " | " + Colors.Green + "Nation: " + Colors.LightGreen + TownyEconomyHandler.getFormattedBalance(TownySettings.getNationUpkeepCost(nation)));
+			output.add(Colors.Yellow + "[Claiming] " + Colors.Green + "TownBlock: " + Colors.LightGreen + TownyEconomyHandler.getFormattedBalance(town.getTownBlockCost()) + Colors.Gray + 
+					(Double.valueOf(TownySettings.getClaimPriceIncreaseValue()).equals(1.0) ? "" : " | " + Colors.Green + "Increase per TownBlock: " + Colors.LightGreen + "+" +  new DecimalFormat("#%").format(TownySettings.getClaimPriceIncreaseValue()-1)));
+			output.add(Colors.Yellow + "[Claiming] " + Colors.Green + "Outposts: " + Colors.LightGreen + TownyEconomyHandler.getFormattedBalance(TownySettings.getOutpostCost()));
+		}
 		if (town == null)
 			output.add(Colors.Yellow + "[Upkeep] " + Colors.Green + "Town: " + Colors.LightGreen + TownyEconomyHandler.getFormattedBalance(TownySettings.getTownUpkeep()) + Colors.Gray + " | " + Colors.Green + "Nation: " + Colors.LightGreen + TownyEconomyHandler.getFormattedBalance(TownySettings.getNationUpkeep()));
 		output.add(Colors.Gray + "Town upkeep is based on " + Colors.LightGreen + " the " + (TownySettings.isUpkeepByPlot() ? " number of plots" : " town level (num residents)."));

--- a/src/com/palmergames/bukkit/towny/object/Town.java
+++ b/src/com/palmergames/bukkit/towny/object/Town.java
@@ -361,8 +361,34 @@ public class Town extends TownBlockOwner implements ResidentList, TownyInviteRec
 	public double getBonusBlockCost() {
 		double nextprice = (Math.pow(TownySettings.getPurchasedBonusBlocksIncreaseValue() , getPurchasedBlocks()) * TownySettings.getPurchasedBonusBlocksCost());
 		return nextprice;
-	}	
+	}
+	
+	public double getTownBlockCost() {
+		double nextprice = (Math.pow(TownySettings.getClaimPriceIncreaseValue(), getTownBlocks().size()) * TownySettings.getClaimPrice());
+		return nextprice;
+	}
 
+	public double getTownBlockCostN(int inputN) throws TownyException {
+		
+		if (inputN < 0)
+			throw new TownyException(TownySettings.getLangString("msg_err_negative"));
+
+		int n = inputN;
+		if (n == 0)
+			return n;
+		
+		double nextprice = getTownBlockCost();
+		int i = 1;
+		double cost = nextprice;
+		while (i < n){
+			nextprice = Math.round(Math.pow(TownySettings.getClaimPriceIncreaseValue() , getTownBlocks().size()+i) * TownySettings.getClaimPrice());			
+			cost += nextprice;
+			i++;
+		}
+		cost = Math.round(cost);
+		return cost;
+	}
+	
 	public double getBonusBlockCostN(int inputN) throws TownyException {
 		
 		if (inputN < 0)


### PR DESCRIPTION
- New Config Option: economy.new_expand.price_claim_townblock_increase
  - default: 1.0
  - How much every additionally claimed townblock increases in cost. Set
to 1 to deactivate this. 1.3 means +30% to every bonus claim block cost.
- Added townblocks and outpost claiming costs to the /towny prices
screen. Shows cost increase when it is used.