### PR TITLE
Replace Hashtables with ConcurrentHashMap

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
             <version>2.10.4</version>
             <scope>provided</scope>
         </dependency>
-        
+
     </dependencies>
 
     <build>

--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -515,6 +515,7 @@ permissions:
             towny.command.townyadmin.town.rename: true
             towny.command.townyadmin.town.set: true
             towny.command.townyadmin.town.toggle: true
+            towny.command.townyadmin.town.meta: true
 
     towny.command.townyadmin.nation.*:
         description: User can access the admin nation commands.
@@ -526,12 +527,13 @@ permissions:
             towny.command.townyadmin.nation.merge: true
             towny.command.townyadmin.nation.toggle: true
             towny.command.townyadmin.nation.set: true
-    
+
     towny.command.townyadmin.plot.*:
         description: User can access the admin plot commans.
         default: false
         children:
             towny.command.townyadmin.plot.claim: true
+            towny.command.townyadmin.plot.meta: true
 
     towny.command.townyadmin.toggle.*:
         description: User can access the admin toggle commands.

--- a/src/com/palmergames/bukkit/towny/TownyAPI.java
+++ b/src/com/palmergames/bukkit/towny/TownyAPI.java
@@ -1,6 +1,7 @@
 package com.palmergames.bukkit.towny;
 
 import com.palmergames.bukkit.towny.db.TownyDataSource;
+import com.palmergames.bukkit.towny.exceptions.KeyAlreadyRegisteredException;
 import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Coord;
@@ -10,6 +11,7 @@ import com.palmergames.bukkit.towny.object.ResidentList;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.WorldCoord;
+import com.palmergames.bukkit.towny.object.metadata.CustomDataField;
 import com.palmergames.bukkit.towny.permissions.TownyPermissionSource;
 import com.palmergames.bukkit.towny.tasks.TeleportWarmupTimerTask;
 import com.palmergames.bukkit.towny.war.eventwar.War;
@@ -20,6 +22,7 @@ import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -387,6 +390,10 @@ public class TownyAPI {
         
         TeleportWarmupTimerTask.abortTeleportRequest(resident);
     }
