### PR TITLE
Add option for keep inventory for arena plots.

### DIFF
--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -531,6 +531,12 @@ public enum ConfigNodes {
 			"# If People should keep their inventories on death in a town",
 			"# Is not guaranteed to work with other keep inventory plugins!"
 	),
+	GTOWN_SETTINGS_KEEP_INVENTORY_ON_DEATH_IN_ARENA(
+		"global_town_settings.keep_inventory_on_death_in_arena",
+		"false",
+		"# If People should keep their inventories on death in an arena townblock",
+		"# Is not guaranteed to work with other keep inventory plugins!"
+	),
 	GTOWN_SETTINGS_KEEP_EXPERIENCE_ON_DEATH_IN_TOWN(
 			"global_town_settings.keep_experience_on_death_in_town",
 			"false",

--- a/src/com/palmergames/bukkit/towny/Towny.java
+++ b/src/com/palmergames/bukkit/towny/Towny.java
@@ -33,6 +33,7 @@ import com.palmergames.bukkit.towny.listeners.TownyWorldListener;
 import com.palmergames.bukkit.towny.object.Coord;
 import com.palmergames.bukkit.towny.object.PlayerCache;
 import com.palmergames.bukkit.towny.object.Resident;
+import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.WorldCoord;
 import com.palmergames.bukkit.towny.permissions.BukkitPermSource;
 import com.palmergames.bukkit.towny.permissions.GroupManagerSource;
@@ -199,6 +200,9 @@ public class Towny extends JavaPlugin {
 					}
 				}
 		}
+
+		TownBlock tb = new TownBlock(23, 23, TownyUniverse.getInstance().getWorldMap().values().iterator().next());
+		TownyUniverse.getInstance().getDataSource().saveTownBlock(tb);
 	}
 
 	@Override

--- a/src/com/palmergames/bukkit/towny/Towny.java
+++ b/src/com/palmergames/bukkit/towny/Towny.java
@@ -33,7 +33,6 @@ import com.palmergames.bukkit.towny.listeners.TownyWorldListener;
 import com.palmergames.bukkit.towny.object.Coord;
 import com.palmergames.bukkit.towny.object.PlayerCache;
 import com.palmergames.bukkit.towny.object.Resident;
-import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.WorldCoord;
 import com.palmergames.bukkit.towny.permissions.BukkitPermSource;
 import com.palmergames.bukkit.towny.permissions.GroupManagerSource;
@@ -200,9 +199,6 @@ public class Towny extends JavaPlugin {
 					}
 				}
 		}
-
-		TownBlock tb = new TownBlock(23, 23, TownyUniverse.getInstance().getWorldMap().values().iterator().next());
-		TownyUniverse.getInstance().getDataSource().saveTownBlock(tb);
 	}
 
 	@Override

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -2692,6 +2692,10 @@ public class TownySettings {
 	public static boolean getKeepInventoryInTowns() {
 		return getBoolean(ConfigNodes.GTOWN_SETTINGS_KEEP_INVENTORY_ON_DEATH_IN_TOWN);
 	}
+	
+	public static boolean getKeepInventoryInArenas() {
+		return getBoolean(ConfigNodes.GTOWN_SETTINGS_KEEP_INVENTORY_ON_DEATH_IN_ARENA);
+	}
 
 	public static boolean getKeepExperienceInTowns() {
 		return getBoolean(ConfigNodes.GTOWN_SETTINGS_KEEP_EXPERIENCE_ON_DEATH_IN_TOWN);

--- a/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -977,6 +977,15 @@ public class TownyPlayerListener implements Listener {
 
 			}
 		}
+		if (TownySettings.getKeepInventoryInArenas()) {
+			if (!keepInventory) {
+				TownBlock tb = TownyAPI.getInstance().getTownBlock(deathloc);
+				if (tb != null && tb.getType() == TownBlockType.ARENA) {
+					event.setKeepInventory(true);
+					event.getDrops().clear();
+				}
+			}
+		}
 	}
 
 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Adds a config option to allow keeping inventory when dying on an arena plot.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
`global_town_settings.keep_inventory_on_death_in_arena` - default `false`

Toggles keepinventory on arena plots.

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #4137 

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
