### PR TITLE
Rewrite TownyPermission data structure to a 2d boolean array

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/PlotCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/PlotCommand.java
@@ -24,6 +24,7 @@ import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.TownBlockOwner;
 import com.palmergames.bukkit.towny.object.TownBlockType;
 import com.palmergames.bukkit.towny.object.TownyPermission;
+import com.palmergames.bukkit.towny.object.TownyPermissionChange;
 import com.palmergames.bukkit.towny.object.TownyWorld;
 import com.palmergames.bukkit.towny.object.WorldCoord;
 import com.palmergames.bukkit.towny.permissions.PermissionNodes;
@@ -606,14 +607,17 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 	}
 
 	/**
-	 * 
+	 * Returns a TownyPermissionChange object representing the change action
+	 *
 	 * @param player Player initiator
 	 * @param townBlockOwner Resident/Town with the targeted permissions change
 	 * @param townBlock Targeted town block
 	 * @param split Permission arguments
-	 * @return whether town block permissions have changed.
+	 * @return a TownyPermissionChange object
 	 */
-	public static boolean setTownBlockPermissions(Player player, TownBlockOwner townBlockOwner, TownBlock townBlock, String[] split) {
+	public static TownyPermissionChange setTownBlockPermissions(Player player, TownBlockOwner townBlockOwner, TownBlock townBlock, String[] split) {
+		TownyPermissionChange permChange = null;
+
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
 		if (split.length == 0 || split[0].equalsIgnoreCase("?")) {
 
@@ -622,15 +626,15 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 				player.sendMessage(ChatTools.formatCommand("Level", "[resident/nation/ally/outsider]", "", ""));
 			if (townBlockOwner instanceof Resident)
 				player.sendMessage(ChatTools.formatCommand("Level", "[friend/town/ally/outsider]", "", ""));
-			
+
 			player.sendMessage(ChatTools.formatCommand("Type", "[build/destroy/switch/itemuse]", "", ""));
 			player.sendMessage(ChatTools.formatCommand("", "set perm", "[on/off]", "Toggle all permissions"));
 			player.sendMessage(ChatTools.formatCommand("", "set perm", "[level/type] [on/off]", ""));
 			player.sendMessage(ChatTools.formatCommand("", "set perm", "[level] [type] [on/off]", ""));
 			player.sendMessage(ChatTools.formatCommand("", "set perm", "reset", ""));
 			player.sendMessage(ChatTools.formatCommand("Eg", "/plot set perm", "friend build on", ""));
-			return false;
-			
+			return null;
+
 		} else {
 
 			TownyPermission perm = townBlock.getPermissions();
@@ -640,7 +644,9 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 				if (split[0].equalsIgnoreCase("reset")) {
 
 					// reset this townBlock permissions (by town/resident)
-					townBlock.setType(townBlock.getType());
+					permChange = new TownyPermissionChange(TownyPermissionChange.Action.RESET, false, townBlock);
+
+					perm.change(permChange);
 					townyUniverse.getDataSource().saveTownBlock(townBlock);
 
 					if (townBlockOwner instanceof Town)
@@ -651,7 +657,7 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 					// Reset all caches as this can affect everyone.
 					plugin.resetCache();
 
-					return true;
+					return permChange;
 
 				} else {
 
@@ -660,126 +666,88 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 
 					try {
 						boolean b = plugin.parseOnOff(split[0]);
-						for (String element : new String[] { "residentBuild",
-								"residentDestroy", "residentSwitch",
-								"residentItemUse", "outsiderBuild",
-								"outsiderDestroy", "outsiderSwitch",
-								"outsiderItemUse", "allyBuild", "allyDestroy",
-								"allySwitch", "allyItemUse", "nationBuild", "nationDestroy",
-								"nationSwitch", "nationItemUse" })
-							perm.set(element, b);
+
+						permChange = new TownyPermissionChange(TownyPermissionChange.Action.ALL_PERMS, b);
+
+						perm.change(permChange);
+						return permChange;
 					} catch (Exception e) {
 						TownyMessaging.sendErrorMsg(player, TownySettings.getLangString("msg_plot_set_perm_syntax_error"));
-						return false;
+						return null;
 					}
 
 				}
 
 			} else if (split.length == 2) {
-				if ((!split[0].equalsIgnoreCase("resident") 
-						&& !split[0].equalsIgnoreCase("friend")
-						&& !split[0].equalsIgnoreCase("town") 
-						&& !split[0].equalsIgnoreCase("nation")
-						&& !split[0].equalsIgnoreCase("ally") 
-						&& !split[0].equalsIgnoreCase("outsider")) 
-						&& !split[0].equalsIgnoreCase("build")
-						&& !split[0].equalsIgnoreCase("destroy")
-						&& !split[0].equalsIgnoreCase("switch")
-						&& !split[0].equalsIgnoreCase("itemuse")) {
-					TownyMessaging.sendErrorMsg(player, TownySettings.getLangString("msg_plot_set_perm_syntax_error"));
-					return false;
-				}
+				boolean b;
 
 				try {
-
-					boolean b = plugin.parseOnOff(split[1]);
-
-					if (split[0].equalsIgnoreCase("friend") || split[0].equalsIgnoreCase("resident")) {
-						perm.residentBuild = b;
-						perm.residentDestroy = b;
-						perm.residentSwitch = b;
-						perm.residentItemUse = b;
-					} else if (split[0].equalsIgnoreCase("town")) {
-						perm.nationBuild = b;
-						perm.nationDestroy = b;
-						perm.nationSwitch = b;
-						perm.nationItemUse = b;
-					} else if (split[0].equalsIgnoreCase("nation")) {
-						perm.nationBuild = b;
-						perm.nationDestroy = b;
-						perm.nationSwitch = b;
-						perm.nationItemUse = b;
-					} else if (split[0].equalsIgnoreCase("outsider")) {
-						perm.outsiderBuild = b;
-						perm.outsiderDestroy = b;
-						perm.outsiderSwitch = b;
-						perm.outsiderItemUse = b;
-					} else if (split[0].equalsIgnoreCase("ally")) {
-						perm.allyBuild = b;
-						perm.allyDestroy = b;
-						perm.allySwitch = b;
-						perm.allyItemUse = b;
-					} else if (split[0].equalsIgnoreCase("build")) {
-						perm.residentBuild = b;
-						perm.outsiderBuild = b;
-						perm.allyBuild = b;
-						perm.nationBuild = b;
-					} else if (split[0].equalsIgnoreCase("destroy")) {
-						perm.residentDestroy = b;
-						perm.outsiderDestroy = b;
-						perm.allyDestroy = b;
-						perm.nationDestroy = b;
-					} else if (split[0].equalsIgnoreCase("switch")) {
-						perm.residentSwitch = b;
-						perm.outsiderSwitch = b;
-						perm.allySwitch = b;
-						perm.nationSwitch = b;
-					} else if (split[0].equalsIgnoreCase("itemuse")) {
-						perm.residentItemUse = b;
-						perm.outsiderItemUse = b;
-						perm.allyItemUse = b;
-						perm.nationItemUse = b;
-					}
-
+					b = plugin.parseOnOff(split[1]);
 				} catch (Exception e) {
 					TownyMessaging.sendErrorMsg(player, TownySettings.getLangString("msg_plot_set_perm_syntax_error"));
-					return false;
+					return null;
 				}
 
-			} else if (split.length == 3) {
-				if ((!split[0].equalsIgnoreCase("resident") 
-						&& !split[0].equalsIgnoreCase("friend") 
-						&& !split[0].equalsIgnoreCase("ally")
-						&& !split[0].equalsIgnoreCase("town")
-						&& !split[0].equalsIgnoreCase("nation")
-						&& !split[0].equalsIgnoreCase("outsider")) 
-						|| (!split[1].equalsIgnoreCase("build")
-						&& !split[1].equalsIgnoreCase("destroy")
-						&& !split[1].equalsIgnoreCase("switch")
-						&& !split[1].equalsIgnoreCase("itemuse"))) {
-					TownyMessaging.sendErrorMsg(player, TownySettings.getLangString("msg_plot_set_perm_syntax_error"));
-					return false;
-				}
-				
-				// reset the friend to resident so the perm settings don't fail
 				if (split[0].equalsIgnoreCase("friend"))
 					split[0] = "resident";
-				
-				// reset the town to nation so the perm settings don't fail
+				else if (split[0].equalsIgnoreCase("town"))
+					split[0] = "nation";
+				else if (split[0].equalsIgnoreCase("itemuse"))
+					split[0] = "item_use";
+
+				// Check if it is a perm level first
+				try {
+					TownyPermission.PermLevel permLevel = TownyPermission.PermLevel.valueOf(split[0].toUpperCase());
+
+					permChange = new TownyPermissionChange(TownyPermissionChange.Action.PERM_LEVEL, b, permLevel);
+				}
+				catch (IllegalArgumentException permLevelException) {
+					// If it is not a perm level, then check if it is a action type
+					try {
+						TownyPermission.ActionType actionType = TownyPermission.ActionType.valueOf(split[0].toUpperCase());
+
+						permChange = new TownyPermissionChange(TownyPermissionChange.Action.ACTION_TYPE, b, actionType);
+					} catch (IllegalArgumentException actionTypeException) {
+						TownyMessaging.sendErrorMsg(player, TownySettings.getLangString("msg_plot_set_perm_syntax_error"));
+						return null;
+					}
+				}
+			} else if (split.length == 3) {
+				// Reset the friend to resident so the perm settings don't fail
+				if (split[0].equalsIgnoreCase("friend"))
+					split[0] = "resident";
+
+					// reset the town to nation so the perm settings don't fail
 				else if (split[0].equalsIgnoreCase("town"))
 					split[0] = "nation";
 
+				if (split[1].equalsIgnoreCase("itemuse"))
+					split[1] = "item_use";
+
+				TownyPermission.PermLevel permLevel;
+				TownyPermission.ActionType actionType;
+
+				try {
+					permLevel = TownyPermission.PermLevel.valueOf(split[0].toUpperCase());
+					actionType = TownyPermission.ActionType.valueOf(split[1].toUpperCase());
+				} catch (IllegalArgumentException ignore) {
+					TownyMessaging.sendErrorMsg(player, TownySettings.getLangString("msg_plot_set_perm_syntax_error"));
+					return null;
+				}
+
 				try {
 					boolean b = plugin.parseOnOff(split[2]);
-					String s = "";
-					s = split[0] + split[1];
-					perm.set(s, b);
+
+					permChange = new TownyPermissionChange(TownyPermissionChange.Action.SINGLE_PERM, b, permLevel, actionType);
 				} catch (Exception e) {
 					TownyMessaging.sendErrorMsg(player, TownySettings.getLangString("msg_plot_set_perm_syntax_error"));
-					return false;
+					return null;
 				}
 
 			}
+
+			if (permChange != null)
+				perm.change(permChange);
 
 			townBlock.setChanged(true);
 			townyUniverse.getDataSource().saveTownBlock(townBlock);
@@ -789,15 +757,15 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 				TownyMessaging.sendMessage(player, (Colors.Green + " Perm: " + ((townBlockOwner instanceof Resident) ? perm.getColourString2().replace("n", "t") : perm.getColourString2().replace("f", "r"))));
 				TownyMessaging.sendMessage(player, Colors.Green + "PvP: " + ((!perm.pvp) ? Colors.Red + "ON" : Colors.LightGreen + "OFF") + Colors.Green + "  Explosions: " + ((perm.explosion) ? Colors.Red + "ON" : Colors.LightGreen + "OFF") + Colors.Green + "  Firespread: " + ((perm.fire) ? Colors.Red + "ON" : Colors.LightGreen + "OFF") + Colors.Green + "  Mob Spawns: " + ((perm.mobs) ? Colors.Red + "ON" : Colors.LightGreen + "OFF"));
 			}
-			
+
 
 			//Change settings event
 			TownBlockSettingsChangedEvent event = new TownBlockSettingsChangedEvent(townBlock);
 			Bukkit.getServer().getPluginManager().callEvent(event);
-			
+
 			// Reset all caches as this can affect everyone.
 			plugin.resetCache();
-			return true;
+			return permChange;
 		}
 	}
 

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -36,6 +36,7 @@ import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.TownBlockOwner;
 import com.palmergames.bukkit.towny.object.TownBlockType;
 import com.palmergames.bukkit.towny.object.TownyPermission;
