### PR TITLE
Update Pom_Deb to match Pom, necessary changes to deploy-on-release

### DIFF
--- a/.github/workflows/deploy-on-release.yml
+++ b/.github/workflows/deploy-on-release.yml
@@ -20,5 +20,6 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                 mkdir ~/.m2
-                echo "<settings><servers><server><id>github</id><username>TownyAdvanced</username><password>${GITHUB_TOKEN}</password></server></servers></settings>" > ~/.m2/settings.xml
+                echo "<settings><servers><server><id>github-towny</id><username>TownyAdvanced</username><password>${GITHUB_TOKEN}</password></server>" > ~/.m2/settings.xml
+                echo "<server><id>github-tne</id><username>TownyAdvanced</username><password>${GITHUB_TOKEN}</password></server></servers></settings>" >> ~/.m2/settings.xml
                 mvn -B deploy --file pom_deb.xml

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,7 @@
                 <version>3.1.1</version>
                 <executions>
                     <execution>
+                        <phase>install</phase>
                         <goals>
                             <goal>jar</goal>
                         </goals>

--- a/pom_deb.xml
+++ b/pom_deb.xml
@@ -38,7 +38,7 @@
     <!-- https://help.github.com/en/articles/about-github-package-registry -->
     <distributionManagement>
         <repository>
-            <id>github</id>
+            <id>github-towny</id>
             <name>GitHub TownyAdvanced Apache Maven Packages</name>
             <url>https://maven.pkg.github.com/TownyAdvanced/Towny</url>
         </repository>
@@ -59,7 +59,7 @@
             <url>https://jitpack.io</url>
         </repository>
         <repository>
-            <id>github</id>
+            <id>github-tne</id>
             <url>https://maven.pkg.github.com/TheNewEconomy/packages/</url>
         </repository>
         <repository>
@@ -85,13 +85,13 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.14.4-R0.1-SNAPSHOT</version>
+            <version>1.15.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.tnemc</groupId>
             <artifactId>Reserve</artifactId>
-            <version>0.1.3.2</version>
+            <version>0.1.4.5</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This PR is purely playing catch-up, since contributors do not always remember to update *both* of the Maven pom files.

- Pom_Deb should now use the same versions as the main Pom.
- Main Pom now defines to build JavaDocs on Install phase
- Deploy on Release now recognizes different 'servers' for the GitHub Package Registry

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
**NOT APPLICABLE**

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
**NOT APPLICABLE**

____
- [x] I have tested this pull request for defects on a server. 
**NOT APPLICABLE**
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
