### PR TITLE
Reduce Object Allocation on Player Move

### DIFF
--- a/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -534,16 +534,17 @@ public class TownyPlayerListener implements Listener {
 			from = event.getFrom();
 		}
 		
-		try {
-			TownyWorld fromWorld = townyUniverse.getDataSource().getWorld(from.getWorld().getName());
-			WorldCoord fromCoord = new WorldCoord(fromWorld.getName(), Coord.parseCoord(from));
-			TownyWorld toWorld = townyUniverse.getDataSource().getWorld(to.getWorld().getName());
-			WorldCoord toCoord = new WorldCoord(toWorld.getName(), Coord.parseCoord(to));
-			if (!fromCoord.equals(toCoord))
+		if (WorldCoord.cellChanged(from, to)) {
+			try {
+				TownyWorld fromWorld = townyUniverse.getDataSource().getWorld(from.getWorld().getName());
+				WorldCoord fromCoord = new WorldCoord(fromWorld.getName(), Coord.parseCoord(from));
+				TownyWorld toWorld = townyUniverse.getDataSource().getWorld(to.getWorld().getName());
+				WorldCoord toCoord = new WorldCoord(toWorld.getName(), Coord.parseCoord(to));
+				
 				onPlayerMoveChunk(player, fromCoord, toCoord, from, to, event);
-
-		} catch (NotRegisteredException e) {
-			TownyMessaging.sendErrorMsg(player, e.getMessage());
+			} catch (NotRegisteredException e) {
+				TownyMessaging.sendErrorMsg(player, e.getMessage());
+			}
 		}
 
 		// Update the cached players current location

--- a/src/com/palmergames/bukkit/towny/object/Coord.java
+++ b/src/com/palmergames/bukkit/towny/object/Coord.java
@@ -84,6 +84,17 @@ public class Coord {
 	 */
 
 	/**
+	 * Convert a value to the grid cell counterpart
+	 * @param value x/z integer
+	 * @return cell position
+	 */
+	protected static int toCell(int value) {
+		// Floor divides means that for negative values will round to the next negative value
+		// and positive value to the previous positive value.
+		return Math.floorDiv(value, getCellSize());
+	}
+
+	/**
 	 * Convert regular grid coordinates to their grid cell's counterparts.
 	 * 
 	 * @param x - X int (Coordinates)
@@ -92,12 +103,7 @@ public class Coord {
 	 * 
 	 */
 	public static Coord parseCoord(int x, int z) {
-
-		int xresult = x / getCellSize();
-		int zresult = z / getCellSize();
-		boolean xneedfix = x % getCellSize() != 0;
-		boolean zneedfix = z % getCellSize() != 0;
-		return new Coord(xresult - (x < 0 && xneedfix ? 1 : 0), zresult - (z < 0 && zneedfix ? 1 : 0));
+		return new Coord(toCell(x), toCell(z));
 	}
 
 	public static Coord parseCoord(Entity entity) {

--- a/src/com/palmergames/bukkit/towny/object/WorldCoord.java
+++ b/src/com/palmergames/bukkit/towny/object/WorldCoord.java
@@ -8,6 +8,8 @@ import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 
+import java.util.Objects;
+
 public class WorldCoord extends Coord {
 
 	private String worldName;
@@ -127,5 +129,18 @@ public class WorldCoord extends Coord {
 	 */
 	public TownBlock getTownBlock() throws NotRegisteredException {
 		return getTownyWorld().getTownBlock(getCoord());
+	}
+
+	/**
+	 * Checks that locations are in different cells without allocating any garbage to the heap.
+	 * 
+	 * @param from Original location
+	 * @param to Next location
+	 * @return whether the locations are in different cells
+	 */
+	public static boolean cellChanged(Location from, Location to) {
+		return toCell(from.getBlockX()) != toCell(to.getBlockX()) ||
+			   toCell(from.getBlockZ()) != toCell(to.getBlockZ()) ||
+			   !Objects.equals(from.getWorld(), to.getWorld());
 	}
 }


### PR DESCRIPTION
Minor Optimization PR

This adds a static method to WorldCoord that checks if a cell has changed without creating a new Coord entirely. Also changes internally how Coord is parsed simplifying the code to a `Math.floorDiv()`. 

The reason of this PR is to reduce two new object allocations every time a player moves a block.