### PR TITLE
Flagwar Feature: Option to disable the capture of a defender's TownBlocks

### DIFF
--- a/resources/ChangeLog.txt
+++ b/resources/ChangeLog.txt
@@ -3905,3 +3905,8 @@ v0.92.0.11:
   - Fixed building with maven and some people having errors re: javadocs, courtesy of TheFlagCourier with PR #3521.
     - Closes ticket #3519.
   - Did some tinkering with event war, created a WarUtil to contain some repeated tests.
+  - FlagWar Feature: Disable capture of a defender's townblocks.
+    - Add boolean config node 'war.enemy.flag_takes_ownership_of_townblocks'; If false, defenders will keep their claims
+    - This is similar effect to Event War's 'winner_takes_ownership_of_townblocks', but does not mess with bonus plots.
+    - Adds the 'msg_war_defender_keeps_claims' language string to notify the towns that capturing the townblock is disabled.
+    - Closes ticket #3514

--- a/resources/ChangeLog.txt
+++ b/resources/ChangeLog.txt
@@ -3905,6 +3905,7 @@ v0.92.0.11:
   - Fixed building with maven and some people having errors re: javadocs, courtesy of TheFlagCourier with PR #3521.
     - Closes ticket #3519.
   - Did some tinkering with event war, created a WarUtil to contain some repeated tests.
+  - Bump langfile versions to 0.66
   - FlagWar Feature: Disable capture of a defender's townblocks.
     - Add boolean config node 'war.enemy.flag_takes_ownership_of_townblocks'; If false, defenders will keep their claims
     - This is similar effect to Event War's 'winner_takes_ownership_of_townblocks', but does not mess with bonus plots.

--- a/resources/chinese.yml
+++ b/resources/chinese.yml
@@ -1029,4 +1029,6 @@ msg_err_cannot_unclaim_homeblock: 'You cannot unclaim your homeblock, use ''/tow
 
 # Added in 0.65
 msg_err_rename_cancelled: 'Renaming was cancelled by another plugin.'
+
+# Added in 0.66
 msg_war_defender_keeps_claims: 'Capturing disabled. Defending town will keep it''s claims.'

--- a/resources/chinese.yml
+++ b/resources/chinese.yml
@@ -1029,3 +1029,4 @@ msg_err_cannot_unclaim_homeblock: 'You cannot unclaim your homeblock, use ''/tow
 
 # Added in 0.65
 msg_err_rename_cancelled: 'Renaming was cancelled by another plugin.'
+msg_war_defender_keeps_claims: 'Capturing disabled. Defending town will keep it''s claims.'

--- a/resources/chinese.yml
+++ b/resources/chinese.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.65
+version: 0.66
 language: Chinese
 author: ElgarL
 website: 'http://townyadvanced.github.io/'

--- a/resources/english.yml
+++ b/resources/english.yml
@@ -1029,4 +1029,6 @@ msg_err_cannot_unclaim_homeblock: 'You cannot unclaim your homeblock, use ''/tow
 
 # Added in 0.65
 msg_err_rename_cancelled: 'Renaming was cancelled by another plugin.'
+
+# Added in 0.66
 msg_war_defender_keeps_claims: 'Capturing disabled. Defending town will keep it''s claims.'

--- a/resources/english.yml
+++ b/resources/english.yml
@@ -1029,3 +1029,4 @@ msg_err_cannot_unclaim_homeblock: 'You cannot unclaim your homeblock, use ''/tow
 
 # Added in 0.65
 msg_err_rename_cancelled: 'Renaming was cancelled by another plugin.'
+msg_war_defender_keeps_claims: 'Capturing disabled. Defending town will keep it''s claims.'

--- a/resources/english.yml
+++ b/resources/english.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.65
+version: 0.66
 language: english
 author: ElgarL
 website: 'http://townyadvanced.github.io/'

--- a/resources/es-mx.yml
+++ b/resources/es-mx.yml
@@ -1017,3 +1017,4 @@ msg_err_cannot_unclaim_homeblock: 'You cannot unclaim your homeblock, use ''/tow
 
 # Added in 0.65
 msg_err_rename_cancelled: 'Renaming was cancelled by another plugin.'
+msg_war_defender_keeps_claims: 'Capturing disabled. Defending town will keep it''s claims.'

