### PR TITLE
CooldownTimerTask

### DIFF
--- a/resources/chinese.yml
+++ b/resources/chinese.yml
@@ -1013,5 +1013,5 @@ msg_war_flag_deny_nation_under_attack: 'You cannot do this while a town in your 
 msg_war_flag_deny_recently_attacked: 'You cannot do that! You were attacked too recently!'
 
 # Added in 0.62
-msg_err_cannot_toggle_pvp_x_seconds_remaining: `You cannot toggle PVP, %s seconds remaining.'
-msg_err_cannot_spawn_x_seconds_remaining: `You cannot spawn for another %s seconds.'
+msg_err_cannot_toggle_pvp_x_seconds_remaining: 'You cannot toggle PVP, %s seconds remaining.'
+msg_err_cannot_spawn_x_seconds_remaining: 'You cannot spawn for another %s seconds.'

--- a/resources/chinese.yml
+++ b/resources/chinese.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.61
+version: 0.62
 language: Chinese
 author: ElgarL
 website: 'http://towny.palmergames.com/'
@@ -1011,3 +1011,7 @@ msg_war_participants: '&6[War] &e%s &f(&b%s&f)'
 msg_war_flag_deny_town_under_attack: 'You cannot do that while under attack!'
 msg_war_flag_deny_nation_under_attack: 'You cannot do this while a town in your nation is under attack!'
 msg_war_flag_deny_recently_attacked: 'You cannot do that! You were attacked too recently!'
+
+# Added in 0.62
+msg_err_cannot_toggle_pvp_x_seconds_remaining: `You cannot toggle PVP, %s seconds remaining.'
+msg_err_cannot_spawn_x_seconds_remaining: `You cannot spawn for another %s seconds.'

--- a/resources/english.yml
+++ b/resources/english.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.61
+version: 0.62
 language: english
 author: ElgarL
 website: 'http://towny.palmergames.com/'
@@ -1011,3 +1011,7 @@ msg_war_participants: '&6[War] &e%s &f(&b%s&f)'
 msg_war_flag_deny_town_under_attack: 'You cannot do that while under attack!'
 msg_war_flag_deny_nation_under_attack: 'You cannot do this while a town in your nation is under attack!'
 msg_war_flag_deny_recently_attacked: 'You cannot do that! You were attacked too recently!'
+
+# Added in 0.62
+msg_err_cannot_toggle_pvp_x_seconds_remaining: `You cannot toggle PVP, %s seconds remaining.'
+msg_err_cannot_spawn_x_seconds_remaining: `You cannot spawn for another %s seconds.'

--- a/resources/english.yml
+++ b/resources/english.yml
@@ -1013,5 +1013,5 @@ msg_war_flag_deny_nation_under_attack: 'You cannot do this while a town in your 
 msg_war_flag_deny_recently_attacked: 'You cannot do that! You were attacked too recently!'
 
 # Added in 0.62
-msg_err_cannot_toggle_pvp_x_seconds_remaining: `You cannot toggle PVP, %s seconds remaining.'
-msg_err_cannot_spawn_x_seconds_remaining: `You cannot spawn for another %s seconds.'
+msg_err_cannot_toggle_pvp_x_seconds_remaining: 'You cannot toggle PVP, %s seconds remaining.'
+msg_err_cannot_spawn_x_seconds_remaining: 'You cannot spawn for another %s seconds.'

--- a/resources/es-mx.yml
+++ b/resources/es-mx.yml
@@ -1001,5 +1001,5 @@ msg_war_flag_deny_nation_under_attack: 'You cannot do this while a town in your 
 msg_war_flag_deny_recently_attacked: 'You cannot do that! You were attacked too recently!'
 
 # Added in 0.62
-msg_err_cannot_toggle_pvp_x_seconds_remaining: `You cannot toggle PVP, %s seconds remaining.'
-msg_err_cannot_spawn_x_seconds_remaining: `You cannot spawn for another %s seconds.'
+msg_err_cannot_toggle_pvp_x_seconds_remaining: 'You cannot toggle PVP, %s seconds remaining.'
+msg_err_cannot_spawn_x_seconds_remaining: 'You cannot spawn for another %s seconds.'

--- a/resources/es-mx.yml
+++ b/resources/es-mx.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.61
+version: 0.62
 language: español
 author: VreyaViress
 website: 'http://towny.palmergames.com'
@@ -999,3 +999,7 @@ msg_war_participants: '&6[War] &e%s &f(&b%s&f)'
 msg_war_flag_deny_town_under_attack: 'You cannot do that while under attack!'
 msg_war_flag_deny_nation_under_attack: 'You cannot do this while a town in your nation is under attack!'
 msg_war_flag_deny_recently_attacked: 'You cannot do that! You were attacked too recently!'
+
+# Added in 0.62
+msg_err_cannot_toggle_pvp_x_seconds_remaining: `You cannot toggle PVP, %s seconds remaining.'
+msg_err_cannot_spawn_x_seconds_remaining: `You cannot spawn for another %s seconds.'

--- a/resources/french.yml
+++ b/resources/french.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.61
+version: 0.62
 language: french
 author: Noiknez,TheCalypso
 website: 'http://towny.palmergames.com/'
@@ -1011,3 +1011,7 @@ msg_war_participants: '&6[War] &e%s &f(&b%s&f)'
 msg_war_flag_deny_town_under_attack: 'You cannot do that while under attack!'
 msg_war_flag_deny_nation_under_attack: 'You cannot do this while a town in your nation is under attack!'
 msg_war_flag_deny_recently_attacked: 'You cannot do that! You were attacked too recently!'
+
+# Added in 0.62
+msg_err_cannot_toggle_pvp_x_seconds_remaining: `You cannot toggle PVP, %s seconds remaining.'
+msg_err_cannot_spawn_x_seconds_remaining: `You cannot spawn for another %s seconds.'

