### PR TITLE
Block glitching prevention

### DIFF
--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1815,8 +1815,32 @@ public enum ConfigNodes {
 			"WOODEN_DOOR,ACACIA_DOOR,DARK_OAK_DOOR,JUNGLE_DOOR,BIRCH_DOOR,SPRUCE_DOOR,IRON_DOOR,CHEST,TRAPPED_CHEST,FURNACE,BURNING_FURNACE,DROPPER,DISPENSER,HOPPER,ENDER_CHEST,WHITE_SHULKER_BOX,ORANGE_SHULKER_BOX,MAGENTA_SHULKER_BOX,LIGHT_BLUE_SHULKER_BOX,YELLOW_SHULKER_BOX,LIME_SHULKER_BOX,PINK_SHULKER_BOX,GRAY_SHULKER_BOX,SILVER_SHULKER_BOX,CYAN_SHULKER_BOX,PURPLE_SHULKER_BOX,BLUE_SHULKER_BOX,BROWN_SHULKER_BOX,GREEN_SHULKER_BOX,RED_SHULKER_BOX,BLACK_SHULKER_BOX,NOTE_BLOCK,LEVER,STONE_PLATE,IRON_DOOR_BLOCK,WOOD_PLATE,JUKEBOX,DIODE_BLOCK_OFF,DIODE_BLOCK_ON,FENCE_GATE,GOLD_PLATE,IRON_PLATE,REDSTONE_COMPARATOR_OFF,REDSTONE_COMPARATOR_ON,BEACON",
 			"# A list of blocks that will not be exploded, mostly because they won't regenerate properly.",
 			"# These blocks will also protect the block below them, so that blocks like doors do not dupe themselves.",
-			"# Only under affect when explosions_break_blocks is true.");
+			"# Only under affect when explosions_break_blocks is true."),
 
+	WAR_COMMON(
+			"war.common",
+			"",
+			"############################################################",
+			"# +------------------------------------------------------+ #",
+			"# |                 Common War settings                  | #",
+			"# |                                                      | #",
+			"# |  These configs are common to multiple war systems.   | #",
+			"# |                                                      | #",
+			"# |  Note: Block glitching prevention settings are here, | #",
+			"# |  because preventing players from bypassing walls     | #", 
+			"# |  is critical during war (less so during peacetime)   | #",
+			"# |  												      | #",
+			"# +------------------------------------------------------+ #",
+			"############################################################",
+			""),
+	WAR_COMMON_BLOCK_GLITCHING_PREVENTION_ENABLED(
+		   "war.common.block_glitching_prevention.enabled",
+		   "true",
+		   "# If this value is true, then block glitching is prevented.",
+		   "# Block glitching refers to the practice of exploiting lag to",
+		   "# A. Quickly place_blocks in an otherwise perm-protected plot, to get over walls, or",
+		   "# B. Quickly destroy blocks in an otherwise perm-protected plot, to get through walls.",
+		   "# If the value is true, then the lag is used against the exploiter, by 'rubber banding' them back to their towny-cached pre-block-interaction location.");
 
 	private final String Root;
 	private final String Default;

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -2907,6 +2907,10 @@ public class TownySettings {
 		return getBoolean(ConfigNodes.NOTIFICATION_TOWN_NAMES_ARE_VERBOSE);
 	}
 
+	public static boolean isBlockGlitchingPreventionEnabled() {
+		return getBoolean(ConfigNodes.WAR_COMMON_BLOCK_GLITCHING_PREVENTION_ENABLED);
+	}
+
 	public static Map<String,String> getNationColorsMap() {
 		List<String> nationColorsList = getStrArr(ConfigNodes.GNATION_SETTINGS_ALLOWED_NATION_COLORS);
 		Map<String,String> nationColorsMap = new HashMap<>();

--- a/src/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
@@ -36,6 +36,8 @@ import org.bukkit.event.block.BlockIgniteEvent;
 import org.bukkit.event.block.BlockPistonExtendEvent;
 import org.bukkit.event.block.BlockPistonRetractEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
+import io.papermc.lib.PaperLib;
+import org.bukkit.event.player.PlayerTeleportEvent;
 
 import java.util.List;
 
@@ -75,12 +77,16 @@ public class TownyBlockListener implements Listener {
 				|| (TownyAPI.getInstance().isWarTime() && cache.getStatus() == TownBlockStatus.WARZONE && !WarUtil.isPlayerNeutral(player))) { // Event War
 			if (!WarZoneConfig.isEditableMaterialInWarZone(block.getType())) {
 				event.setCancelled(true);
+				if(TownySettings.isBlockGlitchingPreventionEnabled())
+					PaperLib.teleportAsync(player, cache.getLastLocation(), PlayerTeleportEvent.TeleportCause.PLUGIN);
 				TownyMessaging.sendErrorMsg(player, String.format(TownySettings.getLangString("msg_err_warzone_cannot_edit_material"), "destroy", block.getType().toString().toLowerCase()));
 			}
 			return;
 		}
 
 		event.setCancelled(true);
+		if(TownySettings.isBlockGlitchingPreventionEnabled())
+			PaperLib.teleportAsync(player, cache.getLastLocation(), PlayerTeleportEvent.TeleportCause.PLUGIN);
 
 		/* 
 		 * display any error recorded for this plot
@@ -134,6 +140,8 @@ public class TownyBlockListener implements Listener {
 
 				event.setBuild(false);
 				event.setCancelled(true);
+				if(TownySettings.isBlockGlitchingPreventionEnabled())
+					PaperLib.teleportAsync(player, cache.getLastLocation(), PlayerTeleportEvent.TeleportCause.PLUGIN);
 
 			// Event War piggy backing on flag war's EditableMaterialInWarZone 
 			} else if ((status == TownBlockStatus.WARZONE && FlagWarConfig.isAllowingAttacks()) // Flag War 
@@ -141,12 +149,16 @@ public class TownyBlockListener implements Listener {
 				if (!WarZoneConfig.isEditableMaterialInWarZone(block.getType())) {
 					event.setBuild(false);
 					event.setCancelled(true);
+					if(TownySettings.isBlockGlitchingPreventionEnabled())
+						PaperLib.teleportAsync(player, cache.getLastLocation(), PlayerTeleportEvent.TeleportCause.PLUGIN);
 					TownyMessaging.sendErrorMsg(player, String.format(TownySettings.getLangString("msg_err_warzone_cannot_edit_material"), "build", block.getType().toString().toLowerCase()));
 				}
 				return;
 			} else {
 				event.setBuild(false);
 				event.setCancelled(true);
+				if(TownySettings.isBlockGlitchingPreventionEnabled())
+					PaperLib.teleportAsync(player, cache.getLastLocation(), PlayerTeleportEvent.TeleportCause.PLUGIN);
 			}
 
 			/* 


### PR DESCRIPTION
#### Description: 
* Currently, players are able to exploit server lag to bypass walls .
* One way is to quickly build a pillar of blocks to climb over a wall, before Towny has the chance to cancel the build events.
* Another way is to quickly break the blocks in a wall and move through the hole, before Towny has the chance to cancel the destroy events.
* This PR resolves this issue by using the lag against the exploiter --> the patch is that when Towny gets around to cancelling the block event (after any lag is finished), Towny then uses its own cached information on the last known player location, to 'rubber-band' the player back to where they were just before they tried to interact with the block.

#### New Nodes/Commands/ConfigOptions: 
* New config node: war.common.block_glitching_prevention.enabled
* True by default

____
#### Relevant Towny Issue ticket:
NA

____
- [ x ] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
