### PR TITLE
Add Duration Config Option for Action Bar and Increase Default Duration

### DIFF
--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -970,8 +970,8 @@ public enum ConfigNodes {
 			"# This setting only applies to servers running spigot, paper or bungeecord.",
 			"# On servers using craftbukkit.jar the notifications will always appear in the chat.",
 			"# When set to false the notifications will appear in the chat rather than the action bar."),
-
-
+	NOTIFICATION_ACTIONBAR_DURATION("notification.notification_actionbar_duration", "15",
+		"# This settings set the duration the actionbar (The text above the inventory bar) lasts in seconds"),
 	FLAGS_DEFAULT(
 			"default_perm_flags",
 			"",

--- a/src/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
@@ -1,5 +1,6 @@
 package com.palmergames.bukkit.towny.listeners;
 
+import com.palmergames.bukkit.config.ConfigNodes;
 import com.palmergames.bukkit.towny.ChunkNotification;
 import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.TownySettings;
@@ -17,10 +18,13 @@ import com.palmergames.bukkit.util.DrawSmokeTaskFactory;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
 
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Author: Chris H (Zren / Shade)
@@ -28,6 +32,7 @@ import org.bukkit.event.Listener;
  */
 public class TownyCustomListener implements Listener {
 	private final Towny plugin;
+	private ConcurrentHashMap<Player, Integer> playerActionTasks = new ConcurrentHashMap<>();
 
 	public TownyCustomListener(Towny instance) {
 		plugin = instance;
@@ -57,10 +62,21 @@ public class TownyCustomListener implements Listener {
 				Resident resident = TownyUniverse.getInstance().getDataSource().getResident(player.getName());
 				ChunkNotification chunkNotifier = new ChunkNotification(from, to);
 				String msg = chunkNotifier.getNotificationString(resident);
+				
+				// Cancel any older tasks running to prevent them from leaking over.
+				if (playerActionTasks.get(player) != null) {
+					Bukkit.getScheduler().cancelTask(playerActionTasks.get(player));
+				}
+				
+				int seconds = TownySettings.getInt(ConfigNodes.NOTIFICATION_ACTIONBAR_DURATION);;
 				if (msg != null)
-					if (Towny.isSpigot && TownySettings.isNotificationsAppearingInActionBar())
-						player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(msg));
-					else {						
+					if (Towny.isSpigot && TownySettings.isNotificationsAppearingInActionBar()) {
+						int taskID = Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, () -> player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(msg)), 0, 20L).getTaskId();
+						Bukkit.getScheduler().runTaskLater(plugin, () -> Bukkit.getScheduler().cancelTask(taskID), 20L * seconds);
+						
+						// Cache ID
+						playerActionTasks.put(player, taskID);
+					} else {						
 						player.sendMessage(msg);
 					}
 			}

--- a/src/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
@@ -24,6 +24,8 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -32,7 +34,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class TownyCustomListener implements Listener {
 	private final Towny plugin;
-	private ConcurrentHashMap<Player, Integer> playerActionTasks = new ConcurrentHashMap<>();
+	private Map<Player, Integer> playerActionTasks = new HashMap<>();
 
 	public TownyCustomListener(Towny instance) {
 		plugin = instance;

--- a/src/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
@@ -26,7 +26,6 @@ import org.bukkit.event.Listener;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Author: Chris H (Zren / Shade)

--- a/src/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
@@ -72,7 +72,14 @@ public class TownyCustomListener implements Listener {
 				if (msg != null)
 					if (Towny.isSpigot && TownySettings.isNotificationsAppearingInActionBar()) {
 						int taskID = Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, () -> player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(msg)), 0, 20L).getTaskId();
-						Bukkit.getScheduler().runTaskLater(plugin, () -> Bukkit.getScheduler().cancelTask(taskID), 20L * seconds);
+						Bukkit.getScheduler().runTaskLater(plugin, () -> {
+							
+							// Cancel task.
+							Bukkit.getScheduler().cancelTask(taskID);
+							
+							// Remove cached task.
+							playerActionTasks.remove(player);
+						}, 20L * seconds);
 						
 						// Cache ID
 						playerActionTasks.put(player, taskID);


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
One of the main complaints I have in terms of UX with Towny, is the lack of persistence with chunk notifications. While moving the text out of chat was a step forward, the small window of time that the notification currently stays on-screen seems like a step backward. So with this PR the duration of the action bar will be modifiable via the config, which sets the default at 15 seconds. This may seem like a lot compared to the ~3s time now, but persistence is the key here.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
`notification.notification_actionbar_duration` with default value of `15`
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
