### PR TITLE
add separate tax limits for towns, nations and townblocks

### DIFF
--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1346,10 +1346,6 @@ public enum ConfigNodes {
 		"economy.daily_taxes.max_nation_tax_amount",
 		"1000.0",
 		"# Maximum tax amount allowed for nations when using flat taxes"),
-	ECO_DAILY_TAXES_MAX_TAX_PERCENT(
-			"economy.daily_taxes.max_tax_percent",
-			"25",
-			"# maximum tax percentage allowed when taxing by percentages"),
 	ECO_DAILY_TAXES_MAX_TOWN_TAX_PERCENT(
 		"economy.daily_taxes.max_town_tax_percent",
 		"25",

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1337,11 +1337,23 @@ public enum ConfigNodes {
 	ECO_DAILY_TAXES_MAX_TAX(
 			"economy.daily_taxes.max_tax_amount",
 			"1000.0",
-			"# Maximum tax amount allowed when using flat taxes"),
+			"# Maximum tax amount allowed when using flat taxes this option"),
+	ECO_DAILY_TOWN_TAXES_MAX(
+		"economy.daily_taxes.max_town_tax_amount",
+		"1000.0",
+		"# Maximum tax amount allowed for towns when using flat taxes"),
+	ECO_DAILY_NATION_TAXES_MAX(
+		"economy.daily_taxes.max_nation_tax_amount",
+		"1000.0",
+		"# Maximum tax amount allowed for nations when using flat taxes"),
 	ECO_DAILY_TAXES_MAX_TAX_PERCENT(
 			"economy.daily_taxes.max_tax_percent",
 			"25",
 			"# maximum tax percentage allowed when taxing by percentages"),
+	ECO_DAILY_TAXES_MAX_TOWN_TAX_PERCENT(
+		"economy.daily_taxes.max_town_tax_percent",
+		"25",
+		"# maximum tax percentage allowed when taxing by percentages for towns."),
 	ECO_PRICE_NATION_UPKEEP(
 			"economy.daily_taxes.price_nation_upkeep",
 			"100.0",

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1334,8 +1334,8 @@ public enum ConfigNodes {
 			"# if a resident can't pay his plot tax he loses his plot.",
 			"# if a resident can't pay his town tax then he is kicked from the town.",
 			"# if a town or nation fails to pay it's upkeep it is deleted."),
-	ECO_DAILY_TAXES_MAX_TAX(
-			"economy.daily_taxes.max_tax_amount",
+	ECO_DAILY_TAXES_MAX_PLOT_TAX(
+			"economy.daily_taxes.max_plot_tax_amount",
 			"1000.0",
 			"# Maximum tax amount allowed when using flat taxes this option"),
 	ECO_DAILY_TOWN_TAXES_MAX(

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1337,7 +1337,7 @@ public enum ConfigNodes {
 	ECO_DAILY_TAXES_MAX_PLOT_TAX(
 			"economy.daily_taxes.max_plot_tax_amount",
 			"1000.0",
-			"# Maximum tax amount allowed when using flat taxes this option"),
+			"# Maximum tax amount allowed for townblocks"),
 	ECO_DAILY_TOWN_TAXES_MAX(
 		"economy.daily_taxes.max_town_tax_amount",
 		"1000.0",

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -1658,8 +1658,8 @@ public class TownySettings {
 		return getBoolean(ConfigNodes.ECO_DAILY_TAXES_ENABLED);
 	}
 
-	public static double getMaxTax() {
-		return getDouble(ConfigNodes.ECO_DAILY_TAXES_MAX_TAX);
+	public static double getMaxPlotTax() {
+		return getDouble(ConfigNodes.ECO_DAILY_TAXES_MAX_PLOT_TAX);
 	}
 
 	public static double getMaxTownTax() {

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -1659,20 +1659,26 @@ public class TownySettings {
 	}
 
 	public static double getMaxTax() {
-
 		return getDouble(ConfigNodes.ECO_DAILY_TAXES_MAX_TAX);
+	}
+
+	public static double getMaxTownTax() {
+		return getDouble(ConfigNodes.ECO_DAILY_TOWN_TAXES_MAX);
+	}
+
+	public static double getMaxNationTax() {
+		return getDouble(ConfigNodes.ECO_DAILY_NATION_TAXES_MAX);
 	}
 	
 	public static double getMaxPlotPrice() {
 		
 		return getDouble(ConfigNodes.GTOWN_MAX_PLOT_PRICE_COST);
 	}
-
-	public static double getMaxTaxPercent() {
-
-		return getDouble(ConfigNodes.ECO_DAILY_TAXES_MAX_TAX_PERCENT);
+	
+	public static double getMaxTownTaxPercent() {
+		return getDouble(ConfigNodes.ECO_DAILY_TAXES_MAX_TOWN_TAX_PERCENT);
 	}
-
+	
 	public static boolean isBackingUpDaily() {
 
 		return getBoolean(ConfigNodes.PLUGIN_DAILY_BACKUPS);

--- a/src/com/palmergames/bukkit/towny/object/Nation.java
+++ b/src/com/palmergames/bukkit/towny/object/Nation.java
@@ -407,7 +407,7 @@ public class Nation extends TownyObject implements ResidentList, TownyInviter, B
 	}
 
 	public void setTaxes(double taxes) {
-		this.taxes = Math.min(taxes, TownySettings.getMaxTax());
+		this.taxes = Math.min(taxes, TownySettings.getMaxNationTax());
 	}
 
 	public double getTaxes() {

--- a/src/com/palmergames/bukkit/towny/object/Town.java
+++ b/src/com/palmergames/bukkit/towny/object/Town.java
@@ -945,7 +945,7 @@ public class Town extends TownyObject implements ResidentList, TownyInviter, Obj
 	}
 
 	public void setPlotTax(double plotTax) {
-		this.plotTax = Math.min(plotTax, TownySettings.getMaxTax());
+		this.plotTax = Math.min(plotTax, TownySettings.getMaxPlotTax());
 	}
 
 	public double getPlotTax() {
@@ -954,7 +954,7 @@ public class Town extends TownyObject implements ResidentList, TownyInviter, Obj
 	}
 
 	public void setCommercialPlotTax(double commercialTax) {
-		this.commercialPlotTax = Math.min(commercialTax, TownySettings.getMaxTax());
+		this.commercialPlotTax = Math.min(commercialTax, TownySettings.getMaxPlotTax());
 	}
 
 	public double getCommercialPlotTax() {
@@ -963,7 +963,7 @@ public class Town extends TownyObject implements ResidentList, TownyInviter, Obj
 	}
 
 	public void setEmbassyPlotTax(double embassyPlotTax) {
-		this.embassyPlotTax = Math.min(embassyPlotTax, TownySettings.getMaxTax());
+		this.embassyPlotTax = Math.min(embassyPlotTax, TownySettings.getMaxPlotTax());
 	}
 
 	public double getEmbassyPlotTax() {

--- a/src/com/palmergames/bukkit/towny/object/Town.java
+++ b/src/com/palmergames/bukkit/towny/object/Town.java
@@ -135,11 +135,10 @@ public class Town extends TownyObject implements ResidentList, TownyInviter, Obj
 	}
 
 	public void setTaxes(double taxes) {
-
 		if (isTaxPercentage) {
-			this.taxes = Math.min(taxes, TownySettings.getMaxTaxPercent());
+			this.taxes = Math.min(taxes, TownySettings.getMaxTownTaxPercent());
 		} else {
-			this.taxes = Math.min(taxes, TownySettings.getMaxTax());
+			this.taxes = Math.min(taxes, TownySettings.getMaxTownTax());
 		}
 	}
 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Adds the ability to set seperate tax limits for both towns and nations.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
`economy.daily_taxes.max_town_tax_amount` - the max town tax
`economy.daily_taxes.max_town_tax_percent` - the max town tax percent
`economy.daily_taxes.max_nation_tax_amount` - the max nation tax
`economy.daily_taxes.max_plot_tax_amount` - the max plot tax


**Removed**
`economy.daily_taxes.max_tax_percent`
`economy.daily_taxes.max_tax_amount`
These values should be migrated to the new config options.
____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #3598

____
- [X] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
