### PR TITLE
Fix plot toggle tab-completion and remove unused code.

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/BaseCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/BaseCommand.java
@@ -60,13 +60,6 @@ public class BaseCommand implements TabCompleter{
 		"on",
 		"off"
 	));
-
-	private static final List<String> toggleTabCompletes = new ArrayList<>(Arrays.asList(
-		"fire",
-		"pvp",
-		"explosion",
-		"mob"
-	));
 	
 	@Override
 	public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
@@ -146,20 +139,6 @@ public class BaseCommand implements TabCompleter{
 				break;
 			case 3:
 				return NameUtil.filterByStart(setOnOffCompletes, args[2]);
-		}
-		
-		return Collections.emptyList();
-	}
-
-	/**
-	 * Used for toggle tab completes which are common across several commands
-	 * 
-	 * @param args args, make sure to remove the first few irrelevant args
-	 * @return tab completes matching the proper arg
-	 */
-	static List<String> toggleTabCompletes(String[] args) {
-		if (args.length == 1) {
-			return NameUtil.filterByStart(toggleTabCompletes, args[0]);
 		}
 		
 		return Collections.emptyList();

--- a/src/com/palmergames/bukkit/towny/command/PlotCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/PlotCommand.java
@@ -124,6 +124,13 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 		"rect",
 		"circle"
 	));
+	
+	private static final List<String> plotToggleTabCompletes = new ArrayList<>(Arrays.asList(
+		"fire",
+		"pvp",
+		"explosion",
+		"mob"
+	));
 
 	public PlotCommand(Towny instance) {
 
@@ -174,8 +181,11 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 					if (args.length > 2 && args[1].equalsIgnoreCase("perm")) {
 						return permTabComplete(StringMgmt.remArgs(args, 2));
 					}
+					break;
 				case "toggle":
-					return toggleTabCompletes(StringMgmt.remArgs(args, 2));
+					if (args.length == 2)
+						return NameUtil.filterByStart(plotToggleTabCompletes, args[1]);
+					break;
 				case "claim":
 				case "notforsale":
 				case "nfs":


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Fix an issue where the toggle options for plots would not tab complete for `/plot toggle`. This was due to the wrong number of arguments being passed in. However instead of simply fixing the issue, I opted to remove the method from the base command (which was only being used by the plot toggle command) instead. This was to follow suit for what the other towny commands were doing for toggle which I believed was a better route. 
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
