### PR TITLE
Remove redundant arraylist creation for tab-completion.

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/BaseCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/BaseCommand.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 public class BaseCommand implements TabCompleter{
 	
-	private static final List<String> setPermTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> setPermTabCompletes = Arrays.asList(
 		"on",
 		"off",
 		"resident",
@@ -29,37 +29,37 @@ public class BaseCommand implements TabCompleter{
 		"switch",
 		"itemuse",
 		"reset"
-	));
+	);
 
-	private static final List<String> setLevelCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> setLevelCompletes = Arrays.asList(
 		"resident",
 		"ally",
 		"outsider",
 		"nation",
 		"friend",
 		"town"		
-	));
+	);
 
-	private static final List<String> setTypeCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> setTypeCompletes = Arrays.asList(
 		"build",
 		"destroy",
 		"switch",
 		"itemuse"
-	));
+	);
 
-	private static final List<String> setOnOffCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> setOnOffCompletes = Arrays.asList(
 		"on",
 		"off"
-	));
+	);
 
-	private static final List<String> toggleTypeOnOffCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> toggleTypeOnOffCompletes = Arrays.asList(
 		"build",
 		"destroy",
 		"switch",
 		"itemuse",
 		"on",
 		"off"
-	));
+	);
 	
 	@Override
 	public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {

--- a/src/com/palmergames/bukkit/towny/command/InviteCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/InviteCommand.java
@@ -30,10 +30,10 @@ import java.util.stream.Collectors;
 
 public class InviteCommand extends BaseCommand implements CommandExecutor {
 
-	private static final List<String> inviteTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> inviteTabCompletes = Arrays.asList(
 		TownySettings.getAcceptCommand(),
 		TownySettings.getDenyCommand()
-	));
+	);
 	
 	@SuppressWarnings("unused")
 	private static Towny plugin;

--- a/src/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -75,7 +75,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 	private static final List<String> king_help = new ArrayList<>();
 	private static final List<String> alliesstring = new ArrayList<>();
 	private static final List<String> invite = new ArrayList<>();
-	private static final List<String> nationTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> nationTabCompletes = Arrays.asList(
 		"list",
 		"online",
 		"leave",
@@ -99,9 +99,9 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 		"ally",
 		"spawn",
 		"king"
-	));
+	);
 
-	private static final List<String> nationSetTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> nationSetTabCompletes = Arrays.asList(
 		"king",
 		"capital",
 		"board",
@@ -112,36 +112,36 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 		"title",
 		"surname",
 		"tag"
-	));
+	);
 	
-	static final List<String> nationToggleTabCompletes = new ArrayList<>(Arrays.asList(
+	static final List<String> nationToggleTabCompletes = Arrays.asList(
 		"neutral",
 		"peaceful",
 		"public",
 		"open"
-	));
+	);
 	
-	private static final List<String> nationEnemyTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> nationEnemyTabCompletes = Arrays.asList(
 		"add",
 		"remove"
-	));
+	);
 	
-	private static final List<String> nationAllyTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> nationAllyTabCompletes = Arrays.asList(
 		"add",
 		"remove",
 		"sent",
 		"received",
 		"accept",
 		"deny"
-	));
+	);
 
-	private static final List<String> nationKingTabCompletes = new ArrayList<>(Collections.singletonList("?"));
+	private static final List<String> nationKingTabCompletes = Collections.singletonList("?");
 	
-	private static final List<String> nationConsoleTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> nationConsoleTabCompletes = Arrays.asList(
 		"?",
 		"help",
 		"list"
-	));
+	);
 	
 	private static final Comparator<Nation> BY_NUM_RESIDENTS = (n1, n2) -> n2.getNumResidents() - n1.getNumResidents();
 	private static final Comparator<Nation> BY_NAME = (n1, n2) -> n1.getName().compareTo(n2.getName());

--- a/src/com/palmergames/bukkit/towny/command/PlotCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/PlotCommand.java
@@ -79,7 +79,7 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 		output.add(TownySettings.getLangString("msg_nfs_abr"));
 	}
 	
-	private static final List<String> plotTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> plotTabCompletes = Arrays.asList(
 		"claim",
 		"unclaim",
 		"forsale",
@@ -92,9 +92,9 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 		"toggle",
 		"clear",
 		"group"
-	));
+	);
 	
-	private static final List<String> plotGroupTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> plotGroupTabCompletes = Arrays.asList(
 		"add",
 		"remove",
 		"set",
@@ -103,9 +103,9 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 		"notforsale",
 		"forsale",
 		"perm"
-	));
+	);
 	
-	private static final List<String> plotSetTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> plotSetTabCompletes = Arrays.asList(
 		"reset",
 		"shop",
 		"embassy",
@@ -118,19 +118,19 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 		"outpost",
 		"name",
 		"perm"
-	));
+	);
 	
-	private static final List<String> plotRectCircleCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> plotRectCircleCompletes = Arrays.asList(
 		"rect",
 		"circle"
-	));
+	);
 	
