### PR TITLE
Replace hashtables with concurrenthashmaps

### DIFF
--- a/src/com/palmergames/bukkit/towny/TownyUniverse.java
+++ b/src/com/palmergames/bukkit/towny/TownyUniverse.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Hashtable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.List;
 import java.util.HashMap;
 
@@ -43,10 +43,10 @@ public class TownyUniverse {
     private static TownyUniverse instance;
     private final Towny towny;
     
-    private final Hashtable<String, Resident> residents = new Hashtable<>();
-    private final Hashtable<String, Town> towns = new Hashtable<>();
-    private final Hashtable<String, Nation> nations = new Hashtable<>();
-    private final Hashtable<String, TownyWorld> worlds = new Hashtable<>();
+    private final ConcurrentHashMap<String, Resident> residents = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Town> towns = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Nation> nations = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, TownyWorld> worlds = new ConcurrentHashMap<>();
     private final HashMap<String, CustomDataField> registeredMetadata = new HashMap<>();
     private final List<Resident> jailedResidents = new ArrayList<>();
     private final String rootFolder;
@@ -251,11 +251,11 @@ public class TownyUniverse {
         return rootFolder;
     }
     
-    public Hashtable<String, Nation> getNationsMap() {
+    public ConcurrentHashMap<String, Nation> getNationsMap() {
         return nations;
     }
     
-    public Hashtable<String, Resident> getResidentMap() {
+    public ConcurrentHashMap<String, Resident> getResidentMap() {
         return residents;
     }
     
@@ -263,11 +263,11 @@ public class TownyUniverse {
         return jailedResidents;
     }
     
-    public Hashtable<String, Town> getTownsMap() {
+    public ConcurrentHashMap<String, Town> getTownsMap() {
         return towns;
     }
     
-    public Hashtable<String, TownyWorld> getWorldMap() {
+    public ConcurrentHashMap<String, TownyWorld> getWorldMap() {
         return worlds;
     }
     

--- a/src/com/palmergames/bukkit/towny/object/TownyWorld.java
+++ b/src/com/palmergames/bukkit/towny/object/TownyWorld.java
@@ -10,7 +10,7 @@ import org.bukkit.entity.Entity;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Hashtable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.List;
 
 public class TownyWorld extends TownyObject {
@@ -30,7 +30,7 @@ public class TownyWorld extends TownyObject {
 	private Boolean unclaimedZoneBuild = null, unclaimedZoneDestroy = null,
 			unclaimedZoneSwitch = null, unclaimedZoneItemUse = null;
 	private String unclaimedZoneName = null;
-	private Hashtable<Coord, TownBlock> townBlocks = new Hashtable<>();
+	private ConcurrentHashMap<Coord, TownBlock> townBlocks = new ConcurrentHashMap<>();
 	private List<Coord> warZones = new ArrayList<>();
 	private List<String> entityExplosionProtection = null;
 	


### PR DESCRIPTION
Re-Opened PR of  #3486 due to bad merging on my part.
## ConcurrentHashMap vs Hashtable

Hashtables are much slower than a normal hashmap. Although they provide thread-safety, they do so at the cost of locking the entire map for reads and writes.
They are also outdated compared to concurrenthashmaps (hashtables were introduced with the original java util, while concurrenthashmaps were introduced in jdk 1.5)

ConcurrentHashMaps are much more efficient because instead of locking the entire map, they lock individual bins. They also do not lock on reads, which makes read-access much faster than a hashtable. Furthermore, they offer thread-safe iteration since they copy the internal data to the iterator.

If that doesn't convince you to use ConcurrentHashMaps, then I don't know what will.
## PR Change

This PR simply changes the hashtables within the TownyUniverse class and the hashtable for townblocks within the TownyWorld class to ConcurrentHashMaps.
Regarding ABI changes, with the latest Towny API most of the previous hashtables were only for internal use and not directly accessible by external plugins anyway. Thus the change should not break any external plugins.
I have tested this PR, but non-extensively; I really doubt anything will break anyway.