--- a/resources/french.yml
+++ b/resources/french.yml
@@ -1013,5 +1013,5 @@ msg_war_flag_deny_nation_under_attack: 'You cannot do this while a town in your 
 msg_war_flag_deny_recently_attacked: 'You cannot do that! You were attacked too recently!'
 
 # Added in 0.62
-msg_err_cannot_toggle_pvp_x_seconds_remaining: `You cannot toggle PVP, %s seconds remaining.'
-msg_err_cannot_spawn_x_seconds_remaining: `You cannot spawn for another %s seconds.'
+msg_err_cannot_toggle_pvp_x_seconds_remaining: 'You cannot toggle PVP, %s seconds remaining.'
+msg_err_cannot_spawn_x_seconds_remaining: 'You cannot spawn for another %s seconds.'

--- a/resources/german.yml
+++ b/resources/german.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.61
+version: 0.62
 language: german
 author: 'ElgarL, translated by Articdive, Wolf2323, BlocK, Yasu-San and enterih'
 website: 'http://towny.palmergames.com/'
@@ -1014,3 +1014,7 @@ msg_war_participants: '&6[War] &e%s &f(&b%s&f)'
 msg_war_flag_deny_town_under_attack: 'You cannot do that while under attack!'
 msg_war_flag_deny_nation_under_attack: 'You cannot do this while a town in your nation is under attack!'
 msg_war_flag_deny_recently_attacked: 'You cannot do that! You were attacked too recently!'
+
+# Added in 0.62
+msg_err_cannot_toggle_pvp_x_seconds_remaining: `You cannot toggle PVP, %s seconds remaining.'
+msg_err_cannot_spawn_x_seconds_remaining: `You cannot spawn for another %s seconds.'

--- a/resources/german.yml
+++ b/resources/german.yml
@@ -1016,5 +1016,5 @@ msg_war_flag_deny_nation_under_attack: 'You cannot do this while a town in your 
 msg_war_flag_deny_recently_attacked: 'You cannot do that! You were attacked too recently!'
 
 # Added in 0.62
-msg_err_cannot_toggle_pvp_x_seconds_remaining: `You cannot toggle PVP, %s seconds remaining.'
-msg_err_cannot_spawn_x_seconds_remaining: `You cannot spawn for another %s seconds.'
+msg_err_cannot_toggle_pvp_x_seconds_remaining: 'You cannot toggle PVP, %s seconds remaining.'
+msg_err_cannot_spawn_x_seconds_remaining: 'You cannot spawn for another %s seconds.'

--- a/resources/italian.yml
+++ b/resources/italian.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.61
+version: 0.62
 language: italian
 author: Leomixer17
 website: 'http://towny.palmergames.com/'
@@ -1013,3 +1013,7 @@ msg_war_participants: '&6[War] &e%s &f(&b%s&f)'
 msg_war_flag_deny_town_under_attack: 'You cannot do that while under attack!'
 msg_war_flag_deny_nation_under_attack: 'You cannot do this while a town in your nation is under attack!'
 msg_war_flag_deny_recently_attacked: 'You cannot do that! You were attacked too recently!'
+
+# Added in 0.62
+msg_err_cannot_toggle_pvp_x_seconds_remaining: `You cannot toggle PVP, %s seconds remaining.'
+msg_err_cannot_spawn_x_seconds_remaining: `You cannot spawn for another %s seconds.'

--- a/resources/italian.yml
+++ b/resources/italian.yml
@@ -1015,5 +1015,5 @@ msg_war_flag_deny_nation_under_attack: 'You cannot do this while a town in your 
 msg_war_flag_deny_recently_attacked: 'You cannot do that! You were attacked too recently!'
 
 # Added in 0.62
-msg_err_cannot_toggle_pvp_x_seconds_remaining: `You cannot toggle PVP, %s seconds remaining.'
-msg_err_cannot_spawn_x_seconds_remaining: `You cannot spawn for another %s seconds.'
+msg_err_cannot_toggle_pvp_x_seconds_remaining: 'You cannot toggle PVP, %s seconds remaining.'
+msg_err_cannot_spawn_x_seconds_remaining: 'You cannot spawn for another %s seconds.'

--- a/resources/korean.yml
+++ b/resources/korean.yml
@@ -926,5 +926,5 @@ msg_war_flag_deny_nation_under_attack: 'You cannot do this while a town in your 
 msg_war_flag_deny_recently_attacked: 'You cannot do that! You were attacked too recently!'
 
 # Added in 0.62
-msg_err_cannot_toggle_pvp_x_seconds_remaining: `You cannot toggle PVP, %s seconds remaining.'
-msg_err_cannot_spawn_x_seconds_remaining: `You cannot spawn for another %s seconds.'
+msg_err_cannot_toggle_pvp_x_seconds_remaining: 'You cannot toggle PVP, %s seconds remaining.'
+msg_err_cannot_spawn_x_seconds_remaining: 'You cannot spawn for another %s seconds.'

--- a/resources/korean.yml
+++ b/resources/korean.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.61
+version: 0.62
 language: 한국어
 author: 'Daybreak 새벽'
 website: 'http://towny.palmergames.com/'
@@ -924,3 +924,7 @@ msg_war_participants: '&6[War] &e%s &f(&b%s&f)'
 msg_war_flag_deny_town_under_attack: 'You cannot do that while under attack!'
 msg_war_flag_deny_nation_under_attack: 'You cannot do this while a town in your nation is under attack!'
 msg_war_flag_deny_recently_attacked: 'You cannot do that! You were attacked too recently!'
+
+# Added in 0.62
+msg_err_cannot_toggle_pvp_x_seconds_remaining: `You cannot toggle PVP, %s seconds remaining.'
+msg_err_cannot_spawn_x_seconds_remaining: `You cannot spawn for another %s seconds.'

--- a/resources/norwegian.yml
+++ b/resources/norwegian.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.61
+version: 0.62
 language: norwegian
 author: Nectuz, Walbern
 website: 'http://towny.palmergames.com/'