--- a/resources/es-mx.yml
+++ b/resources/es-mx.yml
@@ -1017,4 +1017,6 @@ msg_err_cannot_unclaim_homeblock: 'You cannot unclaim your homeblock, use ''/tow
 
 # Added in 0.65
 msg_err_rename_cancelled: 'Renaming was cancelled by another plugin.'
+
+# Added in 0.66
 msg_war_defender_keeps_claims: 'Capturing disabled. Defending town will keep it''s claims.'

--- a/resources/es-mx.yml
+++ b/resources/es-mx.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.65
+version: 0.66
 language: español
 author: VreyaViress
 website: 'http://townyadvanced.github.io/'

--- a/resources/french.yml
+++ b/resources/french.yml
@@ -1029,4 +1029,6 @@ msg_err_cannot_unclaim_homeblock: 'You cannot unclaim your homeblock, use ''/tow
 
 # Added in 0.65
 msg_err_rename_cancelled: 'Renaming was cancelled by another plugin.'
+
+# Added in 0.66
 msg_war_defender_keeps_claims: 'Capturing disabled. Defending town will keep it''s claims.'

--- a/resources/french.yml
+++ b/resources/french.yml
@@ -1029,3 +1029,4 @@ msg_err_cannot_unclaim_homeblock: 'You cannot unclaim your homeblock, use ''/tow
 
 # Added in 0.65
 msg_err_rename_cancelled: 'Renaming was cancelled by another plugin.'
+msg_war_defender_keeps_claims: 'Capturing disabled. Defending town will keep it''s claims.'

--- a/resources/french.yml
+++ b/resources/french.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.65
+version: 0.66
 language: french
 author: Noiknez,TheCalypso
 website: 'http://townyadvanced.github.io/'

--- a/resources/german.yml
+++ b/resources/german.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.65
+version: 0.66
 language: german
 author: 'ElgarL, translated by Articdive, Wolf2323, BlocK, Yasu-San and enterih'
 website: 'http://townyadvanced.github.io/'

--- a/resources/german.yml
+++ b/resources/german.yml
@@ -1032,3 +1032,4 @@ msg_err_cannot_unclaim_homeblock: 'You cannot unclaim your homeblock, use ''/tow
 
 # Added in 0.65
 msg_err_rename_cancelled: 'Renaming was cancelled by another plugin.'
+msg_war_defender_keeps_claims: 'Capturing disabled. Defending town will keep it''s claims.'

--- a/resources/german.yml
+++ b/resources/german.yml
@@ -1032,4 +1032,6 @@ msg_err_cannot_unclaim_homeblock: 'You cannot unclaim your homeblock, use ''/tow
 
 # Added in 0.65
 msg_err_rename_cancelled: 'Renaming was cancelled by another plugin.'
+
+# Added in 0.66
 msg_war_defender_keeps_claims: 'Capturing disabled. Defending town will keep it''s claims.'

--- a/resources/italian.yml
+++ b/resources/italian.yml
@@ -1031,4 +1031,6 @@ msg_err_cannot_unclaim_homeblock: 'You cannot unclaim your homeblock, use ''/tow
 
 # Added in 0.65
 msg_err_rename_cancelled: 'Renaming was cancelled by another plugin.'
+
+# Added in 0.66
 msg_war_defender_keeps_claims: 'Capturing disabled. Defending town will keep it''s claims.'

--- a/resources/italian.yml
+++ b/resources/italian.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.65
+version: 0.66
 language: italian
 author: Leomixer17
 website: 'http://townyadvanced.github.io/'

--- a/resources/italian.yml
+++ b/resources/italian.yml
@@ -1031,3 +1031,4 @@ msg_err_cannot_unclaim_homeblock: 'You cannot unclaim your homeblock, use ''/tow
 
 # Added in 0.65
 msg_err_rename_cancelled: 'Renaming was cancelled by another plugin.'
+msg_war_defender_keeps_claims: 'Capturing disabled. Defending town will keep it''s claims.'

--- a/resources/korean.yml
+++ b/resources/korean.yml
@@ -942,3 +942,4 @@ msg_err_cannot_unclaim_homeblock: 'You cannot unclaim your homeblock, use ''/tow
 
 # Added in 0.65
 msg_err_rename_cancelled: 'Renaming was cancelled by another plugin.'
