### PR TITLE
Ensure that recent JDKs do not error when `mvn javadoc:javadoc` is run

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,14 @@
                     <target>${java.version}</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.1.1</version>
+                <configuration>
+                    <source>8</source>
+                </configuration>
+            </plugin>
         </plugins>
 
         <sourceDirectory>src</sourceDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.1.1</version>
                 <configuration>
-                    <source>8</source>
+                    <source>${java.version}</source>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom_deb.xml
+++ b/pom_deb.xml
@@ -152,6 +152,15 @@
                     <target>${java.version}</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.1.1</version>
+                <configuration>
+                    <source>8</source>
+                    <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
+                </configuration>
+            </plugin>
         </plugins>
 
         <sourceDirectory>src</sourceDirectory>

--- a/pom_deb.xml
+++ b/pom_deb.xml
@@ -157,7 +157,7 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.1.1</version>
                 <configuration>
-                    <source>8</source>
+                    <source>${java.version}</source>
                     <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
                 </configuration>
             </plugin>


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
JDK 11 and 13 will currently fail to properly build Javadoc when the source level isn't declared. This PR rectifies the issue.

NOTE: Does not re-enable automatic building of Javadocs through GitHub Actions. AFAIK, that will still result in an error during the build process. Will get in touch with GitHub support.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
Nothing new, just ensures that running `$ mvn javadoc:javadoc` doesn't fail due to:
```
[ERROR] Exit code: 1 - javadoc: error - The code being documented uses modules but the packages defined in https://docs.oracle.com/javase/8/docs/api/ are in the unnamed module.
```

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->



____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