@@ -1011,3 +1011,7 @@ msg_war_participants: '&6[War] &e%s &f(&b%s&f)'
 msg_war_flag_deny_town_under_attack: 'You cannot do that while under attack!'
 msg_war_flag_deny_nation_under_attack: 'You cannot do this while a town in your nation is under attack!'
 msg_war_flag_deny_recently_attacked: 'You cannot do that! You were attacked too recently!'
+
+# Added in 0.62
+msg_err_cannot_toggle_pvp_x_seconds_remaining: `You cannot toggle PVP, %s seconds remaining.'
+msg_err_cannot_spawn_x_seconds_remaining: `You cannot spawn for another %s seconds.'

--- a/resources/norwegian.yml
+++ b/resources/norwegian.yml
@@ -1013,5 +1013,5 @@ msg_war_flag_deny_nation_under_attack: 'You cannot do this while a town in your 
 msg_war_flag_deny_recently_attacked: 'You cannot do that! You were attacked too recently!'
 
 # Added in 0.62
-msg_err_cannot_toggle_pvp_x_seconds_remaining: `You cannot toggle PVP, %s seconds remaining.'
-msg_err_cannot_spawn_x_seconds_remaining: `You cannot spawn for another %s seconds.'
+msg_err_cannot_toggle_pvp_x_seconds_remaining: 'You cannot toggle PVP, %s seconds remaining.'
+msg_err_cannot_spawn_x_seconds_remaining: 'You cannot spawn for another %s seconds.'

--- a/resources/russian.yml
+++ b/resources/russian.yml
@@ -1013,5 +1013,5 @@ msg_war_flag_deny_nation_under_attack: 'You cannot do this while a town in your 
 msg_war_flag_deny_recently_attacked: 'You cannot do that! You were attacked too recently!'
 
 # Added in 0.62
-msg_err_cannot_toggle_pvp_x_seconds_remaining: `You cannot toggle PVP, %s seconds remaining.'
-msg_err_cannot_spawn_x_seconds_remaining: `You cannot spawn for another %s seconds.'
+msg_err_cannot_toggle_pvp_x_seconds_remaining: 'You cannot toggle PVP, %s seconds remaining.'
+msg_err_cannot_spawn_x_seconds_remaining: 'You cannot spawn for another %s seconds.'

--- a/resources/russian.yml
+++ b/resources/russian.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.61
+version: 0.62
 language: russian
 author: ElgarL (Plugin developer), Communar (Russian Translation)
 website: 'http://towny.palmergames.com/'
@@ -1011,3 +1011,7 @@ msg_war_participants: '&6[War] &e%s &f(&b%s&f)'
 msg_war_flag_deny_town_under_attack: 'You cannot do that while under attack!'
 msg_war_flag_deny_nation_under_attack: 'You cannot do this while a town in your nation is under attack!'
 msg_war_flag_deny_recently_attacked: 'You cannot do that! You were attacked too recently!'
+
+# Added in 0.62
+msg_err_cannot_toggle_pvp_x_seconds_remaining: `You cannot toggle PVP, %s seconds remaining.'
+msg_err_cannot_spawn_x_seconds_remaining: `You cannot spawn for another %s seconds.'

--- a/resources/spanish.yml
+++ b/resources/spanish.yml
@@ -1013,5 +1013,5 @@ msg_war_flag_deny_nation_under_attack: 'You cannot do this while a town in your 
 msg_war_flag_deny_recently_attacked: 'You cannot do that! You were attacked too recently!'
 
 # Added in 0.62
-msg_err_cannot_toggle_pvp_x_seconds_remaining: `You cannot toggle PVP, %s seconds remaining.'
-msg_err_cannot_spawn_x_seconds_remaining: `You cannot spawn for another %s seconds.'
+msg_err_cannot_toggle_pvp_x_seconds_remaining: 'You cannot toggle PVP, %s seconds remaining.'
+msg_err_cannot_spawn_x_seconds_remaining: 'You cannot spawn for another %s seconds.'

--- a/resources/spanish.yml
+++ b/resources/spanish.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.61
+version: 0.62
 language: spanish
 author: Seruhio, Alvarote1998, Beelzebu
 website: 'http://towny.palmergames.com/'
@@ -1011,3 +1011,7 @@ msg_war_participants: '&6[War] &e%s &f(&b%s&f)'
 msg_war_flag_deny_town_under_attack: 'You cannot do that while under attack!'
 msg_war_flag_deny_nation_under_attack: 'You cannot do this while a town in your nation is under attack!'
 msg_war_flag_deny_recently_attacked: 'You cannot do that! You were attacked too recently!'
+
+# Added in 0.62
+msg_err_cannot_toggle_pvp_x_seconds_remaining: `You cannot toggle PVP, %s seconds remaining.'
+msg_err_cannot_spawn_x_seconds_remaining: `You cannot spawn for another %s seconds.'

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -376,6 +376,16 @@ public enum ConfigNodes {
 			"global_town_settings.teleport_warmup_time",
 			"0",
 			"# If non zero it delays any spawn request by x seconds."),
