### PR TITLE
Alternate way to add a PreTownClaimEvent to creation of new towns.

### DIFF
--- a/resources/ChangeLog.txt
+++ b/resources/ChangeLog.txt
@@ -4032,3 +4032,4 @@ v0.92.0.11:
   - REQUIRED TOWNYPERMS.YML CHANGE:
     - towny.town.spawn.ally should be added to the default nation rank.
     - adding this will mean that when the config's global_town_settings.allow_town_spawn_travel_ally will work properly when set to true. 
+  - Update Reserve API, courtesy of thecreatorfromhell, with PR #3612.


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Should stop initial claim of a new town's homeblock, while not stopping the creation of the town itself.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
None.

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
#3620 

____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
