### PR TITLE
Langs: Use Pre-Existing Translatable String 'msg_modes_set' in ResidentCommand

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/ResidentCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/ResidentCommand.java
@@ -276,7 +276,7 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 			player.sendMessage(ChatTools.formatCommand("", "/res toggle", "map", ""));			
 			player.sendMessage(ChatTools.formatCommand("", "/res toggle", "spy", ""));
 
-			TownyMessaging.sendMsg(resident, ("Modes set: " + StringMgmt.join(resident.getModes(), ",")));
+			TownyMessaging.sendMsg(resident, (TownySettings.getLangString("msg_modes_set") + StringMgmt.join(resident.getModes(), ",")));
 			return;
 
 		}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
After browsing reddit, noticed one guy had an (probably unrelated) issue.
Did a quick search and found that this instance of "Modes set: " was hard-coded. Just rectifying that.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
N/A - Translatable string already exists in language files

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
None - caught this while researching a [reddit post](https://www.reddit.com/r/townyplugin/comments/d1c6oc/how_can_i_change_the_color_of_modes_set_channel/).

____
- [ ] I have tested this pull request for defects on a server.
  * No tests have been preformed, this was done on downtime at work. Should work, simple change, but can test later on request.
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
