### PR TITLE
Reorganize TownyFormatter methods to prevent code verbosity

### DIFF
--- a/src/com/palmergames/bukkit/towny/ChunkNotification.java
+++ b/src/com/palmergames/bukkit/towny/ChunkNotification.java
@@ -200,7 +200,7 @@ public class ChunkNotification {
 				}
 			
 			} else if (TownySettings.isNotificationsTownNamesVerbose())
-				return String.format(areaTownNotificationFormat, TownyFormatter.getFormattedName(toTown));
+				return String.format(areaTownNotificationFormat, toTown.getFormattedName());
 			else 
 				return String.format(areaTownNotificationFormat, toTown);
 			
@@ -245,9 +245,9 @@ public class ChunkNotification {
 			
 			if (toResident != null)
 				if (TownySettings.isNotificationOwnerShowingNationTitles()) {
-					return String.format(ownerNotificationFormat, (toTownBlock.getName().isEmpty()) ? TownyFormatter.getFormattedResidentTitleName(toResident) : toTownBlock.getName());
+					return String.format(ownerNotificationFormat, (toTownBlock.getName().isEmpty()) ? toResident.getFormattedTitleName() : toTownBlock.getName());
 				} else {
-					return String.format(ownerNotificationFormat, (toTownBlock.getName().isEmpty()) ? TownyFormatter.getFormattedName(toResident) : toTownBlock.getName());
+					return String.format(ownerNotificationFormat, (toTownBlock.getName().isEmpty()) ? toResident.getFormattedName() : toTownBlock.getName());
 				}
 			else
 				return  String.format(noOwnerNotificationFormat, (toTownBlock.getName().isEmpty()) ? TownySettings.getUnclaimedPlotName() : toTownBlock.getName());

--- a/src/com/palmergames/bukkit/towny/Towny.java
+++ b/src/com/palmergames/bukkit/towny/Towny.java
@@ -136,7 +136,7 @@ public class Towny extends JavaPlugin {
 		BukkitTools.initialize(this);
 		TownyTimerHandler.initialize(this);
 		TownyEconomyHandler.initialize(this);
-		TownyFormatter.initialize(this);
+		TownyFormatter.initialize();
 		TownyRegenAPI.initialize(this);
 		PlayerCacheUtil.initialize(this);
 		SpawnUtil.initialize(this);

--- a/src/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/src/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -46,10 +46,7 @@ public class TownyFormatter {
 	public static final String residentListPrefixFormat = "%3$s%1$s %4$s[%2$d]%3$s:%5$s ";
     public static final String embassyTownListPrefixFormat = "%3$s%1$s:%5$s ";
 
-	public static void initialize(Towny plugin) {
-
-		// TownyFormatter.plugin = plugin;
-	}
+	public static void initialize() {}
 
 	public static List<String> getFormattedOnlineResidents(String prefix, ResidentList residentList, Player player) {
 		List<Resident> onlineResidents = ResidentUtil.getOnlineResidentsViewable(player, residentList);
@@ -68,7 +65,7 @@ public class TownyFormatter {
 
 		String[] residents = getFormattedNames(town.getOutlaws().toArray(new Resident[0]));
 
-		return new ArrayList<String>(ChatTools.listArr(residents, TownySettings.getLangString("outlaws") + " "));
+		return new ArrayList<>(ChatTools.listArr(residents, TownySettings.getLangString("outlaws") + " "));
 
 	}
 	
@@ -103,7 +100,7 @@ public class TownyFormatter {
 	 */
 	public static List<String> getStatus(TownBlock townBlock) {
 
-		List<String> out = new ArrayList<String>();
+		List<String> out = new ArrayList<>();
 		
 		try {
 			TownyObject owner;
@@ -147,7 +144,7 @@ public class TownyFormatter {
 	 */
 	public static List<String> getStatus(Resident resident, Player player) {
 
-		List<String> out = new ArrayList<String>();
+		List<String> out = new ArrayList<>();
 
 		// ___[ King Harlus ]___
 		out.add(ChatTools.formatTitle(resident.getFormattedName() + ((BukkitTools.isOnline(resident.getName()) && (player != null) && (player.canSee(BukkitTools.getPlayer(resident.getName())))) ? TownySettings.getLangString("online2") : "")));
@@ -195,7 +192,7 @@ public class TownyFormatter {
 		out.add(line);
 		
 		// Embassies in: Camelot, London, Tokyo
-		List<Town> townEmbassies = new ArrayList<Town>();
+		List<Town> townEmbassies = new ArrayList<>();
 		try {
 			
 			String actualTown = resident.hasTown() ? resident.getTown().getName() : "";
@@ -208,7 +205,7 @@ public class TownyFormatter {
 				}
 				
 			}
-		} catch (NotRegisteredException e) {}
+		} catch (NotRegisteredException ignored) {}
 		
 		if (townEmbassies.size() > 0) {
 			out.addAll(getFormattedTowns(TownySettings.getLangString("status_embassy_town"), townEmbassies));
@@ -249,28 +246,32 @@ public class TownyFormatter {
 	 */
 	public static List<String> getRanks(Town town) {
 
-		List<String> ranklist = new ArrayList<String>();
+		List<String> ranklist = new ArrayList<>();
 
 		String towntitle = town.getFormattedName();
 		towntitle += TownySettings.getLangString("rank_list_title");
 		ranklist.add(ChatTools.formatTitle(towntitle));
 		ranklist.add(String.format(TownySettings.getLangString("rank_list_mayor"), town.getMayor().getFormattedName()));
 
-		List<Resident> residents = town.getResidents();
-		List<String> townranks = TownyPerms.getTownRanks();
-		List<Resident> residentwithrank = new ArrayList<Resident>();
+		getRanks(town, ranklist);
+		return ranklist;
+	}
 
-		for (String rank : townranks) {
+	private static void getRanks(Town town, List<String> ranklist) {
+		List<Resident> residents = town.getResidents();
+		List<String> townRanks = TownyPerms.getTownRanks();
+		List<Resident> residentWithRank = new ArrayList<>();
+
+		for (String rank : townRanks) {
 			for (Resident r : residents) {
 
 				if ((r.getTownRanks() != null) && (r.getTownRanks().contains(rank))) {
-					residentwithrank.add(r);
+					residentWithRank.add(r);
 				}
 			}
-			ranklist.addAll(getFormattedResidents(StringMgmt.capitalize(rank), residentwithrank));
-			residentwithrank.clear();
+			ranklist.addAll(getFormattedResidents(StringMgmt.capitalize(rank), residentWithRank));
+			residentWithRank.clear();
 		}
-		return ranklist;
 	}
 
 	/**
@@ -281,7 +282,7 @@ public class TownyFormatter {
 	 */
 	public static List<String> formatStatusScreens(List<String> out) {
 		
-		List<String> formattedOut = new ArrayList<String>();
+		List<String> formattedOut = new ArrayList<>();
 		for (String line: out) {
 			if (line.length() > 80) {
 				int middle = (line.length()/2);
@@ -337,7 +338,7 @@ public class TownyFormatter {
 		} catch (NullPointerException ignored) {
 		}
 		// Created Date
-		Long registered= town.getRegistered();
+		long registered= town.getRegistered();
 		if (registered != 0) {
 			out.add(String.format(TownySettings.getLangString("status_founded"), registeredFormat.format(town.getRegistered())));
 		}
@@ -353,8 +354,7 @@ public class TownyFormatter {
 		            		(TownySettings.getTownDisplaysXYZ() ? (town.hasSpawn() ? BukkitTools.convertCoordtoXYZ(town.getSpawn()) : TownySettings.getLangString("status_no_town"))  + "]" 
 		            				: (town.hasHomeBlock() ? town.getHomeBlock().getCoord().toString() : TownySettings.getLangString("status_no_town")) + "]") : "")
 		           );
-		} catch (TownyException e) {
-		}
+		} catch (TownyException ignored) {}
 
 		if (TownySettings.isAllowingOutposts()) {
 			if (TownySettings.isOutpostsLimitedByLevels()) {
@@ -365,8 +365,7 @@ public class TownyFormatter {
 						int nationBonus = 0;
 						try {
 							nationBonus =  (Integer) TownySettings.getNationLevel(town.getNation()).get(TownySettings.NationLevel.NATION_BONUS_OUTPOST_LIMIT);
-						} catch (NotRegisteredException e1) {
-						}
+						} catch (NotRegisteredException ignored) {}
 						out.add(String.format(TownySettings.getLangString("status_town_outposts"), town.getMaxOutpostSpawn(), town.getOutpostLimit()) + 
 								(nationBonus > 0 ? String.format(TownySettings.getLangString("status_town_outposts2"), nationBonus) : "")
 							   );
@@ -392,7 +391,7 @@ public class TownyFormatter {
 			if (TownyEconomyHandler.isActive()) {
 				bankString = String.format(TownySettings.getLangString("status_bank"), town.getAccount().getHoldingFormattedBalance());
 				if (town.hasUpkeep())
-					bankString += String.format(TownySettings.getLangString("status_bank_town2"), new BigDecimal(TownySettings.getTownUpkeepCost(town)).setScale(2, RoundingMode.HALF_UP).doubleValue());
+					bankString += String.format(TownySettings.getLangString("status_bank_town2"), BigDecimal.valueOf(TownySettings.getTownUpkeepCost(town)).setScale(2, RoundingMode.HALF_UP).doubleValue());
 				if (TownySettings.getUpkeepPenalty() > 0 && town.isOverClaimed())
 					bankString += String.format(TownySettings.getLangString("status_bank_town_penalty_upkeep"), TownySettings.getTownPenaltyUpkeepCost(town));
 				bankString += String.format(TownySettings.getLangString("status_bank_town3"), town.getTaxes()) + (town.isTaxPercentage() ? "%" : "");
@@ -404,29 +403,15 @@ public class TownyFormatter {
 		out.add(String.format(TownySettings.getLangString("rank_list_mayor"), town.getMayor().getFormattedName()));
 
 		// Assistants [2]: Sammy, Ginger
-		List<String> ranklist = new ArrayList<String>();
-		List<Resident> residentss = town.getResidents();
-		List<String> townranks = TownyPerms.getTownRanks();
-		List<Resident> residentwithrank = new ArrayList<Resident>();
-
-		for (String rank : townranks) {
-			for (Resident r : residentss) {
-
-				if ((r.getTownRanks() != null) && (r.getTownRanks().contains(rank))) {
-					residentwithrank.add(r);
-				}
-			}
-			ranklist.addAll(getFormattedResidents(StringMgmt.capitalize(rank), residentwithrank));
-			residentwithrank.clear();
-		}
+		List<String> ranklist = new ArrayList<>();
+		getRanks(town, ranklist);
 
 		out.addAll(ranklist);
 
 		// Nation: Azur Empire
 		try {
 			out.add(String.format(TownySettings.getLangString("status_town_nation"), town.getNation().getFormattedName()) + (town.isConquered() ? TownySettings.getLangString("msg_conquered") : "" ));
-		} catch (TownyException e) {
-		}
+		} catch (TownyException ignored) {}
 
 		// Residents [12]: James, Carry, Mason
 
@@ -453,7 +438,7 @@ public class TownyFormatter {
 	 */
 	public static List<String> getStatus(Nation nation) {
 
-		List<String> out = new ArrayList<String>();
+		List<String> out = new ArrayList<>();
 
 		// ___[ Azur Empire (Open)]___
 		String title = nation.getFormattedName();
@@ -501,16 +486,16 @@ public class TownyFormatter {
 					String.format(TownySettings.getLangString("status_nation_tax"), nation.getTaxes())
 				   );
 		// Assistants [2]: Sammy, Ginger
-		List<String> ranklist = new ArrayList<String>();
+		List<String> ranklist = new ArrayList<>();
 		List<Town> towns = nation.getTowns();
-		List<Resident> residents = new ArrayList<Resident>();
+		List<Resident> residents = new ArrayList<>();
 		
 		for (Town town: towns) {
 			 residents.addAll(town.getResidents());
 		}
 		
 		List<String> nationranks = TownyPerms.getNationRanks();
-		List<Resident> residentwithrank = new ArrayList<Resident>();
+		List<Resident> residentwithrank = new ArrayList<>();
 
 		for (String rank : nationranks) {
 			for (Resident r : residents) {
@@ -521,8 +506,7 @@ public class TownyFormatter {
 			ranklist.addAll(getFormattedResidents(StringMgmt.capitalize(rank), residentwithrank));
 			residentwithrank.clear();
 		}
-		if (ranklist != null)
-			out.addAll(ranklist);
+		out.addAll(ranklist);
 		
 		// Towns [44]: James City, Carry Grove, Mason Town
 		String[] towns2 = getFormattedNames(nation.getTowns().toArray(new Town[0]));
@@ -567,7 +551,7 @@ public class TownyFormatter {
 	 */
 	public static List<String> getStatus(TownyWorld world) {
 
-		List<String> out = new ArrayList<String>();
+		List<String> out = new ArrayList<>();
 
 		// ___[ World (PvP) ]___
 		String title = world.getFormattedName();
@@ -619,8 +603,8 @@ public class TownyFormatter {
 	 */
 	public static List<String> getTaxStatus(Resident resident) {
 
-		List<String> out = new ArrayList<String>();
-		Town town = null;
+		List<String> out = new ArrayList<>();
+		Town town;
 
 		double plotTax = 0.0;
 
@@ -641,7 +625,7 @@ public class TownyFormatter {
 
 						if ((resident.getTownBlocks().size() > 0)) {
 
-							for (TownBlock townBlock : new ArrayList<TownBlock>(resident.getTownBlocks())) {
+							for (TownBlock townBlock : new ArrayList<>(resident.getTownBlocks())) {
 								plotTax += townBlock.getType().getTax(townBlock.getTown());
 							}
 
@@ -768,52 +752,6 @@ public class TownyFormatter {
 		
 		extraFields.add(field);
 		
-		return extraFields;
-	}
-
-	public static List<String> getExtraFields(TownBlock tb) {
-		if (!tb.hasMeta())
-			return new ArrayList<>();
-
-		List<String> extraFields = new ArrayList<>();
-
-		String field = "";
-
-		for (CustomDataField cdf : tb.getMetadata()) {
-			if (!cdf.hasLabel())
-				continue;
-
-			if (extraFields.contains(field))
-				field = Colors.Green + cdf.getLabel() + ": ";
-			else
-				field += Colors.Green + cdf.getLabel() + ": ";
-
-			switch (cdf.getType()) {
-				case IntegerField:
-					int ival = (int) cdf.getValue();
-					field += (ival <= 0 ? Colors.Red : Colors.LightGreen) + ival;
-					break;
-				case StringField:
-					field += Colors.White + cdf.getValue();
-					break;
-				case BooleanField:
-					boolean bval = (boolean) cdf.getValue();
-					field += (bval ? Colors.LightGreen : Colors.Red) + bval;
-					break;
-				case DecimalField:
-					double dval = (double) cdf.getValue();
-					field += (dval <= 0 ? Colors.Red : Colors.LightGreen) + dval;
-					break;
-			}
-
-			field += "  ";
-
-			if (field.length() > 40)
-				extraFields.add(field);
-		}
-
-		extraFields.add(field);
-
 		return extraFields;
 	}
 }

--- a/src/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/src/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -662,7 +662,7 @@ public class TownyFormatter {
 	}
 
 	/**
-	 * @deprecated Since 0.96.1.0 use {@link TownyObject#getFormattedName()} instead.
+	 * @deprecated Since 0.96.0.0 use {@link TownyObject#getFormattedName()} instead.
 	 * 
 	 * @param obj The {@link TownyObject} to get the formatted name from.
 	 * @return The formatted name of the object.
@@ -673,7 +673,7 @@ public class TownyFormatter {
 	}
 
 	/**
-	 * @deprecated Since 0.96.1.0 use {@link Resident#getFormattedName()} instead.
+	 * @deprecated Since 0.96.0.0 use {@link Resident#getFormattedName()} instead.
 	 *
 	 * @param resident The {@link Resident} to get the formatted name from.
 	 * @return The formatted name of the object.
@@ -684,7 +684,7 @@ public class TownyFormatter {
 	}
 
 	/**
-	 * @deprecated Since 0.96.1.0 use {@link Town#getFormattedName()} instead.
+	 * @deprecated Since 0.96.0.0 use {@link Town#getFormattedName()} instead.
 	 *
 	 * @param town The {@link Town} to get the formatted name from.
 	 * @return The formatted name of the object.
@@ -695,7 +695,7 @@ public class TownyFormatter {
 	}
 
 	/**
-	 * @deprecated Since 0.96.1.0 use {@link Nation#getFormattedName()} instead.
+	 * @deprecated Since 0.96.0.0 use {@link Nation#getFormattedName()} instead.
 	 *
 	 * @param nation The {@link Nation} to get the formatted name from.
 	 * @return The formatted name of the object.
@@ -706,7 +706,7 @@ public class TownyFormatter {
 	}
 
 	/**
-	 * @deprecated Since 0.96.1.0 use {@link Resident#getFormattedTitleName()} instead.
+	 * @deprecated Since 0.96.0.0 use {@link Resident#getFormattedTitleName()} instead.
 	 *
 	 * @param resident The {@link Resident} to get the formatted title name from.
 	 * @return The formatted title name of the resident.

--- a/src/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/src/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -57,25 +57,18 @@ public class TownyFormatter {
 	}
 
 	public static List<String> getFormattedResidents(Town town) {
-		List<String> out = new ArrayList<>();
 
 		String[] residents = getFormattedNames(town.getResidents().toArray(new Resident[0]));
 
-		out.addAll(ChatTools.listArr(residents, Colors.Green + TownySettings.getLangString("res_list") + " " + Colors.LightGreen + "[" + town.getNumResidents() + "]" + Colors.Green + ":" + Colors.White + " "));
-
-		return out;
+		return new ArrayList<>(ChatTools.listArr(residents, Colors.Green + TownySettings.getLangString("res_list") + " " + Colors.LightGreen + "[" + town.getNumResidents() + "]" + Colors.Green + ":" + Colors.White + " "));
 
 	}
 
 	public static List<String> getFormattedOutlaws(Town town) {
 
-		List<String> out = new ArrayList<String>();
-
 		String[] residents = getFormattedNames(town.getOutlaws().toArray(new Resident[0]));
 
-		out.addAll(ChatTools.listArr(residents, TownySettings.getLangString("outlaws") +  " "));
-
-		return out;
+		return new ArrayList<String>(ChatTools.listArr(residents, TownySettings.getLangString("outlaws") + " "));
 
 	}
 	
@@ -676,17 +669,7 @@ public class TownyFormatter {
 	 */
 	@Deprecated
 	public static String getFormattedName(TownyObject obj) {
-
-		if (obj == null)
-			return "Null";
-		else if (obj instanceof Resident)
-			return getFormattedResidentName((Resident) obj);
-		else if (obj instanceof Town)
-			return getFormattedTownName((Town) obj);
-		else if (obj instanceof Nation)
-			return getFormattedNationName((Nation) obj);
-		// System.out.println("just name: " + obj.getName());
-		return obj.getName().replaceAll("_", " ");
+		return obj.getFormattedName();
 	}
 
 	/**
@@ -697,14 +680,7 @@ public class TownyFormatter {
 	 */
 	@Deprecated
 	public static String getFormattedResidentName(Resident resident) {
-
-		if (resident == null)
-			return "null";
-		if (resident.isKing())
-			return (resident.hasTitle() ? resident.getTitle() + " " : TownySettings.getKingPrefix(resident)) + resident.getName() + (resident.hasSurname() ? " " + resident.getSurname() : TownySettings.getKingPostfix(resident));
-		else if (resident.isMayor())
-			return (resident.hasTitle() ? resident.getTitle() + " " : TownySettings.getMayorPrefix(resident)) + resident.getName() + (resident.hasSurname() ? " " + resident.getSurname() : TownySettings.getMayorPostfix(resident));
-		return (resident.hasTitle() ? resident.getTitle() + " " : "") + resident.getName() + (resident.hasSurname() ? " " + resident.getSurname() : "");
+		return resident.getFormattedName();
 	}
 
 	/**
@@ -715,10 +691,7 @@ public class TownyFormatter {
 	 */
 	@Deprecated
 	public static String getFormattedTownName(Town town) {
-
-		if (town.isCapital())
-			return TownySettings.getCapitalPrefix(town) + town.getName().replaceAll("_", " ") + TownySettings.getCapitalPostfix(town);
-		return TownySettings.getTownPrefix(town) + town.getName().replaceAll("_", " ") + TownySettings.getTownPostfix(town);
+		return town.getFormattedName();
 	}
 
 	/**
@@ -729,8 +702,7 @@ public class TownyFormatter {
 	 */
 	@Deprecated
 	public static String getFormattedNationName(Nation nation) {
-
-		return TownySettings.getNationPrefix(nation) + nation.getName().replaceAll("_", " ") + TownySettings.getNationPostfix(nation);
+		return nation.getFormattedName();
 	}
 
 	/**
@@ -741,11 +713,7 @@ public class TownyFormatter {
 	 */
 	@Deprecated
 	public static String getFormattedResidentTitleName(Resident resident) {
-		if (!resident.hasTitle())
-			return resident.getFormattedName();
-		else 
-			return resident.getTitle() + " " + resident.getName();		
-		
+		return resident.getFormattedTitleName();
 	}
 	
 	public static String[] getFormattedNames(TownyObject[] objs) {

--- a/src/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/src/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -125,7 +125,7 @@ public class TownyFormatter {
 			}
 			
 
-			out.add(ChatTools.formatTitle(TownyFormatter.getFormattedName(owner) + ((BukkitTools.isOnline(owner.getName())) ? TownySettings.getLangString("online") : "")));
+			out.add(ChatTools.formatTitle(owner.getFormattedName() + ((BukkitTools.isOnline(owner.getName())) ? TownySettings.getLangString("online") : "")));
 			if (!townBlock.getType().equals(TownBlockType.RESIDENTIAL))
 				out.add(TownySettings.getLangString("status_plot_type") + townBlock.getType().toString());							
 			out.add(TownySettings.getLangString("status_perm") + ((owner instanceof Resident) ? townBlock.getPermissions().getColourString().replace("n", "t") : townBlock.getPermissions().getColourString().replace("f", "r")));
@@ -157,7 +157,7 @@ public class TownyFormatter {
 		List<String> out = new ArrayList<String>();
 
 		// ___[ King Harlus ]___
-		out.add(ChatTools.formatTitle(getFormattedName(resident) + ((BukkitTools.isOnline(resident.getName()) && (player != null) && (player.canSee(BukkitTools.getPlayer(resident.getName())))) ? TownySettings.getLangString("online2") : "")));
+		out.add(ChatTools.formatTitle(resident.getFormattedName() + ((BukkitTools.isOnline(resident.getName()) && (player != null) && (player.canSee(BukkitTools.getPlayer(resident.getName())))) ? TownySettings.getLangString("online2") : "")));
 
 		// First used if last online is this year, 2nd used if last online is early than this year.
 		// Registered: Sept 3 2009 | Last Online: March 7 @ 14:30
@@ -195,7 +195,7 @@ public class TownyFormatter {
 			line += TownySettings.getLangString("status_no_town");
 		else
 			try {
-				line += getFormattedName(resident.getTown());
+				line += resident.getTown().getFormattedName();
 			} catch (TownyException e) {
 				line += "Error: " + e.getMessage();
 			}
@@ -258,10 +258,10 @@ public class TownyFormatter {
 
 		List<String> ranklist = new ArrayList<String>();
 
-		String towntitle = getFormattedName(town);
+		String towntitle = town.getFormattedName();
 		towntitle += TownySettings.getLangString("rank_list_title");
 		ranklist.add(ChatTools.formatTitle(towntitle));
-		ranklist.add(String.format(TownySettings.getLangString("rank_list_mayor"), getFormattedName(town.getMayor())));
+		ranklist.add(String.format(TownySettings.getLangString("rank_list_mayor"), town.getMayor().getFormattedName()));
 
 		List<Resident> residents = town.getResidents();
 		List<String> townranks = TownyPerms.getTownRanks();
@@ -332,7 +332,7 @@ public class TownyFormatter {
 		}
 
 		// ___[ Raccoon City (PvP) (Open) ]___
-		String title = getFormattedName(town);
+		String title = town.getFormattedName();
 		title += ((!town.isAdminDisabledPVP()) && ((town.isPVP() || town.getWorld().isForcePVP())) ? TownySettings.getLangString("status_title_pvp") : "");
 		title += (town.isOpen() ? TownySettings.getLangString("status_title_open") : "");
 		out.add(ChatTools.formatTitle(title));
@@ -408,7 +408,7 @@ public class TownyFormatter {
 		}
 
 		// Mayor: MrSand | Bank: 534 coins
-		out.add(String.format(TownySettings.getLangString("rank_list_mayor"), getFormattedName(town.getMayor())));
+		out.add(String.format(TownySettings.getLangString("rank_list_mayor"), town.getMayor().getFormattedName()));
 
 		// Assistants [2]: Sammy, Ginger
 		List<String> ranklist = new ArrayList<String>();
@@ -431,7 +431,7 @@ public class TownyFormatter {
 
 		// Nation: Azur Empire
 		try {
-			out.add(String.format(TownySettings.getLangString("status_town_nation"), getFormattedName(town.getNation())) + (town.isConquered() ? TownySettings.getLangString("msg_conquered") : "" ));
+			out.add(String.format(TownySettings.getLangString("status_town_nation"), town.getNation().getFormattedName()) + (town.isConquered() ? TownySettings.getLangString("msg_conquered") : "" ));
 		} catch (TownyException e) {
 		}
 
@@ -463,12 +463,12 @@ public class TownyFormatter {
 		List<String> out = new ArrayList<String>();
 
 		// ___[ Azur Empire (Open)]___
-		String title = getFormattedName(nation);
+		String title = nation.getFormattedName();
 		title += (nation.isOpen() ? TownySettings.getLangString("status_title_open") : "");
 		out.add(ChatTools.formatTitle(title));
 
 		// Created Date
-		Long registered = nation.getRegistered();
+		long registered = nation.getRegistered();
 		if (registered != 0) {
 			out.add(String.format(TownySettings.getLangString("status_founded"),  registeredFormat.format(nation.getRegistered())));
 		}
@@ -504,7 +504,7 @@ public class TownyFormatter {
 
 		// King: King Harlus
 		if (nation.getNumTowns() > 0 && nation.hasCapital() && nation.getCapital().hasMayor())
-			out.add(String.format(TownySettings.getLangString("status_nation_king"), getFormattedName(nation.getCapital().getMayor())) + 
+			out.add(String.format(TownySettings.getLangString("status_nation_king"), nation.getCapital().getMayor().getFormattedName()) + 
 					String.format(TownySettings.getLangString("status_nation_tax"), nation.getTaxes())
 				   );
 		// Assistants [2]: Sammy, Ginger
@@ -577,7 +577,7 @@ public class TownyFormatter {
 		List<String> out = new ArrayList<String>();
 
 		// ___[ World (PvP) ]___
-		String title = getFormattedName(world);
+		String title = world.getFormattedName();
 		title += ((world.isPVP() || world.isForcePVP()) ? TownySettings.getLangString("status_title_pvp") : "");
 		title += (world.isClaimable() ? TownySettings.getLangString("status_world_claimable") : TownySettings.getLangString("status_world_noclaims"));
 		out.add(ChatTools.formatTitle(title));
@@ -631,7 +631,7 @@ public class TownyFormatter {
 
 		double plotTax = 0.0;
 
-		out.add(ChatTools.formatTitle(getFormattedName(resident) + ((BukkitTools.isOnline(resident.getName())) ? Colors.LightGreen + " (Online)" : "")));
+		out.add(ChatTools.formatTitle(resident.getFormattedName() + ((BukkitTools.isOnline(resident.getName())) ? Colors.LightGreen + " (Online)" : "")));
 
 		if (resident.hasTown()) {
 			try {
@@ -668,28 +668,13 @@ public class TownyFormatter {
 		return out;
 	}
 
-	public static String getNamePrefix(Resident resident) {
-
-		if (resident == null)
-			return "";
-		if (resident.isKing())
-			return TownySettings.getKingPrefix(resident);
-		else if (resident.isMayor())
-			return TownySettings.getMayorPrefix(resident);
-		return "";
-	}
-
-	public static String getNamePostfix(Resident resident) {
-
-		if (resident == null)
-			return "";
-		if (resident.isKing())
-			return TownySettings.getKingPostfix(resident);
-		else if (resident.isMayor())
-			return TownySettings.getMayorPostfix(resident);
-		return "";
-	}
-
+	/**
+	 * @deprecated Since 0.96.1.0 use {@link TownyObject#getFormattedName()} instead.
+	 * 
+	 * @param obj The {@link TownyObject} to get the formatted name from.
+	 * @return The formatted name of the object.
+	 */
+	@Deprecated
 	public static String getFormattedName(TownyObject obj) {
 
 		if (obj == null)
@@ -704,6 +689,13 @@ public class TownyFormatter {
 		return obj.getName().replaceAll("_", " ");
 	}
 
+	/**
+	 * @deprecated Since 0.96.1.0 use {@link Resident#getFormattedName()} instead.
+	 *
+	 * @param resident The {@link Resident} to get the formatted name from.
+	 * @return The formatted name of the object.
+	 */
+	@Deprecated
 	public static String getFormattedResidentName(Resident resident) {
 
 		if (resident == null)
@@ -715,6 +707,13 @@ public class TownyFormatter {
 		return (resident.hasTitle() ? resident.getTitle() + " " : "") + resident.getName() + (resident.hasSurname() ? " " + resident.getSurname() : "");
 	}
 
+	/**
+	 * @deprecated Since 0.96.1.0 use {@link Town#getFormattedName()} instead.
+	 *
+	 * @param town The {@link Town} to get the formatted name from.
+	 * @return The formatted name of the object.
+	 */
+	@Deprecated
 	public static String getFormattedTownName(Town town) {
 
 		if (town.isCapital())
@@ -722,40 +721,39 @@ public class TownyFormatter {
 		return TownySettings.getTownPrefix(town) + town.getName().replaceAll("_", " ") + TownySettings.getTownPostfix(town);
 	}
 
+	/**
+	 * @deprecated Since 0.96.1.0 use {@link Nation#getFormattedName()} instead.
+	 *
+	 * @param nation The {@link Nation} to get the formatted name from.
+	 * @return The formatted name of the object.
+	 */
+	@Deprecated
 	public static String getFormattedNationName(Nation nation) {
 
 		return TownySettings.getNationPrefix(nation) + nation.getName().replaceAll("_", " ") + TownySettings.getNationPostfix(nation);
 	}
-	
+
+	/**
+	 * @deprecated Since 0.96.1.0 use {@link Resident#getFormattedTitleName()} instead.
+	 *
+	 * @param resident The {@link Resident} to get the formatted title name from.
+	 * @return The formatted title name of the resident.
+	 */
+	@Deprecated
 	public static String getFormattedResidentTitleName(Resident resident) {
 		if (!resident.hasTitle())
-			return getFormattedName(resident);
+			return resident.getFormattedName();
 		else 
 			return resident.getTitle() + " " + resident.getName();		
 		
 	}
-
-	public static String[] getFormattedNames(Resident[] residents) {
-
-		List<String> names = new ArrayList<String>();
-		for (Resident resident : residents)
-			names.add(getFormattedName(resident));
-		return names.toArray(new String[0]);
-	}
-
-	public static String[] getFormattedNames(Town[] towns) {
-
-		List<String> names = new ArrayList<String>();
-		for (Town town : towns)
-			names.add(getFormattedName(town));
-		return names.toArray(new String[0]);
-	}
-
-	public static String[] getFormattedNames(Nation[] nations) {
-
-		List<String> names = new ArrayList<String>();
-		for (Nation nation : nations)
-			names.add(getFormattedName(nation));
+	
+	public static String[] getFormattedNames(TownyObject[] objs) {
+		List<String> names = new ArrayList<>();
+		for (TownyObject obj : objs) {
+			names.add(obj.getFormattedName());
+		}
+		
 		return names.toArray(new String[0]);
 	}
 	

--- a/src/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -451,7 +451,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 					TownyMessaging.sendErrorMsg(player, TownySettings.getLangString("msg_specify_name"));
 					return;
 				}
-				TownyMessaging.sendMessage(player, ChatTools.formatTitle(TownyFormatter.getFormattedName(nation)));
+				TownyMessaging.sendMessage(player, ChatTools.formatTitle(nation.getFormattedName()));
 				TownyMessaging.sendMessage(player, ChatTools.listArr(TownyFormatter.getFormattedNames(nation.getTowns().toArray(new Town[0])), String.format(TownySettings.getLangString("status_nation_towns"), nation.getTowns().size())));
 
 			} else if (split[0].equalsIgnoreCase("allylist")) {
@@ -474,7 +474,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 				if (nation.getAllies().isEmpty())
 					TownyMessaging.sendErrorMsg(player, TownySettings.getLangString("msg_error_nation_has_no_allies")); 
 				else {
-					TownyMessaging.sendMessage(player, ChatTools.formatTitle(TownyFormatter.getFormattedName(nation)));
+					TownyMessaging.sendMessage(player, ChatTools.formatTitle(nation.getFormattedName()));
 					TownyMessaging.sendMessage(player, ChatTools.listArr(TownyFormatter.getFormattedNames(nation.getAllies().toArray(new Nation[0])), String.format(TownySettings.getLangString("status_nation_allies"), nation.getAllies().size())));
 				}
 
@@ -497,7 +497,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 				if (nation.getEnemies().isEmpty())
 					TownyMessaging.sendErrorMsg(player, TownySettings.getLangString("msg_error_nation_has_no_enemies")); 
 				else {
-					TownyMessaging.sendMessage(player, ChatTools.formatTitle(TownyFormatter.getFormattedName(nation)));
+					TownyMessaging.sendMessage(player, ChatTools.formatTitle(nation.getFormattedName()));
 					TownyMessaging.sendMessage(player, ChatTools.listArr(TownyFormatter.getFormattedNames(nation.getEnemies().toArray(new Nation[0])), String.format(TownySettings.getLangString("status_nation_enemies"), nation.getEnemies().size())));
 				}
 

--- a/src/com/palmergames/bukkit/towny/command/TownyCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyCommand.java
@@ -469,7 +469,7 @@ public class TownyCommand extends BaseCommand implements CommandExecutor {
 			output.add(Colors.Gray + "Overclaimed upkeep is based on " + Colors.LightGreen + (TownySettings.isUpkeepPenaltyByPlot() ? "the number of plots overclaimed * " + TownySettings.getUpkeepPenalty() : "a flat cost of " + TownySettings.getUpkeepPenalty()));
 
 		if (town != null) {
-			output.add(Colors.Yellow + "Town [" + TownyFormatter.getFormattedName(town) + "]");
+			output.add(Colors.Yellow + "Town [" + town.getFormattedName() + "]");
 			output.add(Colors.Rose + "    [Price] " + Colors.Green + "Plot: " + Colors.LightGreen + TownyEconomyHandler.getFormattedBalance(town.getPlotPrice()) + Colors.Gray + " | " + Colors.Green + "Outpost: " + Colors.LightGreen + TownyEconomyHandler.getFormattedBalance(TownySettings.getOutpostCost()));
 			output.add(Colors.Rose + "             " + Colors.Green + "Shop: " + Colors.LightGreen + TownyEconomyHandler.getFormattedBalance(town.getCommercialPlotPrice()) + Colors.Gray + " | " + Colors.Green + "Embassy: " + Colors.LightGreen + TownyEconomyHandler.getFormattedBalance(town.getEmbassyPlotPrice()));
 
@@ -481,7 +481,7 @@ public class TownyCommand extends BaseCommand implements CommandExecutor {
 			output.add(Colors.Rose + "                      " + Colors.Green + "Bank: " + Colors.LightGreen + TownyEconomyHandler.getFormattedBalance(TownySettings.getPlotSetBankCost()));
 			
 			if (nation != null) {
-				output.add(Colors.Yellow + "Nation [" + TownyFormatter.getFormattedName(nation) + "]");
+				output.add(Colors.Yellow + "Nation [" + nation.getFormattedName() + "]");
 				output.add(Colors.Rose + "    [Taxes] " + Colors.Green + "Town: " + Colors.LightGreen + nation.getTaxes() + Colors.Gray + " | " + Colors.Green + "Peace: " + Colors.LightGreen + TownyEconomyHandler.getFormattedBalance(TownySettings.getNationNeutralityCost()));
 			}
 		}
@@ -503,7 +503,7 @@ public class TownyCommand extends BaseCommand implements CommandExecutor {
 			if (maxListing != -1 && n > maxListing)
 				break;
 			EconomyAccount town = kv.key;
-			output.add(String.format(Colors.LightGray + "%-20s " + Colors.Gold + "|" + Colors.Blue + " %s", TownyFormatter.getFormattedName(town), TownyEconomyHandler.getFormattedBalance(kv.value)));
+			output.add(String.format(Colors.LightGray + "%-20s " + Colors.Gold + "|" + Colors.Blue + " %s", town.getFormattedName(), TownyEconomyHandler.getFormattedBalance(kv.value)));
 		}
 		return output;
 	}
@@ -522,7 +522,7 @@ public class TownyCommand extends BaseCommand implements CommandExecutor {
 			if (maxListing != -1 && n > maxListing)
 				break;
 			ResidentList residentList = kv.key;
-			output.add(String.format(Colors.Blue + "%30s " + Colors.Gold + "|" + Colors.LightGray + " %10d", TownyFormatter.getFormattedName((TownyObject) residentList), kv.value));
+			output.add(String.format(Colors.Blue + "%30s " + Colors.Gold + "|" + Colors.LightGray + " %10d", ((TownyObject) residentList).getFormattedName(), kv.value));
 		}
 		return output;
 	}
@@ -541,7 +541,7 @@ public class TownyCommand extends BaseCommand implements CommandExecutor {
 			if (maxListing != -1 && n > maxListing)
 				break;
 			Town town = (Town) kv.key;
-			output.add(String.format(Colors.Blue + "%30s " + Colors.Gold + "|" + Colors.LightGray + " %10d", TownyFormatter.getFormattedName(town), kv.value));
+			output.add(String.format(Colors.Blue + "%30s " + Colors.Gold + "|" + Colors.LightGray + " %10d",town.getFormattedName(), kv.value));
 		}
 		return output;
 	}

--- a/src/com/palmergames/bukkit/towny/object/Nation.java
+++ b/src/com/palmergames/bukkit/towny/object/Nation.java
@@ -690,6 +690,12 @@ public class Nation extends TownyObject implements ResidentList, TownyInviter, B
 		return capital.getMayor();
 	}
 
+	@Override
+	public String getFormattedName() {
+		return TownySettings.getNationPrefix(this) + this.getName().replaceAll("_", " ")
+			+ TownySettings.getNationPostfix(this);
+	}
+
 	public void addMetaData(CustomDataField md) {
 		super.addMetaData(md);
 

--- a/src/com/palmergames/bukkit/towny/object/Resident.java
+++ b/src/com/palmergames/bukkit/towny/object/Resident.java
@@ -698,6 +698,19 @@ public class Resident extends TownyObject implements TownyInviteReceiver, Econom
 	}
 
 	@Override
+	public String getFormattedName() {
+		if (isKing()) {
+			return (hasTitle() ? getTitle() + " " : TownySettings.getKingPrefix(this)) + getName() + (hasSurname() ? " " + getSurname() : TownySettings.getKingPostfix(this));
+		}
+			
+		if (isMayor()) {
+			return (hasTitle() ? getTitle() + " " : TownySettings.getMayorPrefix(this)) + getName() + (hasSurname() ? " " + getSurname() : TownySettings.getMayorPostfix(this));
+		}
+			
+		return (hasTitle() ? getTitle() + " " : "") + getName() + (hasSurname() ? " " + getSurname() : "");
+	}
+
+	@Override
 	public void setTownblocks(List<TownBlock> townBlocks) {
 		this.townBlocks = townBlocks;
 	}

--- a/src/com/palmergames/bukkit/towny/object/Resident.java
+++ b/src/com/palmergames/bukkit/towny/object/Resident.java
@@ -709,6 +709,13 @@ public class Resident extends TownyObject implements TownyInviteReceiver, Econom
 			
 		return (hasTitle() ? getTitle() + " " : "") + getName() + (hasSurname() ? " " + getSurname() : "");
 	}
+	
+	public String getFormattedTitleName() {
+		if (!hasTitle())
+			return getFormattedName();
+		else
+			return getTitle() + " " + getName();
+	}
 
 	@Override
 	public void setTownblocks(List<TownBlock> townBlocks) {

--- a/src/com/palmergames/bukkit/towny/object/Town.java
+++ b/src/com/palmergames/bukkit/towny/object/Town.java
@@ -1403,6 +1403,15 @@ public class Town extends TownyObject implements ResidentList, TownyInviter, Obj
 		return account;
 	}
 
+	@Override
+	public String getFormattedName() {
+		if (this.isCapital()) {
+			return TownySettings.getCapitalPrefix(this) + this.getName().replaceAll("_", " ") + TownySettings.getCapitalPostfix(this);
+		}
+		
+		return TownySettings.getTownPrefix(this) + this.getName().replaceAll("_", " ") + TownySettings.getTownPostfix(this);
+	}
+
 	/**
 	 * @deprecated As of 0.97.0.0+ please use {@link EconomyAccount#getWorld()} instead.
 	 * 

--- a/src/com/palmergames/bukkit/towny/object/TownyObject.java
+++ b/src/com/palmergames/bukkit/towny/object/TownyObject.java
@@ -47,13 +47,16 @@ public abstract class TownyObject implements Nameable {
 
 	@Override
 	public String toString() {
-
 		return getName();
 	}
 
+	/**
+	 * Get the formatted name, usually replacing the "_" with a space.
+	 * 
+	 * @return The formatted name.
+	 */
 	public String getFormattedName() {
-
-		return TownyFormatter.getFormattedName(this);
+		return getName().replaceAll("_", " ");
 	}
 
 	public void addMetaData(CustomDataField md) {

--- a/src/com/palmergames/bukkit/towny/object/TownyObject.java
+++ b/src/com/palmergames/bukkit/towny/object/TownyObject.java
@@ -52,6 +52,7 @@ public abstract class TownyObject implements Nameable {
 
 	/**
 	 * Get the formatted name, usually replacing the "_" with a space.
+	 * For example: <code>"Object_Name"</code> would be <code>"Object Name"</code>
 	 * 
 	 * @return The formatted name.
 	 */

--- a/src/com/palmergames/bukkit/towny/war/eventwar/War.java
+++ b/src/com/palmergames/bukkit/towny/war/eventwar/War.java
@@ -883,7 +883,7 @@ public class War {
 			Town town = kv.key;
 			int score = kv.value;
 			if (score > 0)
-				output.add(String.format(Colors.Blue + "%40s " + Colors.Gold + "|" + Colors.LightGray + " %4d", TownyFormatter.getFormattedName(town), score));
+				output.add(String.format(Colors.Blue + "%40s " + Colors.Gold + "|" + Colors.LightGray + " %4d", town.getFormattedName(), score));
 		}
 		return output;
 	}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
## This is relatively small and quick fix PR:

#### The current formatter takes in objects as a parameter to get their formatted name:
`TownyFormatter.getFormattedName(obj);`
#### With this PR this is simplified to:
`obj.getFormattedName();`

This is accomplished by adding `.getFormattedName()` to `TownyObject`, which just replaces underscores with spaces by default. It's up to the subclassed object to determine if the default behavior will be overridden. 

#### In addition:
- Removed TownyFormatter.getNamePostfix and TownyFormatter.getNamePrefix as they were never used. And were redundant to the `TownySettings` methods.

#### Proper method deprecations and messages have been added to provide legacy compatibility.
#### This PR reduces the codebase about +20~ lines, not counting deprecation documentation. For a total reduction of ~70 lines.

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
