### PR TITLE
Hotfix: Fix Flagwar townblock town transfer.

### DIFF
--- a/src/com/palmergames/bukkit/towny/war/flagwar/listeners/TownyWarCustomListener.java
+++ b/src/com/palmergames/bukkit/towny/war/flagwar/listeners/TownyWarCustomListener.java
@@ -188,17 +188,14 @@ public class TownyWarCustomListener implements Listener {
 
 			// Defender loses townblock
 			if (TownyWarConfig.isFlaggedTownblockTransfered()) {
-				// Defender loses townblock
-				universe.getDataSource().removeTownBlock(townBlock);
-
 				// Attacker Claim Automatically
 				try {
-					List<WorldCoord> selection = new ArrayList<>();
-					selection.add(worldCoord);
-					TownCommand.checkIfSelectionIsValid(attackingTown, selection, false, 0, false);
-					new TownClaim(plugin, null, attackingTown, selection, false, true, false).start();
-				} catch (TownyException te) {
+					townBlock.setTown(attackingTown);
+					TownyUniverse.getInstance().getDataSource().saveTownBlock(townBlock);
+				} catch (Exception te) {
 					// Couldn't claim it.
+					TownyMessaging.sendErrorMsg(te.getMessage());
+					te.printStackTrace();
 				}
 			} else {
 				


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Fixes issue where the "won" townblock would not be saved/transferred after restart in flag war.
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
