### PR TITLE
Set Outpost value for TownPreClaimEvent

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -2411,7 +2411,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 				}
 
 				String title = StringMgmt.join(NameValidation.checkAndFilterArray(split));
-				resident.setTitle(title + " ");
+				resident.setTitle(title);
 				townyUniverse.getDataSource().saveResident(resident);
 
 				if (resident.hasTitle())
@@ -2446,7 +2446,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 				}
 
 				String surname = StringMgmt.join(NameValidation.checkAndFilterArray(split));
-				resident.setSurname(" " + surname);
+				resident.setSurname(surname);
 				townyUniverse.getDataSource().saveResident(resident);
 
 				if (resident.hasSurname())

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -1822,7 +1822,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 				}
 
 				String title = StringMgmt.join(NameValidation.checkAndFilterArray(split));
-				resident.setTitle(title + " ");
+				resident.setTitle(title);
 				townyUniverse.getDataSource().saveResident(resident);
 
 				if (resident.hasTitle())
@@ -1857,7 +1857,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 				}
 
 				String surname = StringMgmt.join(NameValidation.checkAndFilterArray(split));
-				resident.setSurname(" " + surname);
+				resident.setSurname(surname);
 				townyUniverse.getDataSource().saveResident(resident);
 
 				if (resident.hasSurname())

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -3321,7 +3321,9 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 
 				for(WorldCoord coord : selection){
 					//Use the user's current world
-					TownPreClaimEvent preClaimEvent = new TownPreClaimEvent(town, new TownBlock(coord.getX(), coord.getZ(), world), player);
+					TownBlock townBlock = new TownBlock(coord.getX(), coord.getZ(), world);
+					townBlock.setOutpost(outpost);
+					TownPreClaimEvent preClaimEvent = new TownPreClaimEvent(town, townBlock, player);
 					BukkitTools.getPluginManager().callEvent(preClaimEvent);
 					if(preClaimEvent.isCancelled())
 						blockedClaims++;

--- a/src/com/palmergames/bukkit/towny/event/NationTagChangeEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/NationTagChangeEvent.java
@@ -6,31 +6,31 @@ import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
 public class NationTagChangeEvent extends Event {
-	private static final HandlerList handlers = new HandlerList();
+    private static final HandlerList handlers = new HandlerList();
 
-	private String newTag;
-	private Nation nation;
+    private String newTag;
+    private Nation nation;
 
-	@Override
-	public HandlerList getHandlers() {
-		return handlers;
-	}
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
 
-	public static HandlerList getHandlerList() {
-		return handlers;
-	}
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
 
-	public NationTagChangeEvent(Nation nation, String newTag) {
-		super(!Bukkit.getServer().isPrimaryThread());
-		this.nation = nation;
-		this.newTag = newTag;
-	}
+    public NationTagChangeEvent(Nation nation, String newTag) {
+        super(!Bukkit.getServer().isPrimaryThread());
+        this.nation = nation;
+        this.newTag = newTag;
+    }
 
-	public String getNewTag() {
-		return newTag;
-	}
+    public String getNewTag() {
+        return newTag;
+    }
 
-	public Nation getNation() {
-		return nation;
-	}
+    public Nation getNation() {
+        return nation;
+    }
 }


### PR DESCRIPTION
#### Description: 
Essentially, the TownPreClaimEvent's TownBlock#isOutpost method would always return false. This pull request fixes the issue, so plugins using the event can properly address if the block is an outpost.
___
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
