### PR TITLE
Remove Javadocs from Maven's install phase, make Debian/GitHub Actions specific pomfile.

### DIFF
--- a/.github/workflows/deploy-on-release.yml
+++ b/.github/workflows/deploy-on-release.yml
@@ -21,4 +21,4 @@ jobs:
               run: |
                 mkdir ~/.m2
                 echo "<settings><servers><server><id>github</id><username>TownyAdvanced</username><password>${GITHUB_TOKEN}</password></server></servers></settings>" > ~/.m2/settings.xml
-                mvn -B deploy --file pom.xml
+                mvn -B deploy --file pom_deb.xml

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,6 @@
                 <version>3.1.1</version>
                 <executions>
                     <execution>
-                        <phase>install</phase>
                         <goals>
                             <goal>jar</goal>
                         </goals>

--- a/pom_deb.xml
+++ b/pom_deb.xml
@@ -4,6 +4,11 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+
+    <!-- NOTE: This pom file is meant for the GitHub Actions deployment workflow, and for MacOS and Debian derivatives.
+            Javadocs will only run on GitHub Actions by specifying the path to the Javadoc executable.
+            The same goes for the OS that the workflow is currently based on, Ubuntu. -->
+
     <groupId>com.palmergames.bukkit.towny</groupId>
     <artifactId>Towny</artifactId>
     <packaging>jar</packaging>
@@ -160,6 +165,7 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
                     <failOnError>false</failOnError>
                     <failOnWarnings>false</failOnWarnings>
                     <source>8</source>


### PR DESCRIPTION
See individual commits for changes and summary. Addresses issue #3519. Individual developers are now responsible for building their own Javadocs and making necessary tweaks to the Pom file to automate them.

`pom_deb.xml` is now used for GitHub Actions' workflow. It can also be used on Debian-based distributions such as Ubuntu, Mint, and ZorinOS. To do so, Maven will need to be ran with the `--file` argument. IDE helper scripts may not work, or may need editing.