+msg_war_defender_keeps_claims: 'Capturing disabled. Defending town will keep it''s claims.'

--- a/resources/korean.yml
+++ b/resources/korean.yml
@@ -942,4 +942,6 @@ msg_err_cannot_unclaim_homeblock: 'You cannot unclaim your homeblock, use ''/tow
 
 # Added in 0.65
 msg_err_rename_cancelled: 'Renaming was cancelled by another plugin.'
+
+# Added in 0.66
 msg_war_defender_keeps_claims: 'Capturing disabled. Defending town will keep it''s claims.'

--- a/resources/korean.yml
+++ b/resources/korean.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.65
+version: 0.66
 language: 한국어
 author: 'Daybreak 새벽'
 website: 'http://townyadvanced.github.io/'

--- a/resources/norwegian.yml
+++ b/resources/norwegian.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.65
+version: 0.66
 language: norwegian
 author: Nectuz, Walbern
 website: 'http://townyadvanced.github.io/'

--- a/resources/norwegian.yml
+++ b/resources/norwegian.yml
@@ -1029,4 +1029,6 @@ msg_err_cannot_unclaim_homeblock: 'You cannot unclaim your homeblock, use ''/tow
 
 # Added in 0.65
 msg_err_rename_cancelled: 'Renaming was cancelled by another plugin.'
+
+# Added in 0.66
 msg_war_defender_keeps_claims: 'Capturing disabled. Defending town will keep it''s claims.'

--- a/resources/norwegian.yml
+++ b/resources/norwegian.yml
@@ -1029,3 +1029,4 @@ msg_err_cannot_unclaim_homeblock: 'You cannot unclaim your homeblock, use ''/tow
 
 # Added in 0.65
 msg_err_rename_cancelled: 'Renaming was cancelled by another plugin.'
+msg_war_defender_keeps_claims: 'Capturing disabled. Defending town will keep it''s claims.'

--- a/resources/russian.yml
+++ b/resources/russian.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.65
+version: 0.66
 language: russian
 author: ElgarL (Plugin developer), Communar (Russian Translation)
 website: 'http://townyadvanced.github.io/'

--- a/resources/russian.yml
+++ b/resources/russian.yml
@@ -1029,4 +1029,6 @@ msg_err_cannot_unclaim_homeblock: 'You cannot unclaim your homeblock, use ''/tow
 
 # Added in 0.65
 msg_err_rename_cancelled: 'Renaming was cancelled by another plugin.'
+
+# Added in 0.66
 msg_war_defender_keeps_claims: 'Capturing disabled. Defending town will keep it''s claims.'

--- a/resources/russian.yml
+++ b/resources/russian.yml
@@ -1029,3 +1029,4 @@ msg_err_cannot_unclaim_homeblock: 'You cannot unclaim your homeblock, use ''/tow
 
 # Added in 0.65
 msg_err_rename_cancelled: 'Renaming was cancelled by another plugin.'
+msg_war_defender_keeps_claims: 'Capturing disabled. Defending town will keep it''s claims.'

--- a/resources/spanish.yml
+++ b/resources/spanish.yml
@@ -1029,4 +1029,6 @@ msg_err_cannot_unclaim_homeblock: 'You cannot unclaim your homeblock, use ''/tow
 
 # Added in 0.65
 msg_err_rename_cancelled: 'Renaming was cancelled by another plugin.'
+
+# Added in 0.66
 msg_war_defender_keeps_claims: 'Capturing disabled. Defending town will keep it''s claims.'

--- a/resources/spanish.yml
+++ b/resources/spanish.yml
@@ -1029,3 +1029,4 @@ msg_err_cannot_unclaim_homeblock: 'You cannot unclaim your homeblock, use ''/tow
 
 # Added in 0.65
 msg_err_rename_cancelled: 'Renaming was cancelled by another plugin.'
+msg_war_defender_keeps_claims: 'Capturing disabled. Defending town will keep it''s claims.'

