### PR TITLE
Fix preclaim event not firing on town creation.

### DIFF
--- a/resources/ChangeLog.txt
+++ b/resources/ChangeLog.txt
@@ -4043,3 +4043,6 @@ v0.92.0.11:
     - Used to view the /townyadmin screen.
     - Gateway permission node to all other townyadmin sub-commands
     - Child node of towny.command.townyadmin.*
+  - Fix bug with /plot group set {plottype}
+  - Disallowed the use of /plot group set jail, jails can only be set before grouping. 
+  - Language files bumped to 0.69.

--- a/resources/chinese.yml
+++ b/resources/chinese.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.68
+version: 0.69
 language: Chinese
 author: ElgarL
 website: 'http://townyadvanced.github.io/'
@@ -1061,3 +1061,6 @@ msg_set_group_type_to_x: 'Changed plot group''s type to %s'
 msg_player_successfully_bought_group_x: '%s successfully bought plot group %s'
 status_plot_group_name_and_size: '&2Townblock is part of group: %s. Group has %s Townblocks total.'
 msg_player_made_group_not_for_sale: '%s made group %s not for sale.'
+
+# Added in 0.69
+msg_err_cannot_set_group_to_jail: 'Plot groups cannot be set to jail types.'

--- a/resources/english.yml
+++ b/resources/english.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.68
+version: 0.69
 language: english
 author: ElgarL
 website: 'http://townyadvanced.github.io/'
@@ -1060,3 +1060,6 @@ msg_set_group_type_to_x: 'Changed plot group''s type to %s'
 msg_player_successfully_bought_group_x: '%s successfully bought plot group %s'
 status_plot_group_name_and_size: '&2Townblock is part of group: %s. Group has %s Townblocks total.'
 msg_player_made_group_not_for_sale: '%s made group %s not for sale.'
+
+# Added in 0.69
+msg_err_cannot_set_group_to_jail: 'Plot groups cannot be set to jail types.'

--- a/resources/es-mx.yml
+++ b/resources/es-mx.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.68
+version: 0.69
 language: español
 author: VreyaViress
 website: 'http://townyadvanced.github.io/'
@@ -1048,3 +1048,6 @@ msg_set_group_type_to_x: 'Changed plot group''s type to %s'
 msg_player_successfully_bought_group_x: '%s successfully bought plot group %s'
 status_plot_group_name_and_size: '&2Townblock is part of group: %s. Group has %s Townblocks total.'
 msg_player_made_group_not_for_sale: '%s made group %s not for sale.'
+
+# Added in 0.69
+msg_err_cannot_set_group_to_jail: 'Plot groups cannot be set to jail types.'

--- a/resources/french.yml
+++ b/resources/french.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.68
+version: 0.69
 language: french
 author: Noiknez,TheCalypso,Cidalex,Mitsu
 website: 'http://townyadvanced.github.io/'
@@ -1061,3 +1061,6 @@ msg_set_group_type_to_x: 'Changed plot group''s type to %s'
 msg_player_successfully_bought_group_x: '%s successfully bought plot group %s'
 status_plot_group_name_and_size: '&2Townblock is part of group: %s. Group has %s Townblocks total.'
 msg_player_made_group_not_for_sale: '%s made group %s n''est pas a vendre.'
+
+# Added in 0.69
+msg_err_cannot_set_group_to_jail: 'Plot groups cannot be set to jail types.'

--- a/resources/german.yml
+++ b/resources/german.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.68
+version: 0.69
 language: german
 author: 'ElgarL, translated by Articdive, Wolf2323, BlocK, Yasu-San and enterih'
 website: 'http://townyadvanced.github.io/'
@@ -1063,3 +1063,6 @@ msg_set_group_type_to_x: 'Changed plot group''s type to %s'
 msg_player_successfully_bought_group_x: '%s successfully bought plot group %s'
 status_plot_group_name_and_size: '&2Townblock is part of group: %s. Group has %s Townblocks total.'
 msg_player_made_group_not_for_sale: '%s made group %s not for sale.'
+
+# Added in 0.69
+msg_err_cannot_set_group_to_jail: 'Plot groups cannot be set to jail types.'

