### PR TITLE
Fix Maven Building (1.13)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         </repository>
         <repository>
             <id>github</id>
-            <url>https://maven.pkg.github.com/TheNewEconomy</url>
+            <url>https://maven.pkg.github.com/TheNewEconomy/packages/</url>
         </repository>
         <repository>
             <id>ess-repo</id>
@@ -86,13 +86,13 @@
         <dependency>
             <groupId>net.tnemc</groupId>
             <artifactId>Reserve</artifactId>
-            <version>0.1.2.0</version>
+            <version>0.1.3.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.tnemc.tnc</groupId>
             <artifactId>TheNewChat</artifactId>
-            <version>1.5.0.0</version>
+            <version>1.5.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
- Apparently, the GitHub Package Registry documentation is somewhat misleading. Maven searches through the wrong directory if the repository declaration is set up as it was previously. 
- And @creatorfromhell didn't have the older packages in the registry, either...