### PR TITLE
Auto remove towns that do not exist anymore from world files rather than going into safe mode

### DIFF
--- a/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -1180,13 +1180,20 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 				if (line != null) {
 					tokens = line.split(",");
 					for (String token : tokens) {
-						if (!token.isEmpty()) {
-							TownyMessaging.sendDebugMsg("World Fetching Town: " + token);
-							Town town = getTown(token);
-							if (town != null) {
-								town.setWorld(world);
-								//world.addTown(town); not needed as it's handled in the Town object
+						try
+						{
+							if (!token.isEmpty()) {
+								TownyMessaging.sendDebugMsg("World Fetching Town: " + token);
+								Town town = getTown(token);
+								if (town != null) {
+									town.setWorld(world);
+									//world.addTown(town); not needed as it's handled in the Town object
+								}
 							}
+						}
+						catch(Exception e)
+						{
+							TownyMessaging.sendErrorMsg("Loading Error: Exception while reading town list in world file " + path + ", the listed town '" + token + "' does not exist in Towny/data/towns/. It has been skipped and will be removed from the world file on next save.");
 						}
 					}
 				}


### PR DESCRIPTION
Was going in to add this when towny went into safe mode a few weeks ago but I found that I already had it on my local repo from like half a year ago but I forgot to commit it bak then, whoops.

- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
