### PR TITLE
1.16.1: Add Respawn Anchor Integration

### DIFF
--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -425,6 +425,10 @@ public enum ConfigNodes {
 			"enemy",
 			"# Prevent players from using /town spawn while within unclaimed areas and/or enemy/neutral towns.",
 			"# Allowed options: unclaimed,enemy,neutral"),
+	GTOWN_RESPAWN_ANCHOR_HIGHER_PRECEDENCE(
+		"global_town_settings.respawn_anchor_higher_precendence",
+		"true",
+		"# When this is true, players will respawn to respawn anchors on death rather than their own town. 1.16+ only."),
 	GTOWN_SETTINGS_SHOW_TOWN_NOTIFICATIONS(
 			"global_town_settings.show_town_notifications",
 			"true",

--- a/src/com/palmergames/bukkit/towny/Towny.java
+++ b/src/com/palmergames/bukkit/towny/Towny.java
@@ -47,6 +47,7 @@ import com.palmergames.bukkit.towny.war.flagwar.listeners.FlagWarBlockListener;
 import com.palmergames.bukkit.towny.war.flagwar.listeners.FlagWarCustomListener;
 import com.palmergames.bukkit.towny.war.flagwar.listeners.FlagWarEntityListener;
 import com.palmergames.bukkit.util.BukkitTools;
+import com.palmergames.bukkit.util.Version;
 import com.palmergames.util.JavaUtil;
 import com.palmergames.util.StringMgmt;
 
@@ -850,5 +851,17 @@ public class Towny extends JavaPlugin {
 		metrics.addCustomChart(new Metrics.SimplePie("town_block_size", () -> String.valueOf(TownySettings.getTownBlockSize())));
 		
 		metrics.addCustomChart(new Metrics.SimplePie("resident_uuids_stored", () -> TownySettings.getUUIDPercent()));
+	}
+	
+	public static boolean is116Plus() {
+		String verString = Bukkit.getBukkitVersion();
+		verString = verString.replace("-R0.1-SNAPSHOT", "");
+		
+		Version ver = new Version(verString);
+		Version required = new Version("1.16.1");
+		
+		TownyMessaging.sendErrorMsg(ver.compareTo(required) + "");
+		
+		return ver.compareTo(required) >= 0;
 	}
 }

--- a/src/com/palmergames/bukkit/towny/Towny.java
+++ b/src/com/palmergames/bukkit/towny/Towny.java
@@ -860,8 +860,6 @@ public class Towny extends JavaPlugin {
 		Version ver = new Version(verString);
 		Version required = new Version("1.16.1");
 		
-		TownyMessaging.sendErrorMsg(ver.compareTo(required) + "");
-		
 		return ver.compareTo(required) >= 0;
 	}
 }

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -37,6 +37,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -2070,6 +2071,10 @@ public class TownySettings {
 	public static boolean isTownRespawningInOtherWorlds() {
 
 		return getBoolean(ConfigNodes.GTOWN_SETTINGS_TOWN_RESPAWN_SAME_WORLD_ONLY);
+	}
+	
+	public static boolean isRespawnAnchorHigherPrecedence() {
+		return getBoolean(ConfigNodes.GTOWN_RESPAWN_ANCHOR_HIGHER_PRECEDENCE);
 	}
 	
 	public static int getMaxResidentsPerTown() {

--- a/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -156,8 +156,15 @@ public class TownyPlayerListener implements Listener {
 		
 		Player player = event.getPlayer();
 		
-		if (!TownySettings.isTownRespawning())
+		if (!TownySettings.isTownRespawning()) {
 			return;
+		}
+		
+		// If respawn anchors have higher precedence than town spawns, use them instead.
+		if (Towny.is116Plus() && event.isAnchorSpawn() && TownySettings.isRespawnAnchorHigherPrecedence()) {
+			TownyMessaging.sendErrorMsg("got here");
+			return;
+		}
 		
 		Location respawn;
 		respawn = TownyAPI.getInstance().getTownSpawnLocation(player);

--- a/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -162,7 +162,6 @@ public class TownyPlayerListener implements Listener {
 		
 		// If respawn anchors have higher precedence than town spawns, use them instead.
 		if (Towny.is116Plus() && event.isAnchorSpawn() && TownySettings.isRespawnAnchorHigherPrecedence()) {
-			TownyMessaging.sendErrorMsg("got here");
 			return;
 		}
 		

--- a/src/com/palmergames/bukkit/util/Version.java
+++ b/src/com/palmergames/bukkit/util/Version.java
@@ -1,0 +1,48 @@
+package com.palmergames.bukkit.util;
+
+public class Version implements Comparable<Version> {
+
+	private final String version;
+
+	public final String get() {
+		return this.version;
+	}
+
+	public Version(String version) {
+		if(version == null)
+			throw new IllegalArgumentException("Version can not be null");
+		if(!version.matches("[0-9]+(\\.[0-9]+)*"))
+			throw new IllegalArgumentException("Invalid version format");
+		this.version = version;
+	}
+
+	@Override public int compareTo(Version that) {
+		if(that == null)
+			return 1;
+		String[] thisParts = this.get().split("\\.");
+		String[] thatParts = that.get().split("\\.");
+		int length = Math.max(thisParts.length, thatParts.length);
+		for(int i = 0; i < length; i++) {
+			int thisPart = i < thisParts.length ?
+				Integer.parseInt(thisParts[i]) : 0;
+			int thatPart = i < thatParts.length ?
+				Integer.parseInt(thatParts[i]) : 0;
+			if(thisPart < thatPart)
+				return -1;
+			if(thisPart > thatPart)
+				return 1;
+		}
+		return 0;
+	}
+
+	@Override public boolean equals(Object that) {
+		if(this == that)
+			return true;
+		if(that == null)
+			return false;
+		if(this.getClass() != that.getClass())
+			return false;
+		return this.compareTo((Version) that) == 0;
+	}
+
+}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This makes towny respect respawn anchors precedence on player respawn, instead of defaulting to the town spawn. This also makes sure that the server is running at least 1.16.1, if not the behavior is unchanged, so it doesn't break compatibility.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
`global_town_settings.respawn_anchor_higher_precendence` -  defaults to  'true'

When this is true, players will respawn to respawn anchors on death rather than their own town. 1.16+ only.

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #4132

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
