### PR TITLE
Use absolute path for H2

### DIFF
--- a/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -107,7 +107,9 @@ public final class TownySQLSource extends TownyDatabaseHandler {
         if (this.type.equals("h2")) {
         
             driver1 = "org.h2.Driver";
-            this.dsn = ("jdbc:h2:" + dataFolderPath + File.separator + db_name + ".h2db;AUTO_RECONNECT=TRUE");
+            // H2 requires an absolute path
+            String dataFolderAbsolute = Towny.getPlugin().getDataFolder().getAbsolutePath() + File.separator + "data";
+            this.dsn = ("jdbc:h2:" + dataFolderAbsolute + File.separator + db_name + ".h2db;AUTO_RECONNECT=TRUE");
             username = "sa";
             password = "sa";
         


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Fix H2 not accepting implicit relative paths. Ended up just using an absolute path because why not.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->
I tried to test it, but Idk how to install the h2 driver.

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