--- a/resources/italian.yml
+++ b/resources/italian.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.68
+version: 0.69
 language: italian
 author: Leomixer17
 website: 'http://townyadvanced.github.io/'
@@ -1062,3 +1062,6 @@ msg_set_group_type_to_x: 'Changed plot group''s type to %s'
 msg_player_successfully_bought_group_x: '%s successfully bought plot group %s'
 status_plot_group_name_and_size: '&2Townblock is part of group: %s. Group has %s Townblocks total.'
 msg_player_made_group_not_for_sale: '%s made group %s not for sale.'
+
+# Added in 0.69
+msg_err_cannot_set_group_to_jail: 'Plot groups cannot be set to jail types.'

--- a/resources/korean.yml
+++ b/resources/korean.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.68
+version: 0.69
 language: 한국어
 author: 'Daybreak 새벽'
 website: 'http://townyadvanced.github.io/'
@@ -973,3 +973,6 @@ msg_set_group_type_to_x: 'Changed plot group''s type to %s'
 msg_player_successfully_bought_group_x: '%s successfully bought plot group %s'
 status_plot_group_name_and_size: '&2Townblock is part of group: %s. Group has %s Townblocks total.'
 msg_player_made_group_not_for_sale: '%s made group %s not for sale.'
+
+# Added in 0.69
+msg_err_cannot_set_group_to_jail: 'Plot groups cannot be set to jail types.'

--- a/resources/norwegian.yml
+++ b/resources/norwegian.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.68
+version: 0.69
 language: norwegian
 author: Nectuz, Walbern
 website: 'http://townyadvanced.github.io/'
@@ -1060,3 +1060,6 @@ msg_set_group_type_to_x: 'Changed plot group''s type to %s'
 msg_player_successfully_bought_group_x: '%s successfully bought plot group %s'
 status_plot_group_name_and_size: '&2Townblock is part of group: %s. Group has %s Townblocks total.'
 msg_player_made_group_not_for_sale: '%s made group %s not for sale.'
+
+# Added in 0.69
+msg_err_cannot_set_group_to_jail: 'Plot groups cannot be set to jail types.'

--- a/resources/pt-br.yml
+++ b/resources/pt-br.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.68
+version: 0.69
 language: português (Brasil)
 author: BannerGames
 website: 'http://townyadvanced.github.io/'
@@ -1064,3 +1064,6 @@ msg_set_group_type_to_x: 'O tipo do grupo de terrenos foi deefinido para %s'
 msg_player_successfully_bought_group_x: '%s comprou o grupo de terrenos %s'
 status_plot_group_name_and_size: '&2O terreno da cidade faz parte de um grupo: %s. O grupo tem %s terrenos de cidade no total.'
 msg_player_made_group_not_for_sale: '%s tirou o grupo %s do estado de venda.'
+
+# Added in 0.69
+msg_err_cannot_set_group_to_jail: 'Plot groups cannot be set to jail types.'

--- a/resources/russian.yml
+++ b/resources/russian.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.68
+version: 0.69
 language: russian
 author: ElgarL (Plugin developer), Communar (Russian Translation)
 website: 'http://townyadvanced.github.io/'
@@ -1060,3 +1060,6 @@ msg_set_group_type_to_x: 'Changed plot group''s type to %s'
 msg_player_successfully_bought_group_x: '%s successfully bought plot group %s'
 status_plot_group_name_and_size: '&2Townblock is part of group: %s. Group has %s Townblocks total.'
 msg_player_made_group_not_for_sale: '%s made group %s not for sale.'
+
+# Added in 0.69
+msg_err_cannot_set_group_to_jail: 'Plot groups cannot be set to jail types.'

--- a/resources/spanish.yml
+++ b/resources/spanish.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.68
+version: 0.69
 language: spanish
 author: Seruhio, Alvarote1998, Beelzebu
 website: 'http://townyadvanced.github.io/'
@@ -1060,3 +1060,6 @@ msg_set_group_type_to_x: 'Changed plot group''s type to %s'
 msg_player_successfully_bought_group_x: '%s successfully bought plot group %s'
 status_plot_group_name_and_size: '&2Townblock is part of group: %s. Group has %s Townblocks total.'
 msg_player_made_group_not_for_sale: '%s made group %s not for sale.'