-	private static final List<String> plotToggleTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> plotToggleTabCompletes = Arrays.asList(
 		"fire",
 		"pvp",
 		"explosion",
 		"mob"
-	));
+	);
 
 	public PlotCommand(Towny instance) {
 

--- a/src/com/palmergames/bukkit/towny/command/ResidentCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/ResidentCommand.java
@@ -41,7 +41,7 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 
 	private static Towny plugin;
 	private static final List<String> output = new ArrayList<>();
-	private static final List<String> residentTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> residentTabCompletes = Arrays.asList(
 		"friend",
 		"list",
 		"jail",
@@ -49,16 +49,16 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 		"toggle",
 		"set",
 		"tax"
-	));
+	);
 	
-	private static final List<String> residentFriendTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> residentFriendTabCompletes = Arrays.asList(
 		"add",
 		"remove",
 		"clear",
 		"list"
-	));
+	);
 
-	private static final List<String> residentToggleTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> residentToggleTabCompletes = Arrays.asList(
 		"pvp",
 		"fire",
 		"mobs",
@@ -68,9 +68,9 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 		"townclaim",
 		"map",
 		"spy"
-	));
+	);
 	
-	private static final List<String> residentModeTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> residentModeTabCompletes = Arrays.asList(
 		"map",
 		"townclaim",
 		"townunclaim",
@@ -80,18 +80,18 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 		"constantplotborder",
 		"ignoreplots",
 		"reset"
-	));
+	);
 	
-	private static final List<String> residentConsoleTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> residentConsoleTabCompletes = Arrays.asList(
 		"?",
 		"help",
 		"list"
-	));
+	);
 	
-	private static final List<String> residentSetTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> residentSetTabCompletes = Arrays.asList(
 		"perm",
 		"mode"
-	));
+	);
 	
 
 	static {

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -91,7 +91,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 	private static Towny plugin;
 	private static final List<String> output = new ArrayList<>();
 	private static final List<String> invite = new ArrayList<>();
-	private static final List<String> townTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> townTabCompletes = Arrays.asList(
 		"here",
 		"leave",
 		"list",
@@ -119,8 +119,8 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 		"invite",
 		"buy",
 		"mayor"
-		));
-	private static final List<String> townSetTabCompletes = new ArrayList<>(Arrays.asList(
+		);
+	private static final List<String> townSetTabCompletes = Arrays.asList(
 		"board",
 		"mayor",
 		"homeblock",
@@ -140,9 +140,9 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 		"embassytax",
 		"title",
 		"surname"
-	));
+	);
 
-	static final List<String> townToggleTabCompletes = new ArrayList<>(Arrays.asList(
+	static final List<String> townToggleTabCompletes = Arrays.asList(
 		"explosion",
 		"fire",
 		"mobs",
@@ -151,38 +151,38 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 		"taxpercent",
 		"open",
 		"jail"
-	));
+	);
 	
-	private static final List<String> townConsoleTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> townConsoleTabCompletes = Arrays.asList(
 		"?",
 		"help",
 		"list"
-	));
+	);
 	
-	static final List<String> townAddRemoveTabCompletes = new ArrayList<>(Arrays.asList(
+	static final List<String> townAddRemoveTabCompletes = Arrays.asList(
 		"add",
 		"remove"
-	));
+	);
 	
-	private static final List<String> townClaimTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> townClaimTabCompletes = Arrays.asList(
 		"outpost",
 		"circle",
 		"rect"
-	));
+	);
 	
-	private static final List<String> townUnclaimTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> townUnclaimTabCompletes = Arrays.asList(
 		"circle",
 		"rect",
 		"all",
 		"outpost"
-	));
+	);
 	
-	private static List<String> townInviteTabCompletes = new ArrayList<>(Arrays.asList(
+	private static List<String> townInviteTabCompletes = Arrays.asList(
 		"sent",
 		"received",
 		"accept",
 		"deny"
-	));
+	);
 
 	private static final Comparator<Town> BY_NUM_RESIDENTS = (t1, t2) -> t2.getNumResidents() - t1.getNumResidents();
 	private static final Comparator<Town> BY_OPEN = (t1, t2) -> t2.getNumResidents() - t1.getNumResidents();

--- a/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -71,7 +71,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 	private static final List<String> ta_help = new ArrayList<>();
 	private static final List<String> ta_panel = new ArrayList<>();
 	private static final List<String> ta_unclaim = new ArrayList<>();
-	private static final List<String> adminTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> adminTabCompletes = Arrays.asList(
 		"delete",
 		"plot",
 		"resident",
@@ -90,9 +90,9 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		"mysqldump",
 		"tpplot",
 		"database"
-	));
+	);
 
-	private static final List<String> adminTownTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> adminTownTabCompletes = Arrays.asList(
 		"new",
 		"add",
 		"remove",
@@ -106,18 +106,18 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		"toggle",
 		"set",
 		"meta"
-	));
+	);
 