+	GTOWN_SETTINGS_SPAWN_COOLDOWN_TIMER(
+			"global_town_settings.spawn_cooldown_time",
+			"30",
+			"# Number of seconds that must pass before a player can use /t spawn or /res spawn."),
+	GTOWN_SETTINGS_PVP_COOLDOWN_TIMER(
+			"global_town_settings.pvp_cooldown_time",
+			"30",
+			"# Number of seconds that must pass before pvp can be toggled by a town.",
+			"# Applies to residents of the town using /res toggle pvp, as well as",
+			"# plots having their PVP toggled using /plot toggle pvp."),	
 	GTOWN_SETTINGS_TOWN_RESPAWN(
 			"global_town_settings.town_respawn",
 			"false",

--- a/src/com/palmergames/bukkit/towny/Towny.java
+++ b/src/com/palmergames/bukkit/towny/Towny.java
@@ -263,6 +263,7 @@ public class Towny extends JavaPlugin {
 		TownyTimerHandler.toggleMobRemoval(false);
 		TownyTimerHandler.toggleHealthRegen(false);
 		TownyTimerHandler.toggleTeleportWarmup(false);
+		TownyTimerHandler.toggleCooldownTimer(false);
 		TownyTimerHandler.toggleDrawSmokeTask(false);
 
 		// Start timers
@@ -271,6 +272,7 @@ public class Towny extends JavaPlugin {
 		TownyTimerHandler.toggleMobRemoval(true);
 		TownyTimerHandler.toggleHealthRegen(TownySettings.hasHealthRegen());
 		TownyTimerHandler.toggleTeleportWarmup(TownySettings.getTeleportWarmupTime() > 0);
+		TownyTimerHandler.toggleCooldownTimer(TownySettings.getPVPCoolDownTime() > 0 || TownySettings.getSpawnCooldownTime() > 0);
 		TownyTimerHandler.toggleDrawSmokeTask(true);
 		resetCache();
 

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -2527,6 +2527,16 @@ public class TownySettings {
 		return getInt(ConfigNodes.GTOWN_SETTINGS_SPAWN_TIMER);
 	}
 	
+	public static int getSpawnCooldownTime() {
+		
+		return getInt(ConfigNodes.GTOWN_SETTINGS_SPAWN_COOLDOWN_TIMER);
+	}
+	
+	public static int getPVPCoolDownTime() {
+
+		return getInt(ConfigNodes.GTOWN_SETTINGS_PVP_COOLDOWN_TIMER);
+	}
+	
 	public static String getTownAccountPrefix() {
 
 		return getString(ConfigNodes.ECO_TOWN_PREFIX);

--- a/src/com/palmergames/bukkit/towny/TownyTimerHandler.java
+++ b/src/com/palmergames/bukkit/towny/TownyTimerHandler.java
@@ -122,7 +122,7 @@ public class TownyTimerHandler{
 	public static void toggleCooldownTimer(boolean on) {
 		
 		if (on && !isCooldownTimerRunning()) {
-			cooldownTimerTask = BukkitTools.scheduleSyncRepeatingTask(new CooldownTimerTask(plugin), 0, 100);
+			cooldownTimerTask = BukkitTools.scheduleSyncRepeatingTask(new CooldownTimerTask(plugin), 0, 20);
 			if (cooldownTimerTask == -1)
 				TownyMessaging.sendErrorMsg("Could not schedule cooldown timer loop.");			
 		} else if (!on && isCooldownTimerRunning()) {

--- a/src/com/palmergames/bukkit/towny/TownyTimerHandler.java
+++ b/src/com/palmergames/bukkit/towny/TownyTimerHandler.java
@@ -1,5 +1,6 @@
 package com.palmergames.bukkit.towny;
 
+import com.palmergames.bukkit.towny.tasks.CooldownTimerTask;
 import com.palmergames.bukkit.towny.tasks.DailyTimerTask;
 import com.palmergames.bukkit.towny.tasks.DrawSmokeTask;
 import com.palmergames.bukkit.towny.tasks.HealthRegenTimerTask;
@@ -34,6 +35,7 @@ public class TownyTimerHandler{
 	private static int mobRemoveTask = -1;
 	private static int healthRegenTask = -1;
 	private static int teleportWarmupTask = -1;
+	private static int cooldownTimerTask = -1;
 	private static int drawSmokeTask = -1;
 
 	public static void newDay() {
@@ -117,6 +119,18 @@ public class TownyTimerHandler{
 		}
 	}
 	
+	public static void toggleCooldownTimer(boolean on) {
+		
+		if (on && !isCooldownTimerRunning()) {
+			cooldownTimerTask = BukkitTools.scheduleSyncRepeatingTask(new CooldownTimerTask(plugin), 0, 100);
+			if (cooldownTimerTask == -1)
+				TownyMessaging.sendErrorMsg("Could not schedule cooldown timer loop.");			
+		} else if (!on && isCooldownTimerRunning()) {
+			BukkitTools.getScheduler().cancelTask(cooldownTimerTask);
+			cooldownTimerTask = -1;
+		}
+	}
+	
 	public static void toggleDrawSmokeTask(boolean on) {
 		if (on && !isDrawSmokeTaskRunning()) {
 			drawSmokeTask = BukkitTools.scheduleAsyncRepeatingTask(new DrawSmokeTask(plugin), 0, 100);
@@ -152,6 +166,11 @@ public class TownyTimerHandler{
 	public static boolean isTeleportWarmupRunning() {
 
 		return teleportWarmupTask != -1;
+	}
+	
+	public static boolean isCooldownTimerRunning() {
+
+		return cooldownTimerTask != -1;
 	}
 	
 	public static boolean isDrawSmokeTaskRunning() {

--- a/src/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -36,6 +36,8 @@ import com.palmergames.bukkit.towny.object.inviteobjects.NationAllyNationInvite;
 import com.palmergames.bukkit.towny.object.inviteobjects.TownJoinNationInvite;
 import com.palmergames.bukkit.towny.permissions.PermissionNodes;
 import com.palmergames.bukkit.towny.permissions.TownyPerms;
+import com.palmergames.bukkit.towny.tasks.CooldownTimerTask;
+import com.palmergames.bukkit.towny.tasks.CooldownTimerTask.CooldownType;
 import com.palmergames.bukkit.towny.war.flagwar.TownyWar;
 import com.palmergames.bukkit.util.BukkitTools;
 import com.palmergames.bukkit.util.ChatTools;
@@ -2279,6 +2281,10 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
         try {
 
             Resident resident = townyUniverse.getDataSource().getResident(player.getName());
+            
+            if (CooldownTimerTask.hasCooldown(resident, CooldownType.TELEPORT))
+				throw new TownyException(String.format(TownySettings.getLangString("msg_err_cannot_spawn_x_seconds_remaining"), CooldownTimerTask.getCooldownRemaining(resident, CooldownType.TELEPORT))); 
+            
             Nation nation;
             String notAffordMSG;
 
@@ -2472,6 +2478,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
                     if (!chunk.isLoaded())
                         chunk.load();
                     player.teleport(spawnLoc, PlayerTeleportEvent.TeleportCause.COMMAND);
+                    CooldownTimerTask.addCooldownTimer(resident, CooldownType.TELEPORT);
                 }
             }
         } catch (TownyException | EconomyException e) {

--- a/src/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -2282,7 +2282,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 
             Resident resident = townyUniverse.getDataSource().getResident(player.getName());
             
-            if (CooldownTimerTask.hasCooldown(resident, CooldownType.TELEPORT))
+            if (TownySettings.getSpawnCooldownTime() > 0 && CooldownTimerTask.hasCooldown(resident, CooldownType.TELEPORT))
 				throw new TownyException(String.format(TownySettings.getLangString("msg_err_cannot_spawn_x_seconds_remaining"), CooldownTimerTask.getCooldownRemaining(resident, CooldownType.TELEPORT))); 
             
             Nation nation;
@@ -2478,7 +2478,8 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
                     if (!chunk.isLoaded())
                         chunk.load();
                     player.teleport(spawnLoc, PlayerTeleportEvent.TeleportCause.COMMAND);
-                    CooldownTimerTask.addCooldownTimer(resident, CooldownType.TELEPORT);
+                    if (TownySettings.getSpawnCooldownTime() > 0)
+                    	CooldownTimerTask.addCooldownTimer(resident, CooldownType.TELEPORT);
                 }
             }
         } catch (TownyException | EconomyException e) {

--- a/src/com/palmergames/bukkit/towny/command/PlotCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/PlotCommand.java
@@ -835,18 +835,20 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 					// Make sure we are allowed to set these permissions.
 					toggleTest(player, townBlock, StringMgmt.join(split, " "));
 					
-					// Test to see if the pvp cooldown timer is active for the town this plot belongs to.
-					if (CooldownTimerTask.hasCooldown(townBlock.getTown(), CooldownType.PVP))
-						throw new TownyException(String.format(TownySettings.getLangString("msg_err_cannot_toggle_pvp_x_seconds_remaining"), CooldownTimerTask.getCooldownRemaining(townBlock.getTown(), CooldownType.PVP)));
-
-					// Test to see if the pvp cooldown timer is active for this plot.
-					if (CooldownTimerTask.hasCooldown(townBlock, CooldownType.PVP))
-						throw new TownyException(String.format(TownySettings.getLangString("msg_err_cannot_toggle_pvp_x_seconds_remaining"), CooldownTimerTask.getCooldownRemaining(townBlock.getTown(), CooldownType.PVP)));
-
+					if (TownySettings.getPVPCoolDownTime() > 0) {
+						// Test to see if the pvp cooldown timer is active for the town this plot belongs to.
+						if (CooldownTimerTask.hasCooldown(townBlock.getTown(), CooldownType.PVP))
+							throw new TownyException(String.format(TownySettings.getLangString("msg_err_cannot_toggle_pvp_x_seconds_remaining"), CooldownTimerTask.getCooldownRemaining(townBlock.getTown(), CooldownType.PVP)));
+	
+						// Test to see if the pvp cooldown timer is active for this plot.
+						if (CooldownTimerTask.hasCooldown(townBlock, CooldownType.PVP))
+							throw new TownyException(String.format(TownySettings.getLangString("msg_err_cannot_toggle_pvp_x_seconds_remaining"), CooldownTimerTask.getCooldownRemaining(townBlock.getTown(), CooldownType.PVP)));
+					}
 
 					townBlock.getPermissions().pvp = !townBlock.getPermissions().pvp;
 					// Add a cooldown timer for this plot.
-					CooldownTimerTask.addCooldownTimer(townBlock, CooldownType.PVP);
+					if (TownySettings.getPVPCoolDownTime() > 0)
+						CooldownTimerTask.addCooldownTimer(townBlock, CooldownType.PVP);
 					TownyMessaging.sendMessage(player, String.format(TownySettings.getLangString("msg_changed_pvp"), "Plot", townBlock.getPermissions().pvp ? TownySettings.getLangString("enabled") : TownySettings.getLangString("disabled")));
 
 				} else if (split[0].equalsIgnoreCase("explosion")) {

--- a/src/com/palmergames/bukkit/towny/command/PlotCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/PlotCommand.java
@@ -23,7 +23,9 @@ import com.palmergames.bukkit.towny.object.TownyWorld;
 import com.palmergames.bukkit.towny.object.WorldCoord;
 import com.palmergames.bukkit.towny.permissions.PermissionNodes;
 import com.palmergames.bukkit.towny.regen.TownyRegenAPI;
+import com.palmergames.bukkit.towny.tasks.CooldownTimerTask;
 import com.palmergames.bukkit.towny.tasks.PlotClaim;
+import com.palmergames.bukkit.towny.tasks.CooldownTimerTask.CooldownType;
 import com.palmergames.bukkit.towny.utils.AreaSelectionUtil;
 import com.palmergames.bukkit.towny.utils.OutpostUtil;
 import com.palmergames.bukkit.util.BukkitTools;
@@ -832,7 +834,19 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 				if (split[0].equalsIgnoreCase("pvp")) {
 					// Make sure we are allowed to set these permissions.
 					toggleTest(player, townBlock, StringMgmt.join(split, " "));
+					
+					// Test to see if the pvp cooldown timer is active for the town this plot belongs to.
+					if (CooldownTimerTask.hasCooldown(townBlock.getTown(), CooldownType.PVP))
+						throw new TownyException(String.format(TownySettings.getLangString("msg_err_cannot_toggle_pvp_x_seconds_remaining"), CooldownTimerTask.getCooldownRemaining(townBlock.getTown(), CooldownType.PVP)));
+
+					// Test to see if the pvp cooldown timer is active for this plot.
+					if (CooldownTimerTask.hasCooldown(townBlock, CooldownType.PVP))
+						throw new TownyException(String.format(TownySettings.getLangString("msg_err_cannot_toggle_pvp_x_seconds_remaining"), CooldownTimerTask.getCooldownRemaining(townBlock.getTown(), CooldownType.PVP)));
+
+
 					townBlock.getPermissions().pvp = !townBlock.getPermissions().pvp;
+					// Add a cooldown timer for this plot.
+					CooldownTimerTask.addCooldownTimer(townBlock, CooldownType.PVP);
 					TownyMessaging.sendMessage(player, String.format(TownySettings.getLangString("msg_changed_pvp"), "Plot", townBlock.getPermissions().pvp ? TownySettings.getLangString("enabled") : TownySettings.getLangString("disabled")));
 
 				} else if (split[0].equalsIgnoreCase("explosion")) {

--- a/src/com/palmergames/bukkit/towny/command/ResidentCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/ResidentCommand.java
@@ -266,7 +266,7 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 		
 			resident = townyUniverse.getDataSource().getResident(player.getName());
 			
-			if (CooldownTimerTask.hasCooldown(resident, CooldownType.TELEPORT))
+			if (TownySettings.getSpawnCooldownTime() > 0 && CooldownTimerTask.hasCooldown(resident, CooldownType.TELEPORT))
 				throw new TownyException(String.format(TownySettings.getLangString("msg_err_cannot_spawn_x_seconds_remaining"), CooldownTimerTask.getCooldownRemaining(resident, CooldownType.TELEPORT))); 
 
 			Town town;
@@ -388,7 +388,8 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 					if (!chunk.isLoaded())
 						chunk.load();
 					player.teleport(spawnLoc, TeleportCause.COMMAND);
-					CooldownTimerTask.addCooldownTimer(resident, CooldownType.TELEPORT);
+					if (TownySettings.getSpawnCooldownTime() > 0)
+						CooldownTimerTask.addCooldownTimer(resident, CooldownType.TELEPORT);
 				}
 			}
 		} catch (TownyException | EconomyException e) {
@@ -451,7 +452,7 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 		} else if (newSplit[0].equalsIgnoreCase("pvp")) {
 			
 			// Test to see if the pvp cooldown timer is active for the town this resident belongs to.
-			if (resident.hasTown()) {
+			if (TownySettings.getPVPCoolDownTime() > 0 && resident.hasTown()) {
 				if (CooldownTimerTask.hasCooldown(resident.getTown(), CooldownType.PVP))
 					throw new TownyException(String.format(TownySettings.getLangString("msg_err_cannot_toggle_pvp_x_seconds_remaining"), CooldownTimerTask.getCooldownRemaining(resident.getTown(), CooldownType.PVP))); 
 				if (CooldownTimerTask.hasCooldown(resident, CooldownType.PVP))
@@ -460,7 +461,8 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 			}			
 			perm.pvp = !perm.pvp;
 			// Add a task for the resident.
-			CooldownTimerTask.addCooldownTimer(resident, CooldownType.PVP);
+			if (TownySettings.getPVPCoolDownTime() > 0)
+				CooldownTimerTask.addCooldownTimer(resident, CooldownType.PVP);
 		} else if (newSplit[0].equalsIgnoreCase("fire")) {
 			perm.fire = !perm.fire;
 		} else if (newSplit[0].equalsIgnoreCase("explosion")) {

--- a/src/com/palmergames/bukkit/towny/command/ResidentCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/ResidentCommand.java
@@ -20,6 +20,8 @@ import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownSpawnLevel;
 import com.palmergames.bukkit.towny.object.TownyPermission;
 import com.palmergames.bukkit.towny.permissions.PermissionNodes;
+import com.palmergames.bukkit.towny.tasks.CooldownTimerTask;
+import com.palmergames.bukkit.towny.tasks.CooldownTimerTask.CooldownType;
 import com.palmergames.bukkit.util.BukkitTools;
 import com.palmergames.bukkit.util.ChatTools;
 import com.palmergames.bukkit.util.Colors;
@@ -259,10 +261,14 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 
 		boolean isTownyAdmin = townyUniverse.getPermissionSource().isTownyAdmin(player);
 		Resident resident;
-
+		
 		try {
-
+		
 			resident = townyUniverse.getDataSource().getResident(player.getName());
+			
+			if (CooldownTimerTask.hasCooldown(resident, CooldownType.TELEPORT))
+				throw new TownyException(String.format(TownySettings.getLangString("msg_err_cannot_spawn_x_seconds_remaining"), CooldownTimerTask.getCooldownRemaining(resident, CooldownType.TELEPORT))); 
+
 			Town town;
 			Location spawnLoc;
 			String notAffordMSG;
@@ -382,6 +388,7 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 					if (!chunk.isLoaded())
 						chunk.load();
 					player.teleport(spawnLoc, TeleportCause.COMMAND);
+					CooldownTimerTask.addCooldownTimer(resident, CooldownType.TELEPORT);
 				}
 			}
 		} catch (TownyException | EconomyException e) {
@@ -442,7 +449,18 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 			return;
 			
 		} else if (newSplit[0].equalsIgnoreCase("pvp")) {
+			
+			// Test to see if the pvp cooldown timer is active for the town this resident belongs to.
+			if (resident.hasTown()) {
+				if (CooldownTimerTask.hasCooldown(resident.getTown(), CooldownType.PVP))
+					throw new TownyException(String.format(TownySettings.getLangString("msg_err_cannot_toggle_pvp_x_seconds_remaining"), CooldownTimerTask.getCooldownRemaining(resident.getTown(), CooldownType.PVP))); 
+				if (CooldownTimerTask.hasCooldown(resident, CooldownType.PVP))
+					throw new TownyException(String.format(TownySettings.getLangString("msg_err_cannot_toggle_pvp_x_seconds_remaining"), CooldownTimerTask.getCooldownRemaining(resident.getTown(), CooldownType.PVP)));
+
+			}			
 			perm.pvp = !perm.pvp;
+			// Add a task for the resident.
+			CooldownTimerTask.addCooldownTimer(resident, CooldownType.PVP);
 		} else if (newSplit[0].equalsIgnoreCase("fire")) {
 			perm.fire = !perm.fire;
 		} else if (newSplit[0].equalsIgnoreCase("explosion")) {

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -1156,7 +1156,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 				toggleTest(player, town, StringMgmt.join(split, " "));
 				
 				// Test to see if the pvp cooldown timer is active for the town.
-				if (TownySettings.getPVPCoolDownTime() > 0 && CooldownTimerTask.hasCooldown(town, CooldownType.PVP))					 
+				if (TownySettings.getPVPCoolDownTime() > 0 && !admin && CooldownTimerTask.hasCooldown(town, CooldownType.PVP))					 
 					throw new TownyException(String.format(TownySettings.getLangString("msg_err_cannot_toggle_pvp_x_seconds_remaining"), CooldownTimerTask.getCooldownRemaining(town, CooldownType.PVP)));
 				
 				boolean outsiderintown = false;
@@ -1177,7 +1177,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 				if (!outsiderintown) {
 					town.setPVP(!town.isPVP());
 					// Add a cooldown to PVP toggling.
-					if (TownySettings.getPVPCoolDownTime() > 0)
+					if (TownySettings.getPVPCoolDownTime() > 0 && !admin)
 						CooldownTimerTask.addCooldownTimer(town, CooldownType.PVP);
 					TownyMessaging.sendTownMessage(town, String.format(TownySettings.getLangString("msg_changed_pvp"), town.getName(), town.isPVP() ? TownySettings.getLangString("enabled") : TownySettings.getLangString("disabled")));
 				} else if (outsiderintown) {

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -1156,7 +1156,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 				toggleTest(player, town, StringMgmt.join(split, " "));
 				
 				// Test to see if the pvp cooldown timer is active for the town.
-				if (CooldownTimerTask.hasCooldown(town, CooldownType.PVP))					 
+				if (TownySettings.getPVPCoolDownTime() > 0 && CooldownTimerTask.hasCooldown(town, CooldownType.PVP))					 
 					throw new TownyException(String.format(TownySettings.getLangString("msg_err_cannot_toggle_pvp_x_seconds_remaining"), CooldownTimerTask.getCooldownRemaining(town, CooldownType.PVP)));
 				
 				boolean outsiderintown = false;
@@ -1177,7 +1177,8 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 				if (!outsiderintown) {
 					town.setPVP(!town.isPVP());
 					// Add a cooldown to PVP toggling.
-					CooldownTimerTask.addCooldownTimer(town, CooldownType.PVP);
+					if (TownySettings.getPVPCoolDownTime() > 0)
+						CooldownTimerTask.addCooldownTimer(town, CooldownType.PVP);
 					TownyMessaging.sendTownMessage(town, String.format(TownySettings.getLangString("msg_changed_pvp"), town.getName(), town.isPVP() ? TownySettings.getLangString("enabled") : TownySettings.getLangString("disabled")));
 				} else if (outsiderintown) {
 					throw new TownyException(TownySettings.getLangString("msg_cant_toggle_pvp_outsider_in_town"));
@@ -2258,7 +2259,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 			Town town;
 			String notAffordMSG;
 			
-			if (CooldownTimerTask.hasCooldown(resident, CooldownType.TELEPORT))
+			if (TownySettings.getSpawnCooldownTime() > 0 && CooldownTimerTask.hasCooldown(resident, CooldownType.TELEPORT))
 				throw new TownyException(String.format(TownySettings.getLangString("msg_err_cannot_spawn_x_seconds_remaining"), CooldownTimerTask.getCooldownRemaining(resident, CooldownType.TELEPORT))); 
 
 			// Set target town and affiliated messages.
@@ -2515,7 +2516,8 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 					if (!chunk.isLoaded())
 						chunk.load();
 					player.teleport(spawnLoc, TeleportCause.COMMAND);
-					CooldownTimerTask.addCooldownTimer(resident, CooldownType.TELEPORT);
+					if (TownySettings.getSpawnCooldownTime() > 0)
+						CooldownTimerTask.addCooldownTimer(resident, CooldownType.TELEPORT);
 				}
 			}
 		} catch (TownyException | EconomyException e) {

--- a/src/com/palmergames/bukkit/towny/tasks/CooldownTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/CooldownTimerTask.java
@@ -1,27 +1,27 @@
 package com.palmergames.bukkit.towny.tasks;
 
 import java.util.concurrent.ConcurrentHashMap;
+import javafx.util.Pair;
 
 import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.TownySettings;
-import com.palmergames.bukkit.config.ConfigNodes;
 
 public class CooldownTimerTask extends TownyTimerTask {
 	
-	private static ConcurrentHashMap<ConcurrentHashMap<Object, CooldownType>, Long> cooldowns;	
+	private static ConcurrentHashMap<Pair<Object, CooldownType>, Long> cooldowns;	
 
 
 	public enum CooldownType{
-		PVP(ConfigNodes.GTOWN_SETTINGS_PVP_COOLDOWN_TIMER),
-		TELEPORT(ConfigNodes.GTOWN_SETTINGS_SPAWN_COOLDOWN_TIMER);
+		PVP(TownySettings.getPVPCoolDownTime()),
+		TELEPORT(TownySettings.getSpawnCooldownTime());
 		
-		private ConfigNodes seconds;
+		private int seconds;
 		
 		private int getSeconds() {
-			return TownySettings.getInt(seconds);
+			return seconds;
 		}
 
-		CooldownType(ConfigNodes seconds) {
+		CooldownType(int seconds) {
 			this.seconds = seconds;
 		}
 		
@@ -38,7 +38,7 @@ public class CooldownTimerTask extends TownyTimerTask {
 		long currentTime = System.currentTimeMillis();
 
 		while (!cooldowns.isEmpty()) {
-			for (ConcurrentHashMap map : cooldowns.keySet()) {
+			for (Pair<Object, CooldownType> map : cooldowns.keySet()) {
 				long time = cooldowns.get(map);
 				if (time < currentTime)					
 					cooldowns.remove(map);
@@ -48,22 +48,19 @@ public class CooldownTimerTask extends TownyTimerTask {
 	}
 	
 	public static void addCooldownTimer(Object object, CooldownType type) {
-		ConcurrentHashMap<Object, CooldownType> map = new ConcurrentHashMap<>();
-		map.put(object, type);
+		Pair<Object, CooldownType> map = new Pair<Object, CooldownType>(object, type);
 		cooldowns.put(map, (System.currentTimeMillis() + (type.getSeconds() * 1000)));
 	}
 	
 	public static boolean hasCooldown(Object object, CooldownType type) {
-		ConcurrentHashMap<Object, CooldownType> map = new ConcurrentHashMap<>();
-		map.put(object, type);
+		Pair<Object, CooldownType> map = new Pair<Object, CooldownType>(object, type);
 		if (cooldowns.containsKey(map))			
 			return true;
 		return false;
 	}
 	
 	public static int getCooldownRemaining(Object object, CooldownType type) {
-		ConcurrentHashMap<Object, CooldownType> map = new ConcurrentHashMap<>();
-		map.put(object, type);
+		Pair<Object, CooldownType> map = new Pair<Object, CooldownType>(object, type);
 		if (cooldowns.containsKey(map))
 			return (int) ((cooldowns.get(map) - System.currentTimeMillis())/1000);
 		return 0;		

--- a/src/com/palmergames/bukkit/towny/tasks/CooldownTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/CooldownTimerTask.java
@@ -1,0 +1,71 @@
+package com.palmergames.bukkit.towny.tasks;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.palmergames.bukkit.towny.Towny;
+import com.palmergames.bukkit.towny.TownySettings;
+import com.palmergames.bukkit.config.ConfigNodes;
+
+public class CooldownTimerTask extends TownyTimerTask {
+	
+	private static ConcurrentHashMap<ConcurrentHashMap<Object, CooldownType>, Long> cooldowns;	
+
+
+	public enum CooldownType{
+		PVP(ConfigNodes.GTOWN_SETTINGS_PVP_COOLDOWN_TIMER),
+		TELEPORT(ConfigNodes.GTOWN_SETTINGS_SPAWN_COOLDOWN_TIMER);
+		
+		private ConfigNodes seconds;
+		
+		private int getSeconds() {
+			return TownySettings.getInt(seconds);
+		}
+
+		CooldownType(ConfigNodes seconds) {
+			this.seconds = seconds;
+		}
+		
+	}
+
+	public CooldownTimerTask(Towny plugin) {
+
+		super(plugin);
+		cooldowns = new ConcurrentHashMap<>();
+	}
+
+	@Override
+	public void run() {
+		long currentTime = System.currentTimeMillis();
+
+		while (!cooldowns.isEmpty()) {
+			for (ConcurrentHashMap map : cooldowns.keySet()) {
+				long time = cooldowns.get(map);
+				if (time < currentTime)					
+					cooldowns.remove(map);
+			}
+			break;
+		}
+	}
+	
+	public static void addCooldownTimer(Object object, CooldownType type) {
+		ConcurrentHashMap<Object, CooldownType> map = new ConcurrentHashMap<>();
+		map.put(object, type);
+		cooldowns.put(map, (System.currentTimeMillis() + (type.getSeconds() * 1000)));
+	}
+	
+	public static boolean hasCooldown(Object object, CooldownType type) {
+		ConcurrentHashMap<Object, CooldownType> map = new ConcurrentHashMap<>();
+		map.put(object, type);
+		if (cooldowns.containsKey(map))			
+			return true;
+		return false;
+	}
+	
+	public static int getCooldownRemaining(Object object, CooldownType type) {
+		ConcurrentHashMap<Object, CooldownType> map = new ConcurrentHashMap<>();
+		map.put(object, type);
+		if (cooldowns.containsKey(map))
+			return (int) ((cooldowns.get(map) - System.currentTimeMillis())/1000);
+		return 0;		
+	}
+}

--- a/src/com/palmergames/bukkit/towny/tasks/TeleportWarmupTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/TeleportWarmupTimerTask.java
@@ -7,6 +7,8 @@ import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.exceptions.EconomyException;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Resident;
+import com.palmergames.bukkit.towny.tasks.CooldownTimerTask.CooldownType;
+
 import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -49,6 +51,7 @@ public class TeleportWarmupTimerTask extends TownyTimerTask {
 					return;
 				}
 				p.teleport(resident.getTeleportDestination());
+				CooldownTimerTask.addCooldownTimer(resident, CooldownType.TELEPORT);
 				teleportQueue.poll();
 			} else {
 				break;

--- a/src/com/palmergames/bukkit/towny/tasks/TeleportWarmupTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/TeleportWarmupTimerTask.java
@@ -51,7 +51,8 @@ public class TeleportWarmupTimerTask extends TownyTimerTask {
 					return;
 				}
 				p.teleport(resident.getTeleportDestination());
-				CooldownTimerTask.addCooldownTimer(resident, CooldownType.TELEPORT);
+				if (TownySettings.getSpawnCooldownTime() > 0)
+					CooldownTimerTask.addCooldownTimer(resident, CooldownType.TELEPORT);
 				teleportQueue.poll();
 			} else {
 				break;


### PR DESCRIPTION
  - New Feature: Cooldown timers for toggling PVP and using res/town spawn commands.
    - Closes tickets #2224 #2315
  - New Config Option: global_town_settings.spawn_cooldown_time
    - default '30'
    - Number of seconds that must pass before a player can use /n spawn, /t spawn or /res spawn.
  - New Config Option: global_town_settings.pvp_cooldown_time
    - default '30'
    - Number of seconds that must pass before pvp can be toggled by a town using /t toggle pvp.
    - Also applies to residents of the town using /res toggle pvp, as well as plots having their PVP toggled using /plot toggle pvp.
    - /ta town {town} toggle pvp bypasses cooldowntimer.
  - Language files bumped to 0.62.