### PR TITLE
Restore TNE authentication / Remove Automated Javadoc Phase ENTIRELY

### DIFF
--- a/.github/workflows/deploy-on-release.yml
+++ b/.github/workflows/deploy-on-release.yml
@@ -18,4 +18,7 @@ jobs:
             - name: Deploy to GitHub
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: mvn -B deploy --file pom_deb.xml
+              run: |
+                  echo "<settings><servers><server><id>github-towny</id><username>TownyAdvanced</username><password>${GITHUB_TOKEN}</password></server>" > ~/.m2/settings.xml
+                  echo "<server><id>github-tne</id><username>TownyAdvanced</username><password>${GITHUB_TOKEN}</password></server></servers></settings>" >> ~/.m2/settings.xml
+                  mvn -B deploy --file pom_deb.xml

--- a/pom.xml
+++ b/pom.xml
@@ -147,24 +147,6 @@
                     <target>${java.version}</target>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.1.1</version>
-                <executions>
-                    <execution>
-                        <phase>install</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <failOnError>false</failOnError>
-                    <failOnWarnings>false</failOnWarnings>
-                    <source>8</source>
-                </configuration>
-            </plugin>
         </plugins>
 
         <sourceDirectory>src</sourceDirectory>

--- a/pom_deb.xml
+++ b/pom_deb.xml
@@ -152,25 +152,6 @@
                     <target>${java.version}</target>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.1.1</version>
-                <executions>
-                    <execution>
-                        <phase>install</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
-                    <failOnError>false</failOnError>
-                    <failOnWarnings>false</failOnWarnings>
-                    <source>8</source>
-                </configuration>
-            </plugin>
         </plugins>
 
         <sourceDirectory>src</sourceDirectory>


### PR DESCRIPTION
A different CI can handle javadocs if it must - I do not believe GH Packages is capable of handling them in its current form. As for the authentication - this pretty much writes the maven config *without* creating the maven directory first. Recommend a "Testing" point release before 0.96.0.0 would go live.

<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Attempts to fix long-standing issues with GitHub Actions (Can't deploy javadocs), as well as newer ones (Can't auth TNE [regression]).
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
Restores the previous workflow file, but does not attempt to create the .m2 directory ("Already Exists" was a previous error, after some backend update...)
- POM files have their Javadoc functionality stripped out. You should still be capable of running `mvn javadoc:javadoc` to generate them yourself (currently errors out due to incomplete Javadoc comments...)

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Internal (No Known Ticket)

____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
