### PR TITLE
Fixed issue where a badly configured townyperms.yml causes DB failure

### DIFF
--- a/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -631,13 +631,13 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 				try {
 					line = keys.get("town-ranks");
 					if (line != null)
-						resident.setTownRanks(new ArrayList<>(Arrays.asList((line.split(",")))));
+						resident.setTownRanks(Arrays.asList((line.split(","))));
 				} catch (Exception e) {}
 
 				try {
 					line = keys.get("nation-ranks");
 					if (line != null)
-						resident.setNationRanks(new ArrayList<>(Arrays.asList((line.split(",")))));
+						resident.setNationRanks(Arrays.asList((line.split(","))));
 				} catch (Exception e) {}
 
 				line = keys.get("friends");

--- a/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -627,15 +627,19 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 				line = keys.get("town");
 				if (line != null)
 					resident.setTown(getTown(line));
-				
-				line = keys.get("town-ranks");
-				if (line != null)
-					resident.setTownRanks(new ArrayList<>(Arrays.asList((line.split(",")))));
-				
-				line = keys.get("nation-ranks");
-				if (line != null)
-					resident.setNationRanks(new ArrayList<>(Arrays.asList((line.split(",")))));
-				
+
+				try {
+					line = keys.get("town-ranks");
+					if (line != null)
+						resident.setTownRanks(new ArrayList<>(Arrays.asList((line.split(",")))));
+				} catch (Exception e) {}
+
+				try {
+					line = keys.get("nation-ranks");
+					if (line != null)
+						resident.setNationRanks(new ArrayList<>(Arrays.asList((line.split(",")))));
+				} catch (Exception e) {}
+
 				line = keys.get("friends");
 				if (line != null) {
 					String[] tokens = line.split(",");

--- a/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -739,7 +739,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 					line = rs.getString("town-ranks");
 					if ((line != null) && (!line.isEmpty())) {
 						search = (line.contains("#")) ? "#" : ",";
-						resident.setTownRanks(new ArrayList<>(Arrays.asList((line.split(search)))));
+						resident.setTownRanks(Arrays.asList((line.split(search))));
 						TownyMessaging.sendDebugMsg("Resident " + resident.getName() + " set Town-ranks " + line);
 					}
 				} catch (Exception e) {}
@@ -748,7 +748,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 					line = rs.getString("nation-ranks");
 					if ((line != null) && (!line.isEmpty())) {
 						search = (line.contains("#")) ? "#" : ",";
-						resident.setNationRanks(new ArrayList<>(Arrays.asList((line.split(search)))));
+						resident.setNationRanks(Arrays.asList((line.split(search))));
 						TownyMessaging.sendDebugMsg("Resident " + resident.getName() + " set Nation-ranks " + line);
 					}
 				} catch (Exception e) {}

--- a/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -735,19 +735,23 @@ public final class TownySQLSource extends TownyDatabaseHandler {
                     TownyMessaging.sendDebugMsg("Resident " + resident.getName() + " set to Town " + line);
                 }
 
-                line = rs.getString("town-ranks");
-                if ((line != null) && (!line.isEmpty())) {
-                    search = (line.contains("#")) ? "#" : ",";
-                    resident.setTownRanks(new ArrayList<>(Arrays.asList((line.split(search)))));
-                    TownyMessaging.sendDebugMsg("Resident " + resident.getName() + " set Town-ranks " + line);
-                }
+				try {
+					line = rs.getString("town-ranks");
+					if ((line != null) && (!line.isEmpty())) {
+						search = (line.contains("#")) ? "#" : ",";
+						resident.setTownRanks(new ArrayList<>(Arrays.asList((line.split(search)))));
+						TownyMessaging.sendDebugMsg("Resident " + resident.getName() + " set Town-ranks " + line);
+					}
+				} catch (Exception e) {}
 
-                line = rs.getString("nation-ranks");
-                if ((line != null) && (!line.isEmpty())) {
-                    search = (line.contains("#")) ? "#" : ",";
-                    resident.setNationRanks(new ArrayList<>(Arrays.asList((line.split(search)))));
-                    TownyMessaging.sendDebugMsg("Resident " + resident.getName() + " set Nation-ranks " + line);
-                }
+				try {
+					line = rs.getString("nation-ranks");
+					if ((line != null) && (!line.isEmpty())) {
+						search = (line.contains("#")) ? "#" : ",";
+						resident.setNationRanks(new ArrayList<>(Arrays.asList((line.split(search)))));
+						TownyMessaging.sendDebugMsg("Resident " + resident.getName() + " set Nation-ranks " + line);
+					}
+				} catch (Exception e) {}
 
                 try {
                     line = rs.getString("friends");


### PR DESCRIPTION
#### Description: 
- With current towny master code, certain misconfigurations of Townyperms.yml will cause a cascading DB failure
- The failure flow is as follows:
 1. Server deploys a bad townyperms file, and starts server
 2. Towny tries to load all residents
 3. Towny tries to load resident x, but fails due to the bad townyperms.yml
 4. Resident is consider 'bad data' and removed
 5. All residents removed in turn
 6. All towns removed as they are empty
 7. All nations disbanded as they are empty
- I don't know what exactly it is in the townyperms.yml file which causes the exception.
- I have an exact example of such a townyperms.yml file, won't append here as it belongs to a particular server, but can provide on request if server agrees too.
- This pull request fixes the issue by not failing the resident load even if perms file is bad. Thus the complete db fail is avoided (and only town/nation ranks are lost).

#### New Nodes/Commands/ConfigOptions: 
NA

#### Relevant Towny Issue ticket:
NA

____
- [ X] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