-	private static final List<String> adminNationTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> adminNationTabCompletes = Arrays.asList(
 		"add",
 		"rename",
 		"delete",
 		"toggle",
 		"set",
 		"meta"
-	));
+	);
 
-	private static final List<String> adminToggleTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> adminToggleTabCompletes = Arrays.asList(
 		"war",
 		"neutral",
 		"npc",
@@ -125,43 +125,43 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		"devmode",
 		"townwithdraw",
 		"nationwithdraw"
-	));
+	);
 	
-	private static final List<String> adminPlotTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> adminPlotTabCompletes = Arrays.asList(
 		"claim",
 		"meta"
-	));
+	);
 	
-	private static final List<String> adminPlotMetaTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> adminPlotMetaTabCompletes = Arrays.asList(
 		"set",
 		"add",
 		"remove"
-	));
+	);
 	
-	private static final List<String> adminDatabaseTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> adminDatabaseTabCompletes = Arrays.asList(
 		"save",
 		"load"
-	));
+	);
 	
-	private static final List<String> adminResidentTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> adminResidentTabCompletes = Arrays.asList(
 		"rename",
 		"friend"
-	));
+	);
 	
-	private static final List<String> adminResidentFriendTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> adminResidentFriendTabCompletes = Arrays.asList(
 		"add",
 		"remove",
 		"list",
 		"clear"
-	));
+	);
 	
-	private static final List<String> adminSetCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> adminSetCompletes = Arrays.asList(
 		"mayor",
 		"capital",
 		"title",
 		"surname",
 		"plot"
-	));
+	);
 	
 
 	private boolean isConsole;

--- a/src/com/palmergames/bukkit/towny/command/TownyCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyCommand.java
@@ -51,7 +51,7 @@ public class TownyCommand extends BaseCommand implements CommandExecutor {
 	private static final List<String> towny_top = new ArrayList<>();
 	private static final List<String> towny_war = new ArrayList<>();
 	private static String towny_version;
-	private static final List<String> townyTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> townyTabCompletes = Arrays.asList(
 		"map",
 		"prices",
 		"time",
@@ -60,9 +60,9 @@ public class TownyCommand extends BaseCommand implements CommandExecutor {
 		"universe",
 		"v",
 		"war"
-	));
+	);
 	
-	private static final List<String> townyConsoleTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> townyConsoleTabCompletes = Arrays.asList(
 		"prices",
 		"time",
 		"top",
@@ -71,31 +71,31 @@ public class TownyCommand extends BaseCommand implements CommandExecutor {
 		"tree",
 		"v",
 		"war"
-	));
+	);
 
-	private static final List<String> townyWarTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> townyWarTabCompletes = Arrays.asList(
 		"stats",
 		"scores",
 		"hud",
 		"participants"
-	));
+	);
 	
-	private static final List<String> townyTopTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> townyTopTabCompletes = Arrays.asList(
 		"residents",
 		"land"
-	));
+	);
 	
-	private static final List<String> townyTopResidentsTabComplete = new ArrayList<>(Arrays.asList(
+	private static final List<String> townyTopResidentsTabComplete = Arrays.asList(
 		"all",
 		"town",
 		"nation"
-	));
+	);
 	
-	private static final List<String> townyTopLandTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> townyTopLandTabCompletes = Arrays.asList(
 		"all",
 		"resident",
 		"town"
-	));
+	);
 	
 
 	static {

--- a/src/com/palmergames/bukkit/towny/command/TownyWorldCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyWorldCommand.java
@@ -42,15 +42,15 @@ public class TownyWorldCommand extends BaseCommand implements CommandExecutor {
 	private static final List<String> townyworld_set_console = new ArrayList<>();
 	private static TownyWorld Globalworld;
 	
-	private static final List<String> townyWorldTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> townyWorldTabCompletes = Arrays.asList(
 		"list",
 		"toggle",
 		"set",
 		"regen",
 		"undo"
-	));
+	);
 
-	private static final List<String> townyWorldToggleTabCompletes = new ArrayList<>(Arrays.asList(
+	private static final List<String> townyWorldToggleTabCompletes = Arrays.asList(
 		"claimable",
 		"usingtowny",
 		"pvp",
@@ -63,15 +63,15 @@ public class TownyWorldCommand extends BaseCommand implements CommandExecutor {
 		"revertunclaim",
 		"revertexpl",
 		"warallowed"
-	));
+	);
 	
-	private static List<String> townySetTabCompletes = new ArrayList<>(Arrays.asList(
+	private static List<String> townySetTabCompletes = Arrays.asList(
 		"usedefault",
 		"wildperm",
 		"wildignore",
 		"wildregen",
 		"wildname"
-	));
+	);
 	
 	private boolean isConsole = false;
 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This just gets rid of the redundant `new ArrayList<>()` call. It's important to note that `Arrays.asList()` creates a unique arraylist backed by a fixed array. This means that you cannot mutate the size of the list (attempting to will throw an `UnsupportedOperation Exception` . This works in our favor as Siris and I both agreed that we want a fixed list for the tab-completes.
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->
By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.