--- a/resources/spanish.yml
+++ b/resources/spanish.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.65
+version: 0.66
 language: spanish
 author: Seruhio, Alvarote1998, Beelzebu
 website: 'http://townyadvanced.github.io/'

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1652,7 +1652,7 @@ public enum ConfigNodes {
 	WAR_ENEMY_MAX_ACTIVE_FLAGS_PER_PLAYER(
 			"war.enemy.max_active_flags_per_player",
 			"1"),
-	WAR_ENENY_FLAG("war.enemy.flag", ""),
+	WAR_ENEMY_FLAG("war.enemy.flag", ""),
 	WAR_ENEMY_FLAG_WAITING_TIME("war.enemy.flag.waiting_time", "1m"),
 	WAR_ENEMY_FLAG_BASE_BLOCK(
 			"war.enemy.flag.base_block",
@@ -1697,6 +1697,11 @@ public enum ConfigNodes {
 		"600000",
 		"# This is how much time that must pass after a town in a nation has been flagged",
 		"# before certain actions can be performed, measured in milliseconds."),
+	WAR_ENEMY_FLAG_TAKES_OWNERSHIP_OF_TOWNBLOCKS(
+		"war.enemy.flag_takes_ownership_of_townblocks",
+		"true",
+		"# If set to true, when a war flag finishes it's countdown successfully, the attacking town takes full control of the townblock.",
+		"# Setting this to 'False' will result only in monetary exchanges."),
 	WAR_WARZONE(
 			"war.warzone",
 			"",

--- a/src/com/palmergames/bukkit/towny/war/flagwar/TownyWarConfig.java
+++ b/src/com/palmergames/bukkit/towny/war/flagwar/TownyWarConfig.java
@@ -187,4 +187,8 @@ public class TownyWarConfig {
 
         return TownySettings.getBoolean(ConfigNodes.WAR_ENEMY_ONLY_ATTACK_BORDER);
     }
+
+	public static boolean isFlaggedTownblockTransfered() {
+		return TownySettings.getBoolean(ConfigNodes.WAR_ENEMY_FLAG_TAKES_OWNERSHIP_OF_TOWNBLOCKS);
+	}
 }

--- a/src/com/palmergames/bukkit/towny/war/flagwar/listeners/TownyWarCustomListener.java
+++ b/src/com/palmergames/bukkit/towny/war/flagwar/listeners/TownyWarCustomListener.java
@@ -30,6 +30,8 @@ import org.bukkit.event.Listener;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.palmergames.bukkit.towny.war.flagwar.TownyWarConfig.isFlaggedTownblockTransfered;
+
 public class TownyWarCustomListener implements Listener {
 
 	private final Towny plugin;
@@ -187,16 +189,23 @@ public class TownyWarCustomListener implements Listener {
 			}
 
 			// Defender loses townblock
-			universe.getDataSource().removeTownBlock(townBlock);
+			if (TownyWarConfig.isFlaggedTownblockTransfered()) {
+				// Defender loses townblock
+				universe.getDataSource().removeTownBlock(townBlock);
 
-			// Attacker Claim Automatically
-			try {
-				List<WorldCoord> selection = new ArrayList<>();
-				selection.add(worldCoord);
-				TownCommand.checkIfSelectionIsValid(attackingTown, selection, false, 0, false);
-				new TownClaim(plugin, null, attackingTown, selection, false, true, false).start();
-			} catch (TownyException te) {
-				// Couldn't claim it.
+				// Attacker Claim Automatically
+				try {
+					List<WorldCoord> selection = new ArrayList<>();
+					selection.add(worldCoord);
+					TownCommand.checkIfSelectionIsValid(attackingTown, selection, false, 0, false);
+					new TownClaim(plugin, null, attackingTown, selection, false, true, false).start();
+				} catch (TownyException te) {
+					// Couldn't claim it.
+				}
+			} else {
+				
+				TownyMessaging.sendTownMessage(attackingTown, String.format(TownySettings.getLangString("msg_war_defender_keeps_claims")));
+				TownyMessaging.sendTownMessage(defendingTown, String.format(TownySettings.getLangString("msg_war_defender_keeps_claims")));
 			}
 
 			// Cleanup


### PR DESCRIPTION
Closes ticket #3514

Adds language file entry to broadcast this to the attacking and defending towns.

See ChangeLog for full commit description.

(Also fixes spelling of WAR_ENEMY_FLAG)