+import com.palmergames.bukkit.towny.object.TownyPermissionChange;
 import com.palmergames.bukkit.towny.object.TownyWorld;
 import com.palmergames.bukkit.towny.object.WorldCoord;
 import com.palmergames.bukkit.towny.object.Transaction;
@@ -2818,14 +2819,8 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 
 					try {
 						boolean b = plugin.parseOnOff(split[0]);
-						for (String element : new String[] { "residentBuild",
-								"residentDestroy", "residentSwitch",
-								"residentItemUse", "outsiderBuild",
-								"outsiderDestroy", "outsiderSwitch",
-								"outsiderItemUse", "allyBuild", "allyDestroy",
-								"allySwitch", "allyItemUse", "nationBuild", "nationDestroy",
-								"nationSwitch", "nationItemUse"  })
-							perm.set(element, b);
+						
+						perm.change(TownyPermissionChange.Action.ALL_PERMS, b);
 					} catch (Exception e) {
 						TownyMessaging.sendErrorMsg(player, TownySettings.getLangString("msg_town_set_perm_syntax_error"));
 						return;
@@ -2833,88 +2828,67 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 				}
 
 			} else if (split.length == 2) {
-				if ((!split[0].equalsIgnoreCase("resident")
-						&& !split[0].equalsIgnoreCase("friend")
-						&& !split[0].equalsIgnoreCase("town") 
-						&& !split[0].equalsIgnoreCase("nation")
-						&& !split[0].equalsIgnoreCase("ally")
-						&& !split[0].equalsIgnoreCase("outsider"))
-						&& !split[0].equalsIgnoreCase("build")
-						&& !split[0].equalsIgnoreCase("destroy")
-						&& !split[0].equalsIgnoreCase("switch")
-						&& !split[0].equalsIgnoreCase("itemuse")) {
-					TownyMessaging.sendErrorMsg(player, TownySettings.getLangString("msg_town_set_perm_syntax_error"));
-					return;
-				}
+				boolean b;
 
 				try {
-
-					boolean b = plugin.parseOnOff(split[1]);
-
-					if (split[0].equalsIgnoreCase("resident") || split[0].equalsIgnoreCase("friend")) {
-						perm.residentBuild = b;
-						perm.residentDestroy = b;
-						perm.residentSwitch = b;
-						perm.residentItemUse = b;
-					} else if (split[0].equalsIgnoreCase("town") || split[0].equalsIgnoreCase("nation")) {
-						perm.nationBuild = b;
-						perm.nationDestroy = b;
-						perm.nationSwitch = b;
-						perm.nationItemUse = b;
-					} else if (split[0].equalsIgnoreCase("outsider")) {
-						perm.outsiderBuild = b;
-						perm.outsiderDestroy = b;
-						perm.outsiderSwitch = b;
-						perm.outsiderItemUse = b;
-					} else if (split[0].equalsIgnoreCase("ally")) {
-						perm.allyBuild = b;
-						perm.allyDestroy = b;
-						perm.allySwitch = b;
-						perm.allyItemUse = b;
-					} else if (split[0].equalsIgnoreCase("build")) {
-						perm.residentBuild = b;
-						perm.outsiderBuild = b;
-						perm.allyBuild = b;
-					} else if (split[0].equalsIgnoreCase("destroy")) {
-						perm.residentDestroy = b;
-						perm.outsiderDestroy = b;
-						perm.allyDestroy = b;
-					} else if (split[0].equalsIgnoreCase("switch")) {
-						perm.residentSwitch = b;
-						perm.outsiderSwitch = b;
-						perm.allySwitch = b;
-					} else if (split[0].equalsIgnoreCase("itemuse")) {
-						perm.residentItemUse = b;
-						perm.outsiderItemUse = b;
-						perm.allyItemUse = b;
-					}
-
+					b = plugin.parseOnOff(split[1]);
 				} catch (Exception e) {
 					TownyMessaging.sendErrorMsg(player, TownySettings.getLangString("msg_town_set_perm_syntax_error"));
 					return;
 				}
 
-			} else if (split.length == 3) {
+				if (split[0].equalsIgnoreCase("friend"))
+					split[0] = "resident";
+				else if (split[0].equalsIgnoreCase("town"))
+					split[0] = "nation";
+				else if (split[0].equalsIgnoreCase("itemuse"))
+					split[0] = "item_use";
 
-				if ((!split[0].equalsIgnoreCase("resident")
-						&& !split[0].equalsIgnoreCase("friend")
-						&& !split[0].equalsIgnoreCase("town")
-						&& !split[0].equalsIgnoreCase("nation")
-						&& !split[0].equalsIgnoreCase("ally")
-						&& !split[0].equalsIgnoreCase("outsider"))
-						|| (!split[1].equalsIgnoreCase("build")
-								&& !split[1].equalsIgnoreCase("destroy")
-								&& !split[1].equalsIgnoreCase("switch")
-								&& !split[1].equalsIgnoreCase("itemuse"))) {
+				// Check if it is a perm level first
+				try {
+					TownyPermission.PermLevel permLevel = TownyPermission.PermLevel.valueOf(split[0].toUpperCase());
+
+					perm.change(TownyPermissionChange.Action.PERM_LEVEL, b, permLevel);
+				}
+				catch (IllegalArgumentException permLevelException) {
+					// If it is not a perm level, then check if it is a action type
+					try {
+						TownyPermission.ActionType actionType = TownyPermission.ActionType.valueOf(split[0].toUpperCase());
+
+						perm.change(TownyPermissionChange.Action.ACTION_TYPE, b, actionType);
+					} catch (IllegalArgumentException actionTypeException) {
+						TownyMessaging.sendErrorMsg(player, TownySettings.getLangString("msg_town_set_perm_syntax_error"));
+						return;
+					}
+				}
+
+			} else if (split.length == 3) {
+				// Reset the friend to resident so the perm settings don't fail
+				if (split[0].equalsIgnoreCase("friend"))
+					split[0] = "resident";
+
+					// reset the town to nation so the perm settings don't fail
+				else if (split[0].equalsIgnoreCase("town"))
+					split[0] = "nation";
+
+				if (split[1].equalsIgnoreCase("itemuse"))
+					split[1] = "item_use";
+
+				TownyPermission.PermLevel permLevel;
+				TownyPermission.ActionType actionType;
+
+				try {
+					permLevel = TownyPermission.PermLevel.valueOf(split[0].toUpperCase());
+					actionType = TownyPermission.ActionType.valueOf(split[1].toUpperCase());
+				} catch (IllegalArgumentException ignore) {
 					TownyMessaging.sendErrorMsg(player, TownySettings.getLangString("msg_town_set_perm_syntax_error"));
 					return;
 				}
-
+				
 				try {
 					boolean b = plugin.parseOnOff(split[2]);
-					String s = "";
-					s = split[0] + split[1];
-					perm.set(s, b);
+
+					perm.change(TownyPermissionChange.Action.SINGLE_PERM, b, permLevel, actionType);
 
 				} catch (Exception e) {
 					TownyMessaging.sendErrorMsg(player, TownySettings.getLangString("msg_town_set_perm_syntax_error"));

--- a/src/com/palmergames/bukkit/towny/confirmations/ConfirmationHandler.java
+++ b/src/com/palmergames/bukkit/towny/confirmations/ConfirmationHandler.java
@@ -6,6 +6,7 @@ import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.command.PlotCommand;
+import com.palmergames.bukkit.towny.event.TownBlockSettingsChangedEvent;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.PlotObjectGroup;
@@ -14,6 +15,7 @@ import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.TownBlockOwner;
 import com.palmergames.bukkit.towny.object.TownyPermission;
+import com.palmergames.bukkit.towny.object.TownyPermissionChange;
 import com.palmergames.bukkit.towny.object.WorldCoord;
 import com.palmergames.bukkit.towny.permissions.PermissionNodes;
 import com.palmergames.bukkit.towny.tasks.PlotClaim;
@@ -22,6 +24,7 @@ import com.palmergames.bukkit.towny.tasks.TownClaim;
 import com.palmergames.bukkit.util.Colors;
 import com.palmergames.util.TimeTools;
 
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
@@ -321,16 +324,27 @@ public class ConfirmationHandler {
 				TownBlock tb = confirmation.getGroup().getTownBlocks().get(0);
 				TownBlockOwner townBlockOwner = confirmation.getTownBlockOwner();				
 				
-				// setTownBlockPermissions returns true if the town block permissions were successfully changed
-				if (PlotCommand.setTownBlockPermissions(confirmation.getPlayer(), townBlockOwner, tb, confirmation.getArgs())) {
+				// setTownBlockPermissions returns a towny permission change object
+				TownyPermissionChange permChange = PlotCommand.setTownBlockPermissions(confirmation.getPlayer(), townBlockOwner, tb, confirmation.getArgs());
+				
+				// If the perm change object is not null
+				if (permChange != null) {
 					
 					// A simple index loop starting from the second element
 					for (int i = 1; i < confirmation.getGroup().getTownBlocks().size(); ++i) {
 						tb = confirmation.getGroup().getTownBlocks().get(i);
 						
-						// TODO Redesign how townblock perms are handled to allow better caching and setting of multiple townblock perms
-						PlotCommand.setTownBlockPermissions(confirmation.getPlayer(), townBlockOwner, tb, confirmation.getArgs());
+						tb.getPermissions().change(permChange);
+
+						tb.setChanged(true);
+						townyUniverse.getDataSource().saveTownBlock(tb);
+
+						// Change settings event
+						TownBlockSettingsChangedEvent event = new TownBlockSettingsChangedEvent(tb);
+						Bukkit.getServer().getPluginManager().callEvent(event);
 					}
+
+					plugin.resetCache();
 
 					Player player = confirmation.getPlayer();
 					

--- a/src/com/palmergames/bukkit/towny/object/TownyPermission.java
+++ b/src/com/palmergames/bukkit/towny/object/TownyPermission.java
@@ -3,94 +3,194 @@ package com.palmergames.bukkit.towny.object;
 import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.util.Colors;
 
-//TODO: 12 permission so far. Anything else will expand it to include even more variables. Possibly change the data structure.
-public class TownyPermission {
+import java.util.Arrays;
 
-	public boolean residentBuild, residentDestroy, residentSwitch, residentItemUse, 
-			outsiderBuild, outsiderDestroy, outsiderSwitch, outsiderItemUse, 
-			allyBuild, allyDestroy, allySwitch, allyItemUse, 
-			nationBuild, nationDestroy, nationSwitch, nationItemUse;
+public class TownyPermission {
+	public enum ActionType {
+		BUILD (0, "Build"),
+		DESTROY (1, "Destroy"),
+		SWITCH (2, "Switch"),
+		ITEM_USE (3, "ItemUse");
+
+		// This is a static copy of the values to avoid Enum.values() which copies all the values to a new array
+		// Since this is MUTABLE, we don't have a public call to it, restricting it to this class
+		private static final ActionType[] values = ActionType.values();
+		
+		private final int index;
+		private final String commonName;
+
+		ActionType(int index, String commonName) {
+			this.index = index;
+			this.commonName = commonName;
+		}
+		
+		public int getIndex() {
+			return index;
+		}
+		
+		public String getCommonName() {
+			return commonName;
+		}
+		
+		@Override
+		public String toString() {
+			return super.toString().toLowerCase();
+		}
+	}
+
+	public enum PermLevel {
+		RESIDENT (0, 'f'), NATION (1, 'n'), ALLY (2, 'a'), OUTSIDER (3, 'o');
+		
+		private static final PermLevel[] values = PermLevel.values();
+		
+		private final int index;
+		private final char shortVal;
+		
+		PermLevel(int index, char shortVal) {
+			this.index = index;
+			this.shortVal = shortVal;
+		}
+		
+		public int getIndex() {
+			return index;
+		}
+		
+		public char getShortChar() {
+			return shortVal;
+		}
+
+		@Override
+		public String toString() {
+			return super.toString().toLowerCase();
+		}
+	}
+	
+	// Towny permissions are split into Action Type and Permission Level
+	// So they can inherently be represented by a 2d array
+	protected boolean[][] perms;
+	
 	public boolean pvp, fire, explosion, mobs;
 
 	public TownyPermission() {
-
+		// Fill the perms array
+		perms = new boolean[PermLevel.values.length][ActionType.values.length];
+		
 		reset();
 	}
 
 	public void reset() {
-
 		setAll(false);
+	}
+	
+	public void change(TownyPermissionChange permChange) {
+		change(permChange.getChangeAction(), permChange.getChangeValue(), permChange.getArgs());
+	}
+	
+	public void change(TownyPermissionChange.Action permChange, boolean toValue, Object... args) {
+		// Sorted by most common to least common
+		if (permChange == TownyPermissionChange.Action.SINGLE_PERM && args.length == 2) {
+			perms[((PermLevel) args[0]).getIndex()][((ActionType) args[1]).getIndex()] = toValue;
+		}
+		else if (permChange == TownyPermissionChange.Action.PERM_LEVEL && args.length == 1) {
+			Arrays.fill(perms[((PermLevel) args[0]).getIndex()], toValue);
+		}
+		else if (permChange == TownyPermissionChange.Action.ACTION_TYPE && args.length == 1) {
+			for (PermLevel permLevel : PermLevel.values) {
+				perms[permLevel.getIndex()][((ActionType) args[0]).getIndex()] = toValue;
+			}
+		}
+		else if (permChange == TownyPermissionChange.Action.ALL_PERMS) {
+			setAllNonEnvironmental(toValue);
+		}
+		else if (permChange == TownyPermissionChange.Action.RESET && args.length == 1) {
+			TownBlock tb = (TownBlock) args[0];
+			tb.setType(tb.getType());
+		}
+	}
+	
+	public void setAllNonEnvironmental(boolean b) {
+		for (boolean[] permLevel : perms) {
+			Arrays.fill(permLevel, b);
+		}
 	}
 
 	public void setAll(boolean b) {
-
-		residentBuild = b;
-		residentDestroy = b;
-		residentSwitch = b;
-		residentItemUse = b;
-		outsiderBuild = b;
-		outsiderDestroy = b;
-		outsiderSwitch = b;
-		outsiderItemUse = b;
-		allyBuild = b;
-		allyDestroy = b;
-		allySwitch = b;
-		allyItemUse = b;
-		nationBuild = b;
-		nationDestroy = b;
-		nationSwitch = b;
-		nationItemUse = b;
-
+		setAllNonEnvironmental(b);
+		
 		pvp = b;
 		fire = b;
 		explosion = b;
 		mobs = b;
 	}
 
+	// TODO Restructure how perms are saved
 	public void set(String s, boolean b) {
-
-		if (s.equalsIgnoreCase("denyAll"))
-			reset();
-		else if (s.equalsIgnoreCase("residentBuild"))
-			residentBuild = b;
-		else if (s.equalsIgnoreCase("residentDestroy"))
-			residentDestroy = b;
-		else if (s.equalsIgnoreCase("residentSwitch"))
-			residentSwitch = b;
-		else if (s.equalsIgnoreCase("residentItemUse"))
-			residentItemUse = b;
-		else if (s.equalsIgnoreCase("outsiderBuild"))
-			outsiderBuild = b;
-		else if (s.equalsIgnoreCase("outsiderDestroy"))
-			outsiderDestroy = b;
-		else if (s.equalsIgnoreCase("outsiderSwitch"))
-			outsiderSwitch = b;
-		else if (s.equalsIgnoreCase("outsiderItemUse"))
-			outsiderItemUse = b;
-		else if (s.equalsIgnoreCase("allyBuild"))
-			allyBuild = b;
-		else if (s.equalsIgnoreCase("allyDestroy"))
-			allyDestroy = b;
-		else if (s.equalsIgnoreCase("allySwitch"))
-			allySwitch = b;
-		else if (s.equalsIgnoreCase("allyItemUse"))
-			allyItemUse = b;
-		else if (s.equalsIgnoreCase("nationBuild"))
-			nationBuild = b;
-		else if (s.equalsIgnoreCase("nationDestroy"))
-			nationDestroy = b;
-		else if (s.equalsIgnoreCase("nationSwitch"))
-			nationSwitch = b;
-		else if (s.equalsIgnoreCase("nationItemUse"))
-			nationItemUse = b;
-		else if (s.equalsIgnoreCase("pvp"))
-			pvp = b;
-		else if (s.equalsIgnoreCase("fire"))
-			fire = b;
-		else if (s.equalsIgnoreCase("explosion"))
-			explosion = b;
-		else if (s.equalsIgnoreCase("mobs"))
-			mobs = b;
+		
+		switch (s.toLowerCase()) {
+			case "denyall":
+				reset();
+				break;
+			case "residentbuild":
+				perms[PermLevel.RESIDENT.getIndex()][ActionType.BUILD.getIndex()] = b;
+				break;
+			case "residentdestroy":
+				perms[PermLevel.RESIDENT.getIndex()][ActionType.DESTROY.getIndex()] = b;
+				break;
+			case "residentswitch":
+				perms[PermLevel.RESIDENT.getIndex()][ActionType.SWITCH.getIndex()] = b;
+				break;
+			case "residentitemuse":
+				perms[PermLevel.RESIDENT.getIndex()][ActionType.ITEM_USE.getIndex()] = b;
+				break;
+			case "outsiderbuild":
+				perms[PermLevel.OUTSIDER.getIndex()][ActionType.BUILD.getIndex()] = b;
+				break;
+			case "outsiderdestroy":
+				perms[PermLevel.OUTSIDER.getIndex()][ActionType.DESTROY.getIndex()] = b;
+				break;
+			case "outsiderswitch":
+				perms[PermLevel.OUTSIDER.getIndex()][ActionType.SWITCH.getIndex()] = b;
+				break;
+			case "outsideritemuse":
+				perms[PermLevel.OUTSIDER.getIndex()][ActionType.ITEM_USE.getIndex()] = b;
+				break;
+			case "nationbuild":
+				perms[PermLevel.NATION.getIndex()][ActionType.BUILD.getIndex()] = b;
+				break;
+			case "nationdestroy":
+				perms[PermLevel.NATION.getIndex()][ActionType.DESTROY.getIndex()] = b;
+				break;
+			case "nationswitch":
+				perms[PermLevel.NATION.getIndex()][ActionType.SWITCH.getIndex()] = b;
+				break;
+			case "nationitemuse":
+				perms[PermLevel.NATION.getIndex()][ActionType.ITEM_USE.getIndex()] = b;
+				break;
+			case "allybuild":
+				perms[PermLevel.ALLY.getIndex()][ActionType.BUILD.getIndex()] = b;
+				break;
+			case "allydestroy":
+				perms[PermLevel.ALLY.getIndex()][ActionType.DESTROY.getIndex()] = b;
+				break;
+			case "allyswitch":
+				perms[PermLevel.ALLY.getIndex()][ActionType.SWITCH.getIndex()] = b;
+				break;
+			case "allyitemuse":
+				perms[PermLevel.ALLY.getIndex()][ActionType.ITEM_USE.getIndex()] = b;
+				break;
+			case "pvp":
+				pvp = b;
+				break;
+			case "fire":
+				fire = b;
+				break;
+			case "explosion":
+				explosion = b;
+				break;
+			case "mobs":
+				mobs = b;
+				break;
+		}
 	}
 
 	public void load(String s) {
@@ -103,170 +203,92 @@ public class TownyPermission {
 
 	@Override
 	public String toString() {
+		
+		StringBuilder output = new StringBuilder("");
+		
+		for (PermLevel permLevel : PermLevel.values) {
+			String permLevelName = permLevel.name().toLowerCase();
+			
+			for (ActionType actionType : ActionType.values) {
+				if (perms[permLevel.getIndex()][actionType.getIndex()]) {
 
-		String out = "";
-		if (residentBuild)
-			out += "residentBuild";
-		if (residentDestroy)
-			out += (out.length() > 0 ? "," : "") + "residentDestroy";
-		if (residentSwitch)
-			out += (out.length() > 0 ? "," : "") + "residentSwitch";
-		if (residentItemUse)
-			out += (out.length() > 0 ? "," : "") + "residentItemUse";
-		if (outsiderBuild)
-			out += (out.length() > 0 ? "," : "") + "outsiderBuild";
-		if (outsiderDestroy)
-			out += (out.length() > 0 ? "," : "") + "outsiderDestroy";
-		if (outsiderSwitch)
-			out += (out.length() > 0 ? "," : "") + "outsiderSwitch";
-		if (outsiderItemUse)
-			out += (out.length() > 0 ? "," : "") + "outsiderItemUse";
-		if (allyBuild)
-			out += (out.length() > 0 ? "," : "") + "allyBuild";
-		if (allyDestroy)
-			out += (out.length() > 0 ? "," : "") + "allyDestroy";
-		if (allySwitch)
-			out += (out.length() > 0 ? "," : "") + "allySwitch";
-		if (allyItemUse)
-			out += (out.length() > 0 ? "," : "") + "allyItemUse";
-		if (nationBuild)
-			out += (out.length() > 0 ? "," : "") + "nationBuild";
-		if (nationDestroy)
-			out += (out.length() > 0 ? "," : "") + "nationDestroy";
-		if (nationSwitch)
-			out += (out.length() > 0 ? "," : "") + "nationSwitch";
-		if (nationItemUse)
-			out += (out.length() > 0 ? "," : "") + "nationItemUse";
+					if (output.length() != 0) {
+						output.append(',');
+					}
+
+					output.append(permLevelName).append(actionType.getCommonName());
+				}
+			}
+		}
+
 		if (pvp)
-			out += (out.length() > 0 ? "," : "") + "pvp";
+			output.append(output.length() > 0 ? "," : "").append("pvp");
 		if (fire)
-			out += (out.length() > 0 ? "," : "") + "fire";
+			output.append(output.length() > 0 ? "," : "").append("fire");
 		if (explosion)
-			out += (out.length() > 0 ? "," : "") + "explosion";
+			output.append(output.length() > 0 ? "," : "").append("explosion");
 		if (mobs)
-			out += (out.length() > 0 ? "," : "") + "mobs";
-		if (out.length() == 0)
-			out += "denyAll"; // Make the token not empty
-		return out;
+			output.append(output.length() > 0 ? "," : "").append("mobs");
+		
+		if (output.length() == 0)
+			return "denyAll";
+		
+		return output.toString();
+	}
+	
+	public boolean getPerm(PermLevel permLevel, ActionType type) {
+		return perms[permLevel.getIndex()][type.getIndex()];
 	}
 
-	public enum ActionType {
-		BUILD, DESTROY, SWITCH, ITEM_USE;
-
-		@Override
-		public String toString() {
-
-			return super.toString().toLowerCase();
-		}
-	}
-
-	public enum PermLevel {
-		RESIDENT, NATION, ALLY, OUTSIDER;
-
-		@Override
-		public String toString() {
-
-			return super.toString().toLowerCase();
-		}
-	}
-
+	// Legacy Compatibility
 	public boolean getResidentPerm(ActionType type) {
-
-		switch (type) {
-		case BUILD:
-			return residentBuild;
-		case DESTROY:
-			return residentDestroy;
-		case SWITCH:
-			return residentSwitch;
-		case ITEM_USE:
-			return residentItemUse;
-		default:
-			throw new UnsupportedOperationException();
-		}
+		return getPerm(PermLevel.RESIDENT, type);
 	}
 
 	public boolean getOutsiderPerm(ActionType type) {
-
-		switch (type) {
-		case BUILD:
-			return outsiderBuild;
-		case DESTROY:
-			return outsiderDestroy;
-		case SWITCH:
-			return outsiderSwitch;
-		case ITEM_USE:
-			return outsiderItemUse;
-		default:
-			throw new UnsupportedOperationException();
-		}
+		return getPerm(PermLevel.OUTSIDER, type);
 	}
 
 	public boolean getAllyPerm(ActionType type) {
-
-		switch (type) {
-		case BUILD:
-			return allyBuild;
-		case DESTROY:
-			return allyDestroy;
-		case SWITCH:
-			return allySwitch;
-		case ITEM_USE:
-			return allyItemUse;
-		default:
-			throw new UnsupportedOperationException();
-		}
+		return getPerm(PermLevel.ALLY, type);
 	}
 
 	public boolean getNationPerm(ActionType type) {
-
-		switch (type) {
-		case BUILD:
-			return nationBuild;
-		case DESTROY:
-			return nationDestroy;
-		case SWITCH:
-			return nationSwitch;
-		case ITEM_USE:
-			return nationItemUse;
-		default:
-			throw new UnsupportedOperationException();
-		}
+		return getPerm(PermLevel.NATION, type);
 	}
-	public String getColourString() {
 
-		return Colors.LightGreen + "Build = " + Colors.LightGray + (residentBuild ? "f" : "-") + (nationBuild ? "n" : "-") + (allyBuild ? "a" : "-") + (outsiderBuild ? "o" : "-") + 
-				Colors.LightGreen + " Destroy = " + Colors.LightGray + (residentDestroy ? "f" : "-") + (nationDestroy ? "n" : "-") + (allyDestroy ? "a" : "-") + (outsiderDestroy ? "o" : "-"); 
+	public String getColoredPermLevel(ActionType type) {
+		return getColoredPermLevel(type, type.getCommonName());
+	}
+	
+	public String getColoredPermLevel(ActionType type, String typeCommonName) {
+		StringBuilder output = new StringBuilder(Colors.LightGreen).append(typeCommonName).append(" = ").append(Colors.LightGray);
+		
+		for (PermLevel permLevel : PermLevel.values) {
+			if (perms[permLevel.getIndex()][type.getIndex()]) {
+				output.append(permLevel.getShortChar());
+			} else {
+				output.append('-');
+			}
+		}
+		
+		return output.toString();
+	}
+	
+	public String getColourString() {
+		return getColoredPermLevel(ActionType.BUILD) + getColoredPermLevel(ActionType.DESTROY, " Destroy");
 	}
 	public String getColourString2() {
-		return Colors.LightGreen + "Switch = " + Colors.LightGray + (residentSwitch ? "f" : "-") + (nationSwitch ? "n" : "-") + (allySwitch ? "a" : "-") + (outsiderSwitch ? "o" : "-") + 
-				Colors.LightGreen + " Item = " + Colors.LightGray + (residentItemUse ? "f" : "-") + (nationItemUse ? "n" : "-") + (allyItemUse ? "a" : "-") + (outsiderItemUse ? "o" : "-");
+		return getColoredPermLevel(ActionType.SWITCH) + getColoredPermLevel(ActionType.ITEM_USE, " Item");
 	}
 
 	public void loadDefault(TownBlockOwner owner) {
-
-		residentBuild = TownySettings.getDefaultPermission(owner, PermLevel.RESIDENT, ActionType.BUILD);
-		residentDestroy = TownySettings.getDefaultPermission(owner, PermLevel.RESIDENT, ActionType.DESTROY);
-		residentSwitch = TownySettings.getDefaultPermission(owner, PermLevel.RESIDENT, ActionType.SWITCH);
-		residentItemUse = TownySettings.getDefaultPermission(owner, PermLevel.RESIDENT, ActionType.ITEM_USE);
-		nationBuild = TownySettings.getDefaultPermission(owner, PermLevel.NATION, ActionType.BUILD);
-		nationDestroy = TownySettings.getDefaultPermission(owner, PermLevel.NATION, ActionType.DESTROY);
-		nationSwitch = TownySettings.getDefaultPermission(owner, PermLevel.NATION, ActionType.SWITCH);
-		nationItemUse = TownySettings.getDefaultPermission(owner, PermLevel.NATION, ActionType.ITEM_USE);
-		allyBuild = TownySettings.getDefaultPermission(owner, PermLevel.ALLY, ActionType.BUILD);
-		allyDestroy = TownySettings.getDefaultPermission(owner, PermLevel.ALLY, ActionType.DESTROY);
-		allySwitch = TownySettings.getDefaultPermission(owner, PermLevel.ALLY, ActionType.SWITCH);
-		allyItemUse = TownySettings.getDefaultPermission(owner, PermLevel.ALLY, ActionType.ITEM_USE);
-		outsiderBuild = TownySettings.getDefaultPermission(owner, PermLevel.OUTSIDER, ActionType.BUILD);
-		outsiderDestroy = TownySettings.getDefaultPermission(owner, PermLevel.OUTSIDER, ActionType.DESTROY);
-		outsiderItemUse = TownySettings.getDefaultPermission(owner, PermLevel.OUTSIDER, ActionType.ITEM_USE);
-		outsiderSwitch = TownySettings.getDefaultPermission(owner, PermLevel.OUTSIDER, ActionType.SWITCH);
-		/*
-		 * pvp = owner.getPermissions().pvp;
-		 * fire = owner.getPermissions().fire;
-		 * explosion = owner.getPermissions().explosion;
-		 * mobs = owner.getPermissions().mobs;
-		 */
+		
+		for (PermLevel permLevel : PermLevel.values) {
+			for (ActionType actionType : ActionType.values) {
+				perms[permLevel.getIndex()][actionType.getIndex()] = TownySettings.getDefaultPermission(owner, permLevel, actionType);
+			}
+		}
 
 		if (owner instanceof Town) {
 			pvp = TownySettings.getPermFlag_Town_Default_PVP();

--- a/src/com/palmergames/bukkit/towny/object/TownyPermissionChange.java
+++ b/src/com/palmergames/bukkit/towny/object/TownyPermissionChange.java
@@ -1,0 +1,35 @@
+package com.palmergames.bukkit.towny.object;
+
+/**
+ * A class that represents a permission change to a town block owner.
+ * This class can be used to cache a permission change and apply it to multiple town block owners efficiently.
+ */
+public class TownyPermissionChange {
+
+	// Enum represents a permission change action
+	public enum Action {
+		ALL_PERMS, SINGLE_PERM, PERM_LEVEL, ACTION_TYPE, RESET
+	}
+
+	private Object[] args;
+	private Action changeAction;
+	private boolean changeValue;
+
+	public TownyPermissionChange(Action changeAction, boolean changeValue, Object... args) {
+		this.changeAction = changeAction;
+		this.changeValue = changeValue;
+		this.args = args;
+	}
+	
+	public Action getChangeAction() {
+		return changeAction;
+	}
+	
+	public boolean getChangeValue() {
+		return changeValue;
+	}
+
+	public Object[] getArgs() {
+		return args;
+	}
+}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
The current way permissions were stored in the TownyPermissions class was through several individual booleans. While it worked, it was no doubt tedious to add permission levels or permission actions. This PR aims to alleviate that. 

Towny permissions are now stored in memory as a 2D boolean array. The first dimension represents the Permission Level (resident, ally, etc) which is referenced through the PermLevel enum. The second level is the Action type (switch, item use, etc) which is referenced through the ActionType enum. Both enums have hard-coded index values to allow fetching from the array. 

This PR also cleans up the `setTownBlockPermissions` and `setTownPermissions` method. Furthermore, the PR also adds permission changing caching. The `setTownBlockPermissions` method now returns a `TownyPermissionChange` object which essentially describes how the permissions holder was changed. This cache is used to quickly change all permissions in a plot group.

The PR does not change how permissions are serialized or loaded (will address after Arctidive/Siris have finished #3461) . The PR also tries to maintains legacy compatibility deleting no methods. However, it is important to note that the towny permission fields were public and the removal of them will break plugins that set permissions via those fields.

---
- [x] I have tested this pull request for defects on a server. 
Tested on a local 1.15.1 server. No errors found. I would appreciate some further external testing in case I missed anything.
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
