### PR TITLE
nationzones added to the chunknotifier

### DIFF
--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -526,6 +526,12 @@ public enum ConfigNodes {
 			"true",
 			"",
 			"# When set to true, nation zones are disabled during the the Towny war types."),
+	GNATION_SETTINGS_NATIONZONE_SHOW_NOTIFICATIONS(
+			"global_nation_settings.nationzone.show_notifications",
+			"false",
+			"",
+			"# When set to true, players will receive a notification when they enter into a nationzone.",
+			"# Set to false by default because, like the nationzone feature, it will generate more load on servers."),
 	GNATION_SETTINGS_DISPLAY_NATIONBOARD_ONLOGIN(
 			"global_nation_settings.display_board_onlogin",
 			"true",

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -2706,6 +2706,10 @@ public class TownySettings {
 		return getBoolean(ConfigNodes.GNATION_SETTINGS_NATIONZONE_WAR_DISABLES);
 	}
 	
+	public static boolean getNationZonesShowNotifications() {
+		return getBoolean(ConfigNodes.GNATION_SETTINGS_NATIONZONE_SHOW_NOTIFICATIONS);
+	}
+	
 	public static int getNationZonesCapitalBonusSize() {
 		return getInt(ConfigNodes.GNATION_SETTINGS_NATIONZONE_CAPITAL_BONUS_SIZE);
 	}


### PR DESCRIPTION
- New Feature: nation zones show notifications when you enter into them.
  - New Config Option: global_nation_settings.nationzone.show_notifications
    - Default: false
    - When set to true, players will receive a notification when they enter into a nationzone.
    - Set to false by default because, like the nationzone feature, it will generate more load on servers.