### PR TITLE
Add configurable default Town&Nation board

### DIFF
--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -58,6 +58,9 @@ public enum ConfigNodes {
 			"town.default_open",
 			"false",
 			"# Default Open status of the town (are new towns open and joinable by anyone at creation?)"),
+	TOWN_DEF_BOARD("town.default_board", 
+			"/town set board [msg]",
+			"# Default town board"),
 	TOWN_DEF_TAXES(
 			"town.default_taxes", "", "# Default tax settings for new towns."),
 	TOWN_DEF_TAXES_TAX(
@@ -618,6 +621,9 @@ public enum ConfigNodes {
             "global_nation_settings.default.open",
             "false",
             "# If set to true, any newly made nation will have open status and any town may join without an invite."),
+	GNATION_DEF_BOARD("global_nation_settings.default.board", 
+			"/nation set board [msg]",
+			"# Default nation board"),
 	GNATION_SETTINGS_ALLOWED_NATION_COLORS(
 			"global_nation_settings.allowed_map_colors",
 			"aqua:00ffff, azure:f0ffff, beige:f5f5dc, black:000000, blue:0000ff, brown:a52a2a, cyan:00ffff, darkblue:00008b, darkcyan:008b8b, darkgrey:a9a9a9, darkgreen:006400, darkkhaki:bdb76b, darkmagenta:8b008b, darkolivegreen:556b2f, darkorange:ff8c00, darkorchid:9932cc, darkred:8b0000, darksalmon:e9967a, darkviolet:9400d3, fuchsia:ff00ff, gold:ffd700, green:008000, indigo:4b0082, khaki:f0e68c, lightblue:add8e6, lightcyan:e0ffff, lightgreen:90ee90, lightgrey:d3d3d3, lightpink:ffb6c1, lightyellow:ffffe0, lime:00ff00, magenta:ff00ff, maroon:800000, navy:000080, olive:808000, orange:ffa500, pink:ffc0cb, purple:800080, violet:800080, red:ff0000, silver:c0c0c0, white:ffffff, yellow:ffff00",

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -613,22 +613,27 @@ public enum ConfigNodes {
 			"0",
 			"# If higher than 0, it will limit how many towns can be joined into a nation.",
 			"# Does not affect existing nations that are already over the limit."),
-    GNATION_DEF_PUBLIC(
-            "global_nation_settings.default.public",
-            "false",
-            "# If set to true, any newly made nation will have their spawn set to public."),
-    GNATION_DEF_OPEN(
-            "global_nation_settings.default.open",
-            "false",
-            "# If set to true, any newly made nation will have open status and any town may join without an invite."),
-	GNATION_DEF_BOARD("global_nation_settings.default.board", 
-			"/nation set board [msg]",
-			"# Default nation board"),
 	GNATION_SETTINGS_ALLOWED_NATION_COLORS(
 			"global_nation_settings.allowed_map_colors",
 			"aqua:00ffff, azure:f0ffff, beige:f5f5dc, black:000000, blue:0000ff, brown:a52a2a, cyan:00ffff, darkblue:00008b, darkcyan:008b8b, darkgrey:a9a9a9, darkgreen:006400, darkkhaki:bdb76b, darkmagenta:8b008b, darkolivegreen:556b2f, darkorange:ff8c00, darkorchid:9932cc, darkred:8b0000, darksalmon:e9967a, darkviolet:9400d3, fuchsia:ff00ff, gold:ffd700, green:008000, indigo:4b0082, khaki:f0e68c, lightblue:add8e6, lightcyan:e0ffff, lightgreen:90ee90, lightgrey:d3d3d3, lightpink:ffb6c1, lightyellow:ffffe0, lime:00ff00, magenta:ff00ff, maroon:800000, navy:000080, olive:808000, orange:ffa500, pink:ffc0cb, purple:800080, violet:800080, red:ff0000, silver:c0c0c0, white:ffffff, yellow:ffff00",
 			"# This setting determines the list of allowed nation map colors.",
 			"# The color codes are in hex format."),
+	NATION("nation", "", "", "############################################################",
+			"# +------------------------------------------------------+ #",
+			"# |               New Nation Defaults                    | #",
+			"# +------------------------------------------------------+ #",
+			"############################################################", ""),
+    NATION_DEF_PUBLIC(
+            "nation.default_public",
+            "false",
+            "# If set to true, any newly made nation will have their spawn set to public."),
+    NATION_DEF_OPEN(
+            "nation.default_open",
+            "false",
+            "# If set to true, any newly made nation will have open status and any town may join without an invite."),
+	NATION_DEF_BOARD("nation.default_board", 
+			"/nation set board [msg]",
+			"# Default nation board"),
 	PLUGIN(
 			"plugin",
 			"",

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -1359,7 +1359,7 @@ public class TownySettings {
 
 	public static boolean getNationDefaultOpen() {
 
-		return getBoolean(ConfigNodes.GNATION_DEF_OPEN);
+		return getBoolean(ConfigNodes.NATION_DEF_OPEN);
 	}
 
 	public static double getTownDefaultTax() {
@@ -1950,12 +1950,12 @@ public class TownySettings {
 
 	public static boolean getNationDefaultPublic(){
 
-		return getBoolean(ConfigNodes.GNATION_DEF_PUBLIC);
+		return getBoolean(ConfigNodes.NATION_DEF_PUBLIC);
 	}
 
 	public static String getNationDefaultBoard(){
 
-		return getString(ConfigNodes.GNATION_DEF_BOARD);
+		return getString(ConfigNodes.NATION_DEF_BOARD);
 	}
 
 	public static String getFlatFileBackupType() {

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -1351,7 +1351,12 @@ public class TownySettings {
 
 		return getBoolean(ConfigNodes.TOWN_DEF_OPEN);
 	}
-	
+
+	public static String getTownDefaultBoard() {
+
+		return getString(ConfigNodes.TOWN_DEF_BOARD);
+	}
+
 	public static boolean getNationDefaultOpen() {
 
 		return getBoolean(ConfigNodes.GNATION_DEF_OPEN);
@@ -1946,6 +1951,11 @@ public class TownySettings {
 	public static boolean getNationDefaultPublic(){
 
 		return getBoolean(ConfigNodes.GNATION_DEF_PUBLIC);
+	}
+
+	public static String getNationDefaultBoard(){
+
+		return getString(ConfigNodes.GNATION_DEF_BOARD);
 	}
 
 	public static String getFlatFileBackupType() {

--- a/src/com/palmergames/bukkit/towny/object/Nation.java
+++ b/src/com/palmergames/bukkit/towny/object/Nation.java
@@ -42,7 +42,7 @@ public class Nation extends TownyObject implements ResidentList, TownyInviter, B
 	private Town capital;
 	private double taxes, spawnCost;
 	private boolean neutral = false;
-	private String nationBoard = "/nation set board [msg]";
+	private String nationBoard = TownySettings.getNationDefaultBoard();
 	private String mapColorHexCode = "";
 	private String tag = "";
 	public UUID uuid;

--- a/src/com/palmergames/bukkit/towny/object/Town.java
+++ b/src/com/palmergames/bukkit/towny/object/Town.java
@@ -61,7 +61,7 @@ public class Town extends TownyObject implements ResidentList, TownyInviter, Obj
 	private boolean isPublic = TownySettings.getTownDefaultPublic();
 	private boolean isTaxPercentage = TownySettings.getTownDefaultTaxPercentage();
 	private boolean isOpen = TownySettings.getTownDefaultOpen();
-	private String townBoard = "/town set board [msg]";
+	private String townBoard = TownySettings.getTownDefaultBoard();
 	private String tag = "";
 	private TownBlock homeBlock;
 	private TownyWorld world;


### PR DESCRIPTION
#### Description: 
The PR title says it all - it adds 2 config options to change the default town & nation board message.
____
#### New ConfigOptions: 
- `town.default_board`
- `global_nation_settings.default.board`
____
#### Relevant Towny Issue ticket:
N/A
____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
