### PR TITLE
Add missing code line to add remaining extra fields

### DIFF
--- a/src/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/src/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -798,6 +798,7 @@ public class TownyFormatter {
 				extraFields.add(field);
 		}
 		
+		extraFields.add(field);
 		
 		return extraFields;
 	}
@@ -843,6 +844,7 @@ public class TownyFormatter {
 				extraFields.add(field);
 		}
 
+		extraFields.add(field);
 
 		return extraFields;
 	}


### PR DESCRIPTION
Something I forgot when adding the extra fields metadata. I just noticed that two lines of code were missing, meaning any fields that left a line <40 characters long wouldn't be shown. Don't know how I missed it, but here's the fix. Literally just 2 lines of code to add any leftovers that haven't been added to a list yet.