+    
+    public void registerCustomDataField(CustomDataField field) throws KeyAlreadyRegisteredException {
+    	townyUniverse.addCustomCustomDataField(field);
+	}
     
     public static TownyAPI getInstance() {
         if (instance == null) {

--- a/src/com/palmergames/bukkit/towny/TownyUniverse.java
+++ b/src/com/palmergames/bukkit/towny/TownyUniverse.java
@@ -3,6 +3,7 @@ package com.palmergames.bukkit.towny;
 import com.palmergames.bukkit.towny.db.TownyDataSource;
 import com.palmergames.bukkit.towny.db.TownyFlatFileSource;
 import com.palmergames.bukkit.towny.db.TownySQLSource;
+import com.palmergames.bukkit.towny.exceptions.KeyAlreadyRegisteredException;
 import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
 import com.palmergames.bukkit.towny.object.Coord;
 import com.palmergames.bukkit.towny.object.Nation;
@@ -11,6 +12,7 @@ import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.TownyWorld;
 import com.palmergames.bukkit.towny.object.WorldCoord;
+import com.palmergames.bukkit.towny.object.metadata.CustomDataField;
 import com.palmergames.bukkit.towny.permissions.TownyPermissionSource;
 import com.palmergames.bukkit.towny.permissions.TownyPerms;
 import com.palmergames.bukkit.towny.tasks.OnPlayerLogin;
@@ -28,6 +30,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Hashtable;
 import java.util.List;
+import java.util.HashMap;
 
 /**
  * Towny's class for internal API Methods
@@ -44,6 +47,7 @@ public class TownyUniverse {
     private final Hashtable<String, Town> towns = new Hashtable<>();
     private final Hashtable<String, Nation> nations = new Hashtable<>();
     private final Hashtable<String, TownyWorld> worlds = new Hashtable<>();
+    private final HashMap<String, CustomDataField> registeredMetadata = new HashMap<>();
     private final List<Resident> jailedResidents = new ArrayList<>();
     private final String rootFolder;
     private TownyDataSource dataSource;
@@ -338,6 +342,14 @@ public class TownyUniverse {
         return false;
     }
     
+    public void addCustomCustomDataField(CustomDataField cdf) throws KeyAlreadyRegisteredException {
+    	
+    	if (this.getRegisteredMetadataMap().containsKey(cdf.getKey()))
+    		throw new KeyAlreadyRegisteredException();
+    	
+    	this.getRegisteredMetadataMap().put(cdf.getKey(), cdf);
+	}
+    
     public static TownyUniverse getInstance() {
         if (instance == null) {
             instance = new TownyUniverse();
@@ -351,5 +363,8 @@ public class TownyUniverse {
         towns.clear();
         residents.clear();
     }
-    
+
+	public HashMap<String, CustomDataField> getRegisteredMetadataMap() {
+		return registeredMetadata;
+	}
 }

--- a/src/com/palmergames/bukkit/towny/TownyUniverse.java
+++ b/src/com/palmergames/bukkit/towny/TownyUniverse.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Hashtable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.List;
 import java.util.HashMap;
 
@@ -43,10 +43,10 @@ public class TownyUniverse {
     private static TownyUniverse instance;
     private final Towny towny;
     
-    private final Hashtable<String, Resident> residents = new Hashtable<>();
-    private final Hashtable<String, Town> towns = new Hashtable<>();
-    private final Hashtable<String, Nation> nations = new Hashtable<>();
-    private final Hashtable<String, TownyWorld> worlds = new Hashtable<>();
+    private final ConcurrentHashMap<String, Resident> residents = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Town> towns = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Nation> nations = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, TownyWorld> worlds = new ConcurrentHashMap<>();
     private final HashMap<String, CustomDataField> registeredMetadata = new HashMap<>();
     private final List<Resident> jailedResidents = new ArrayList<>();
     private final String rootFolder;
@@ -251,11 +251,11 @@ public class TownyUniverse {
         return rootFolder;
     }
     
-    public Hashtable<String, Nation> getNationsMap() {
+    public ConcurrentHashMap<String, Nation> getNationsMap() {
         return nations;
     }
     
-    public Hashtable<String, Resident> getResidentMap() {
+    public ConcurrentHashMap<String, Resident> getResidentMap() {
         return residents;
     }
     
@@ -263,11 +263,11 @@ public class TownyUniverse {
         return jailedResidents;
     }
     
-    public Hashtable<String, Town> getTownsMap() {
+    public ConcurrentHashMap<String, Town> getTownsMap() {
         return towns;
     }
     
-    public Hashtable<String, TownyWorld> getWorldMap() {
+    public ConcurrentHashMap<String, TownyWorld> getWorldMap() {
         return worlds;
     }
     

--- a/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
+++ b/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
@@ -128,6 +128,7 @@ public class SQL_Schema {
 		columns.add("`uuid` VARCHAR(36) DEFAULT NULL");
 		columns.add("`registered` BIGINT DEFAULT NULL");
 		columns.add("`spawnCost` float NOT NULL");
+		columns.add("`metadata` text DEFAULT NULL");
 		return columns;
 	}
 
@@ -179,6 +180,7 @@ public class SQL_Schema {
 		columns.add("`permissions` mediumtext NOT NULL");
 		columns.add("`locked` bool NOT NULL DEFAULT '0'");
 		columns.add("`changed` bool NOT NULL DEFAULT '0'");
+		columns.add("`metadata` text DEFAULT NULL");
 		return columns;
 	}
 

--- a/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -13,6 +13,7 @@ import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.TownyWorld;
 import com.palmergames.bukkit.towny.object.WorldCoord;
+import com.palmergames.bukkit.towny.object.metadata.CustomDataField;
 import com.palmergames.bukkit.towny.regen.PlotBlockData;
 import com.palmergames.bukkit.towny.regen.TownyRegenAPI;
 import com.palmergames.bukkit.util.BukkitTools;
@@ -47,6 +48,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.HashSet;
 
 public final class TownyFlatFileSource extends TownyDatabaseHandler {
 
@@ -892,6 +894,10 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 						town.setRegistered(0);
 					}
 				}
+
+				line = keys.get("metadata");
+				if (!line.isEmpty() && line != null)
+					town.setMetadata(line.trim());
 				
 			} catch (Exception e) {
 				TownyMessaging.sendErrorMsg("Loading Error: Exception while reading town file " + town.getName() + " at line: " + line + ", in towny\\data\\towns\\" + town.getName() + ".txt");
@@ -1437,6 +1443,11 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 						world.removeTownBlock(townBlock);
 					}
 					
+					line = keys.get("metadata");
+					if (!line.isEmpty() && line != null) 
+						townBlock.setMetadata(line.trim());
+					
+					
 				} catch (Exception e) {
 					if (test == "town") {
 						TownyMessaging.sendDebugMsg("TownBlock file missing Town, deleting " + path);
@@ -1728,6 +1739,16 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 		// Outlaws
 		list.add("outlaws=" + StringMgmt.join(town.getOutlaws(), ","));
 
+		// Metadata
+		StringBuilder md = new StringBuilder();
+		if (town.hasMeta()) {
+			HashSet<CustomDataField> tdata = town.getMetadata();
+			for (CustomDataField cdf : tdata) {
+				md.append(cdf.toString()).append(";");
+			}
+		}
+		list.add("metadata=" + md.toString());
+
 		/*
 		 *  Make sure we only save in async
 		 */
@@ -1974,6 +1995,17 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 		list.add("changed=" + townBlock.isChanged());
 
 		list.add("locked=" + townBlock.isLocked());
+		
+		// Metadata
+		StringBuilder md = new StringBuilder();
+		if (townBlock.hasMeta()) {
+			HashSet<CustomDataField> tdata = townBlock.getMetadata();
+			for (CustomDataField cdf : tdata) {
+				md.append(cdf.toString()).append(";");
+			}
+		}
+
+		list.add("metadata=" + md.toString());
 
 		/*
 		 *  Make sure we only save in async

--- a/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -19,6 +19,7 @@ import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.TownyWorld;
 import com.palmergames.bukkit.towny.object.WorldCoord;
+import com.palmergames.bukkit.towny.object.metadata.CustomDataField;
 import com.palmergames.bukkit.towny.regen.PlotBlockData;
 import com.palmergames.bukkit.towny.regen.TownyRegenAPI;
 import com.palmergames.bukkit.util.BukkitTools;
@@ -794,7 +795,6 @@ public final class TownySQLSource extends TownyDatabaseHandler {
             String search;
 
             while (rs.next()) {
-
                 line = rs.getString("residents");
                 if (line != null) {
                     search = (line.contains("#")) ? "#" : ",";
@@ -961,8 +961,8 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 
 
                 /*
-				 * Attempt these for older databases.
-				 */
+                 * Attempt these for older databases.
+                 */
                 try {
 
                     line = rs.getString("townBlocks");
@@ -984,6 +984,15 @@ public final class TownySQLSource extends TownyDatabaseHandler {
                 } catch (NumberFormatException | NullPointerException e) {
                     town.setRegistered(0);
                 }
+
+				try {
+					line = rs.getString("metadata");
+					if (line != null && !line.isEmpty()) {
+						town.setMetadata(line);
+					}
+				} catch (SQLException ignored) {
+					
+				}
 
                 s.close();
                 return true;
@@ -1378,7 +1387,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 
     }
 
-    @Override
+	@Override
     public boolean loadTownBlocks() {
 
         String line = "";
@@ -1437,7 +1446,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
                         }
 
                     boolean outpost = rs.getBoolean("outpost");
-                    if (line != null)
+                    if (line != null && !line.isEmpty())
                         try {
                             townBlock.setOutpost(outpost);
                         } catch (Exception ignored) {
@@ -1462,6 +1471,14 @@ public final class TownySQLSource extends TownyDatabaseHandler {
                         townBlock.setLocked(result);
                     } catch (Exception ignored) {
                     }
+                    
+					try {
+						line = rs.getString("metadata");
+						if (line != null) {
+							townBlock.setMetadata(line);
+						}
+					} catch (SQLException ignored) {
+					}
     
                 }
 
@@ -1543,6 +1560,10 @@ public final class TownySQLSource extends TownyDatabaseHandler {
             twn_hm.put("public", town.isPublic());
             twn_hm.put("admindisabledpvp", town.isAdminDisabledPVP());
             twn_hm.put("adminenabledpvp", town.isAdminEnabledPVP());
+			if (town.hasMeta())
+				twn_hm.put("metadata", StringMgmt.join(new ArrayList<CustomDataField>(town.getMetadata()), ";"));
+			else
+				twn_hm.put("metadata", "");
         
             //twn_hm.put("townBlocks", utilSaveTownBlocks(new ArrayList<TownBlock>(town.getTownBlocks())));
             twn_hm.put("homeblock", town.hasHomeBlock() ? town.getHomeBlock().getWorld().getName() + "#" + town.getHomeBlock().getX() + "#" + town.getHomeBlock().getZ() : "");
@@ -1730,6 +1751,10 @@ public final class TownySQLSource extends TownyDatabaseHandler {
             tb_hm.put("permissions", (townBlock.isChanged()) ? townBlock.getPermissions().toString().replaceAll(",", "#") : "");
             tb_hm.put("locked", townBlock.isLocked());
             tb_hm.put("changed", townBlock.isChanged());
+            if (townBlock.hasMeta())
+				tb_hm.put("metadata", StringMgmt.join(new ArrayList<CustomDataField>(townBlock.getMetadata()), ";"));
+			else
+				tb_hm.put("metadata", "");
 
             UpdateDB("TOWNBLOCKS", tb_hm, Arrays.asList("world", "x", "z"));
 

--- a/src/com/palmergames/bukkit/towny/exceptions/InvalidMetadataTypeException.java
+++ b/src/com/palmergames/bukkit/towny/exceptions/InvalidMetadataTypeException.java
@@ -1,0 +1,11 @@
+package com.palmergames.bukkit.towny.exceptions;
+
+import com.palmergames.bukkit.towny.object.metadata.CustomDataFieldType;
+
+public class InvalidMetadataTypeException extends TownyException {
+    private static final long serialVersionUID = 2335936343233569066L;
+    
+    public InvalidMetadataTypeException(CustomDataFieldType type) {
+        super("The given string for type " + type.getTypeName() + " is not valid!");
+    }
+}

--- a/src/com/palmergames/bukkit/towny/exceptions/KeyAlreadyRegisteredException.java
+++ b/src/com/palmergames/bukkit/towny/exceptions/KeyAlreadyRegisteredException.java
@@ -1,0 +1,13 @@
+package com.palmergames.bukkit.towny.exceptions;
+
+public class KeyAlreadyRegisteredException extends TownyException {
+    private static final long serialVersionUID = 1435945343723569023L;
+
+    public KeyAlreadyRegisteredException() {
+        super("Meta Data can't be added because key with same name already exists.");
+    }
+
+    public KeyAlreadyRegisteredException(String message) {
+        super(message);
+    }
+}

--- a/src/com/palmergames/bukkit/towny/exceptions/MetaDataSerializationException.java
+++ b/src/com/palmergames/bukkit/towny/exceptions/MetaDataSerializationException.java
@@ -1,0 +1,7 @@
+package com.palmergames.bukkit.towny.exceptions;
+
+import com.palmergames.bukkit.towny.exceptions.TownyException;
+
+public class MetaDataSerializationException extends TownyException {
+    
+}

--- a/src/com/palmergames/bukkit/towny/object/Town.java
+++ b/src/com/palmergames/bukkit/towny/object/Town.java
@@ -17,6 +17,7 @@ import com.palmergames.bukkit.towny.invites.InviteHandler;
 import com.palmergames.bukkit.towny.invites.TownyInviteReceiver;
 import com.palmergames.bukkit.towny.invites.TownyInviteSender;
 import com.palmergames.bukkit.towny.invites.exceptions.TooManyInvitesException;
+import com.palmergames.bukkit.towny.object.metadata.CustomDataField;
 import com.palmergames.bukkit.towny.permissions.TownyPerms;
 import com.palmergames.bukkit.util.BukkitTools;
 import com.palmergames.util.StringMgmt;
@@ -29,6 +30,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.HashSet;
 
 public class Town extends TownBlockOwner implements ResidentList, TownyInviteReceiver, TownyInviteSender {
 
@@ -64,6 +66,8 @@ public class Town extends TownBlockOwner implements ResidentList, TownyInviteRec
 	private long registered;
 	private transient List<Invite> receivedinvites = new ArrayList<>();
 	private transient List<Invite> sentinvites = new ArrayList<>();
+	private HashSet<CustomDataField> metadata = null;
+	private boolean hasMeta = false;
 
 	public Town(String name) {
 		super(name);
@@ -1275,5 +1279,45 @@ public class Town extends TownBlockOwner implements ResidentList, TownyInviteRec
 	public boolean isOverClaimed() {
 		
 		return (getTownBlocks().size() > TownySettings.getMaxTownBlocks(this));
+	}
+
+	public void addMetaData(CustomDataField md) {
+		if (getMetadata() == null)
+			metadata = new HashSet<>();
+		
+		getMetadata().add(md);
+
+		TownyUniverse.getInstance().getDataSource().saveTown(this);
+	}
+
+	public void removeMetaData(CustomDataField md) {
+		if (!hasMeta())
+			return;
+
+		getMetadata().remove(md);
+		
+		if (getMetadata().size() == 0)
+			this.metadata = null;
+
+		TownyUniverse.getInstance().getDataSource().saveTown(this);
+	}
+
+	public HashSet<CustomDataField> getMetadata() {
+		return metadata;
+	}
+
+	public boolean hasMeta() {
+		return getMetadata() != null;
+	}
+
+	public void setMetadata(String str) {
+
+		if (metadata == null)
+			metadata = new HashSet<>();
+
+		String[] objects = str.split(";");
+		for (int i = 0; i < objects.length; i++) {
+			metadata.add(CustomDataField.load(objects[i]));
+		}
 	}
 }

--- a/src/com/palmergames/bukkit/towny/object/TownBlock.java
+++ b/src/com/palmergames/bukkit/towny/object/TownBlock.java
@@ -3,13 +3,16 @@ package com.palmergames.bukkit.towny.object;
 import com.palmergames.bukkit.towny.TownyEconomyHandler;
 import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.TownySettings;
+import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.event.PlotChangeOwnerEvent;
 import com.palmergames.bukkit.towny.event.PlotChangeTypeEvent;
 import com.palmergames.bukkit.towny.exceptions.AlreadyRegisteredException;
 import com.palmergames.bukkit.towny.exceptions.EconomyException;
 import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
+import com.palmergames.bukkit.towny.object.metadata.CustomDataField;
 import org.bukkit.Bukkit;
+import java.util.HashSet;
 
 public class TownBlock {
 
@@ -24,6 +27,8 @@ public class TownBlock {
 	private double plotPrice = -1;
 	private boolean locked = false;
 	private boolean outpost = false;
+	private HashSet<CustomDataField> metadata = null;
+	private boolean hasMeta = false;
 
 	//Plot level permissions
 	protected TownyPermission permissions = new TownyPermission();
@@ -182,8 +187,6 @@ public class TownBlock {
 
 		return type;
 	}
-
-	
 	
 	public void setType(TownBlockType type) {
 		if (type != this.type)
@@ -452,5 +455,44 @@ public class TownBlock {
 	public boolean isJail() {
 
 		return this.getType() == TownBlockType.JAIL;
+	}
+	
+	public void addMetaData(CustomDataField md) {
+		if (getMetadata() == null)
+			metadata = new HashSet<>();
+		
+		getMetadata().add(md);
+		TownyUniverse.getInstance().getDataSource().saveTownBlock(this);
+	}
+	
+	public void removeMetaData(CustomDataField md) {
+		if (!hasMeta())
+			return;
+		
+		getMetadata().remove(md);
+
+		if (getMetadata().size() == 0)
+			this.metadata = null;
+
+		TownyUniverse.getInstance().getDataSource().saveTownBlock(this);
+	}
+
+	public HashSet<CustomDataField> getMetadata() {
+		return metadata;
+	}
+
+	public boolean hasMeta() {
+		return getMetadata() != null;
+	}
+
+	public void setMetadata(String str) {
+		
+		if (metadata == null)
+			metadata = new HashSet<>();
+		
+		String[] objects = str.split(";");
+		for (int i = 0; i < objects.length; i++) {
+			metadata.add(CustomDataField.load(objects[i]));
+		}
 	}
 }

--- a/src/com/palmergames/bukkit/towny/object/TownyWorld.java
+++ b/src/com/palmergames/bukkit/towny/object/TownyWorld.java
@@ -10,7 +10,7 @@ import org.bukkit.entity.Entity;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Hashtable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.List;
 
 public class TownyWorld extends TownyObject {
@@ -30,7 +30,7 @@ public class TownyWorld extends TownyObject {
 	private Boolean unclaimedZoneBuild = null, unclaimedZoneDestroy = null,
 			unclaimedZoneSwitch = null, unclaimedZoneItemUse = null;
 	private String unclaimedZoneName = null;
-	private Hashtable<Coord, TownBlock> townBlocks = new Hashtable<>();
+	private ConcurrentHashMap<Coord, TownBlock> townBlocks = new ConcurrentHashMap<>();
 	private List<Coord> warZones = new ArrayList<>();
 	private List<String> entityExplosionProtection = null;
 	

--- a/src/com/palmergames/bukkit/towny/object/metadata/BooleanDataField.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/BooleanDataField.java
@@ -1,0 +1,13 @@
+package com.palmergames.bukkit.towny.object.metadata;
+
+public class BooleanDataField extends CustomDataField<Boolean> {
+    
+    public BooleanDataField(String key, Boolean value) {
+        super(key, CustomDataFieldType.BooleanField, value);
+    }
+    
+    public BooleanDataField(String key) {
+        // Initialized to false
+        super(key, CustomDataFieldType.BooleanField, false);
+    }
+}

--- a/src/com/palmergames/bukkit/towny/object/metadata/CustomDataField.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/CustomDataField.java
@@ -1,0 +1,133 @@
+package com.palmergames.bukkit.towny.object.metadata;
+
+import com.palmergames.bukkit.towny.exceptions.InvalidMetadataTypeException;
+
+public abstract class CustomDataField<T> {
+    private CustomDataFieldType type;
+    private T value;
+    private String key;
+    
+    public CustomDataField(String key, CustomDataFieldType type, T value)
+    {
+        this.type = type;
+        this.setValue(value);
+        this.key = key;
+    }
+
+    public CustomDataField(String key, CustomDataFieldType type)
+    {
+        this.type = type;
+        this.value = null;
+        this.key = key;
+    }
+
+    public CustomDataFieldType getType() {
+        return type;
+    }
+
+    public T getValue() {
+        
+        return value;
+    }
+
+    public void setValue(T value) {
+        // TODO: Save to yml
+        
+        this.value = value;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    @Override
+    public String toString() {
+        String out = "";
+        
+        // Type
+        out += type.getValue().toString();
+        
+        // Key
+        out += "," + getKey();
+        
+        // Value
+        out += "," + getValue();
+        
+        return out;
+    }
+    
+    public static CustomDataField load(String str) {
+        String[] tokens = str.split(",");
+        CustomDataFieldType type = CustomDataFieldType.values()[Integer.parseInt(tokens[0])];
+        String key = tokens[1];
+        CustomDataField field = null;
+        
+        switch (type) {
+            case IntegerField:
+                Integer intValue = Integer.parseInt(tokens[2]);
+                field = new IntegerDataField(key, intValue);
+                break;
+            case StringField:
+                field = new StringDataField(key, tokens[2]);
+            case BooleanField:
+                field = new BooleanDataField(key, Boolean.parseBoolean(tokens[2]));
+                break;
+            case DecimalField:
+                field = new DecimalDataField(key, Double.parseDouble(tokens[2]));
+        }
+        
+        return field;
+    }
+    
+    public void isValidType(String str) throws InvalidMetadataTypeException {
+        switch (type) {
+            case IntegerField:
+                try {
+                    Integer.parseInt(str);
+                } catch (NumberFormatException e) {
+                    throw new InvalidMetadataTypeException(type);
+                }
+                break;
+            case BooleanField:
+                // Apparently any string that isn't "true" is just evaluated to false.
+                break;
+            case DecimalField:
+                try {
+                    Double.parseDouble(str);
+                } catch (NumberFormatException e) {
+                    throw new InvalidMetadataTypeException(type);
+                }
+                break;
+        }
+    }
+    
+    @Override
+    public boolean equals(Object rhs) {
+        if (rhs instanceof CustomDataField)
+            return ((CustomDataField) rhs).getKey().equals(this.getKey());
+        
+        return false;
+    }
+    
+    @Override
+    public int hashCode() {
+        // Use the key as a unique id
+        return getKey().hashCode();
+    }
+    
+    public CustomDataField newCopy() {
+        switch (type) {
+            case BooleanField:
+                return new BooleanDataField(getKey(), (Boolean)getValue());
+            case IntegerField:
+                return new IntegerDataField(getKey(), (Integer)getValue());
+            case DecimalField:
+                return new DecimalDataField(getKey(), (Double)getValue());
+            case StringField:
+                return new StringDataField(getKey(), (String)getValue());
+        }
+        
+        return null;
+    }
+    
+}

--- a/src/com/palmergames/bukkit/towny/object/metadata/CustomDataFieldType.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/CustomDataFieldType.java
@@ -1,0 +1,21 @@
+package com.palmergames.bukkit.towny.object.metadata;
+
+public enum CustomDataFieldType {
+    IntegerField(0, "Integer"), StringField(1, "String"), BooleanField(2, "Boolean"), DecimalField(3,"Decimal");
+    
+    private Integer value;
+    private String typeName;
+    
+    CustomDataFieldType(Integer type, String typeName) {
+        this.value = type;
+        this.typeName = typeName;
+    }
+
+    public Integer getValue() {
+        return value;
+    }
+
+    public String getTypeName() {
+        return typeName;
+    }
+}

--- a/src/com/palmergames/bukkit/towny/object/metadata/DecimalDataField.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/DecimalDataField.java
@@ -1,0 +1,11 @@
+package com.palmergames.bukkit.towny.object.metadata;
+
+public class DecimalDataField extends CustomDataField<Double> {
+    public DecimalDataField(String key, Double value) {
+        super(key, CustomDataFieldType.DecimalField, value);
+    }
+
+    public DecimalDataField(String key) {
+        super(key, CustomDataFieldType.DecimalField, 0.0);
+    }
+}

--- a/src/com/palmergames/bukkit/towny/object/metadata/IntegerDataField.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/IntegerDataField.java
@@ -1,0 +1,14 @@
+package com.palmergames.bukkit.towny.object.metadata;
+
+public class IntegerDataField extends CustomDataField<Integer> {
+    
+    // Initializes default value to zero.
+    public IntegerDataField(String key) {
+        super(key, CustomDataFieldType.IntegerField);
+    }
+    
+    // Allow for initialization with default value provided.
+    public IntegerDataField(String key, Integer value) {
+        super(key, CustomDataFieldType.IntegerField, value);
+    }
+}

--- a/src/com/palmergames/bukkit/towny/object/metadata/StringDataField.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/StringDataField.java
@@ -1,0 +1,12 @@
+package com.palmergames.bukkit.towny.object.metadata;
+
+public class StringDataField extends CustomDataField<String> {
+
+    public StringDataField(String key) {
+        super(key, CustomDataFieldType.StringField);
+    }
+    
+    public StringDataField(String key, String value) {
+        super(key, CustomDataFieldType.StringField, value);
+    }
+}

--- a/src/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
+++ b/src/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
@@ -215,6 +215,7 @@ public enum PermissionNodes {
 		
     TOWNY_COMMAND_TOWNYADMIN_PLOT("towny.command.townyadmin.plot.*"),
     	TOWNY_COMMAND_TOWNYADMIN_PLOT_CLAIM("towny.command.townyadmin.plot.claim"),
+		TOWNY_COMMAND_TOWNYADMIN_PLOT_META("towny.command.townyadmin.plot.meta"),
 	
 	TOWNY_COMMAND_TOWNYADMIN_RESIDENT("towny.command.townyadmin.resident.*"),
 		TOWNY_COMMMAND_TOWNYADMIN_RESIDENT_RENAME("towny.command.townyadmin.resident.rename"),
@@ -232,6 +233,7 @@ public enum PermissionNodes {
 		TOWNY_COMMAND_TOWNYADMIN_TOWN_SPAWN_OTHER("towny.command.townyadmin.town.spawn"),
 		TOWNY_COMMAND_TOWNYADMIN_NATION_SPAWN_OTHER("towny.command.townyadmin.nation.spawn"),
 		TOWNY_COMMAND_TOWNYADMIN_TOWN_SPAWN_FREECHARGE("towny.command.townyadmin.town.spawn.freecharge"),
+	    TOWNY_COMMAND_TOWNYADMIN_TOWN_META("towny.command.townyadmin.town.meta"),
 	
 	TOWNY_COMMAND_TOWNYADMIN_NATION("towny.command.townyadmin.nation.*"),
 		TOWNY_COMMAND_TOWNYADMIN_NATION_ADD("towny.command.townyadmin.nation.add"),


### PR DESCRIPTION
## ConcurrentHashMap vs Hashtable

Hashtables are much slower than a normal hashmap. Although they provide thread-safety, they do so at the cost of locking the entire map for reads and writes.
They are also outdated compared to concurrenthashmaps (hashtables were introduced with the original java util, while concurrenthashmaps were introduced in jdk 1.5)

ConcurrentHashMaps are much more efficient because instead of locking the entire map, they lock individual bins. They also **do not lock on reads**, which makes read-access much faster than a hashtable. Furthermore, they offer thread-safe iteration since they copy the internal data to the iterator.

If that doesn't convince you to use ConcurrentHashMaps, then I don't know what will.

## PR Change
This PR simply changes the hashtables within the TownyUniverse class and the hashtable for townblocks within the TownyWorld class to ConcurrentHashMaps. 
Regarding ABI changes, with the latest Towny API most of the previous hashtables were only for internal use and not directly accessible by external plugins anyway. Thus the change should not break any external plugins. 
I have tested this PR, but non-extensively; I really doubt anything will break anyway.