### PR TITLE
Nation Bonus Event

### DIFF
--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -2,6 +2,7 @@ package com.palmergames.bukkit.towny;
 
 import com.palmergames.bukkit.config.CommentedConfiguration;
 import com.palmergames.bukkit.config.ConfigNodes;
+import com.palmergames.bukkit.towny.event.NationBonusCalculationEvent;
 import com.palmergames.bukkit.towny.event.NationUpkeepCalculationEvent;
 import com.palmergames.bukkit.towny.event.TownUpkeepCalculationEvent;
 import com.palmergames.bukkit.towny.event.TownUpkeepPenalityCalculationEvent;
@@ -1114,11 +1115,7 @@ public class TownySettings {
 		} else
 			n += town.getNumResidents() * ratio;
 
-		if (town.hasNation())
-			try {
-				n += (Integer) getNationLevel(town.getNation()).get(TownySettings.NationLevel.TOWN_BLOCK_LIMIT_BONUS);
-			} catch (NotRegisteredException e) {
-			}
+		n += getNationBonusBlocks(town);
 
 		return n;
 	}
@@ -1142,8 +1139,9 @@ public class TownySettings {
 	}
 
 	public static int getNationBonusBlocks(Nation nation) {
-
-		return (Integer) getNationLevel(nation).get(TownySettings.NationLevel.TOWN_BLOCK_LIMIT_BONUS);
+		int bonusBlocks = (Integer) getNationLevel(nation).get(TownySettings.NationLevel.TOWN_BLOCK_LIMIT_BONUS);
+		NationBonusCalculationEvent calculationEvent = new NationBonusCalculationEvent(nation, bonusBlocks);
+		return calculationEvent.getBonusBlocks();
 	}
 
 	public static int getNationBonusBlocks(Town town) {

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -1141,6 +1141,7 @@ public class TownySettings {
 	public static int getNationBonusBlocks(Nation nation) {
 		int bonusBlocks = (Integer) getNationLevel(nation).get(TownySettings.NationLevel.TOWN_BLOCK_LIMIT_BONUS);
 		NationBonusCalculationEvent calculationEvent = new NationBonusCalculationEvent(nation, bonusBlocks);
+		Bukkit.getPluginManager().callEvent(calculationEvent);
 		return calculationEvent.getBonusBlocks();
 	}
 

--- a/src/com/palmergames/bukkit/towny/event/NationBonusCalculationEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/NationBonusCalculationEvent.java
@@ -1,0 +1,41 @@
+package com.palmergames.bukkit.towny.event;
+
+import com.palmergames.bukkit.towny.object.Nation;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Event called whenever nation bonus blocks are being fetched.
+ */
+public class NationBonusCalculationEvent extends Event {
+	private static HandlerList handlers = new HandlerList();
+	
+	private Nation nation;
+	private int bonusBlocks;
+	
+	public NationBonusCalculationEvent(Nation nation, int bonusBlocks) {
+		this.nation = nation;
+		this.bonusBlocks = bonusBlocks;
+	}
+	
+	public Nation getNation() {
+		return nation;
+	}
+		
+	public int getBonusBlocks() {
+		return bonusBlocks;
+	}
+	
+	public void setBonusBlocks(int bonusBlocks) {
+		this.bonusBlocks = bonusBlocks;
+	}
+	
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
+	
+	@Override
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This adds `NationBonusCalculationEvent` to the API which allows plugins to modify the nation bonus returned by a nation. This is a particularly useful if plugins want to add nation bonus blocks based on their own specific criteria rather than what is determined by Towny config.
The reason the event call was placed in the TownySettings directory was because that was the converging method call for fetching the nation bonus and thus removed the need for placing the event call in every location the nation bonus was accessed.
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