+
+# Added in 0.69
+msg_err_cannot_set_group_to_jail: 'Plot groups cannot be set to jail types.'

--- a/src/com/palmergames/bukkit/towny/command/PlotCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/PlotCommand.java
@@ -1439,17 +1439,21 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 				TownyMessaging.sendConfirmationMessage(player, firstLine, null, null, null);
 				return true;
 			}
-			
+			// Stop setting plot groups to Jail plot, because that would set a spawn point for each plot in the location of the player.			
+			if (split[1].equalsIgnoreCase("jail")) {
+				throw new TownyException(TownySettings.getLangString(TownySettings.getLangString("msg_err_cannot_set_group_to_jail")));
+			}
+				
 			for (TownBlock tb : townBlock.getPlotObjectGroup().getTownBlocks()) {
 				try {
-					setPlotType(resident, tb.getWorldCoord(), split[2]);
+					setPlotType(resident, tb.getWorldCoord(), split[1]);
 				} catch (Exception e) {
 					TownyMessaging.sendErrorMsg(player, TownySettings.getLangString("msg_err_could_not_set_group_type") + e.getMessage());
 					return false;
 				}
 			}
 
-			TownyMessaging.sendMsg(player, String.format(TownySettings.getLangString("msg_set_group_type_to_x"), split[2]));
+			TownyMessaging.sendMsg(player, String.format(TownySettings.getLangString("msg_set_group_type_to_x"), split[1]));
 			
 		}
 		

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -2097,7 +2097,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 			if (!noCharge && TownySettings.isUsingEconomy() && !resident.pay(TownySettings.getNewTownPrice(), "New Town Cost"))
 				throw new TownyException(String.format(TownySettings.getLangString("msg_no_funds_new_town2"), (resident.getName().equals(player.getName()) ? "You" : resident.getName()), TownySettings.getNewTownPrice()));
 
-			newTown(world, name, resident, key, player.getLocation());
+			newTown(world, name, resident, key, player.getLocation(), player);
 			TownyMessaging.sendGlobalMessage(TownySettings.getNewTownMsg(player.getName(), StringMgmt.remUnderscore(name)));
 		} catch (TownyException x) {
 			TownyMessaging.sendErrorMsg(player, x.getMessage());
@@ -2107,8 +2107,15 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		}
 	}
 
-	public static Town newTown(TownyWorld world, String name, Resident resident, Coord key, Location spawn) throws TownyException {
+	public static Town newTown(TownyWorld world, String name, Resident resident, Coord key, Location spawn, Player player) throws TownyException {
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
+		
+		TownPreClaimEvent preEvent = new TownPreClaimEvent(townyUniverse.getDataSource().getTown(name), world.getTownBlock(key), player);
+		Bukkit.getPluginManager().callEvent(preEvent);
+		
+		if (preEvent.isCancelled()) {
+			return null;
+		}
 
 		world.newTownBlock(key);
 		townyUniverse.getDataSource().newTown(name);

--- a/src/com/palmergames/bukkit/towny/tasks/ProtectionRegenTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/ProtectionRegenTask.java
@@ -7,7 +7,9 @@ import com.palmergames.bukkit.towny.regen.block.BlockLocation;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Chest;
+import org.bukkit.block.CreatureSpawner;
 import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.EntityType;
 import org.bukkit.inventory.BlockInventoryHolder;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -65,6 +67,18 @@ public class ProtectionRegenTask extends TownyTimerTask {
 			block.setBlockData(blockData);
 		} catch (Exception ex) {
 			ex.printStackTrace();
+		}
+		
+		if (state instanceof CreatureSpawner) {
+			// Up cast to interface.
+			CreatureSpawner spawner = (CreatureSpawner) state;
+			
+			// Capture spawn type and set it.
+			EntityType type = spawner.getSpawnedType();
+			((CreatureSpawner) state).setSpawnedType(type);
+
+			// update blocks.
+			state.update();
 		}
 		
 		// Add inventory back to the block if it conforms to BlockInventoryHolder.


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Fixes the TownPreClaimEvent not firing when the homeblock is claimed during town creation.
____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
#3620

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
