### PR TITLE
Make fields/objects that don't change Immutable

### DIFF
--- a/src/com/palmergames/bukkit/config/CommentedConfiguration.java
+++ b/src/com/palmergames/bukkit/config/CommentedConfiguration.java
@@ -14,11 +14,12 @@ import java.io.IOException;
 import java.util.HashMap;
 
 /**
- * @author dumptruckman &amp; Articdive
+ * @author dumptruckman
+ * @author Lukas Mansour (Articdive)
  */
 public class CommentedConfiguration extends YamlConfiguration {
-	private HashMap<String, String> comments;
-	private File file;
+	private final HashMap<String, String> comments;
+	private final File file;
 
 	private final DumperOptions yamlOptions = new DumperOptions();
 	private final Representer yamlRepresenter = new YamlRepresenter();

--- a/src/com/palmergames/bukkit/towny/TownyPlaceholderExpansion.java
+++ b/src/com/palmergames/bukkit/towny/TownyPlaceholderExpansion.java
@@ -20,7 +20,7 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion {
 	final String mayor = TownySettings.getLangString("mayor_sing");
 	final String king = TownySettings.getLangString("king_sing");
 	
-	private Towny plugin;
+	private final Towny plugin;
 
 	/**
 	 * Since we register the expansion inside our own plugin, we can simply use this

--- a/src/com/palmergames/bukkit/towny/TownyUniverse.java
+++ b/src/com/palmergames/bukkit/towny/TownyUniverse.java
@@ -58,7 +58,7 @@ public class TownyUniverse {
     private final Trie nationsTrie = new Trie();
     private final Map<String, TownyWorld> worlds = new ConcurrentHashMap<>();
     private final Map<String, CustomDataField> registeredMetadata = new HashMap<>();
-	private Map<WorldCoord, TownBlock> townBlocks = new ConcurrentHashMap<>();
+	private final Map<WorldCoord, TownBlock> townBlocks = new ConcurrentHashMap<>();
     
     private final List<Resident> jailedResidents = new ArrayList<>();
     private final String rootFolder;

--- a/src/com/palmergames/bukkit/towny/TownyUniverse.java
+++ b/src/com/palmergames/bukkit/towny/TownyUniverse.java
@@ -91,9 +91,6 @@ public class TownyUniverse {
         saveDbType = TownySettings.getSaveDatabase();
         loadDbType = TownySettings.getLoadDatabase();
         
-        // Setup any defaults before we load the dataSource.
-        Coord.setCellSize(TownySettings.getTownBlockSize());
-        
         System.out.println("[Towny] Database: [Load] " + loadDbType + " [Save] " + saveDbType);
         
         clearAll();

--- a/src/com/palmergames/bukkit/towny/event/DeleteNationEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/DeleteNationEvent.java
@@ -9,7 +9,7 @@ public class DeleteNationEvent extends Event  {
 
     private static final HandlerList handlers = new HandlerList();
     
-    private String nationName;
+    private final String nationName;
 
     @Override
     public HandlerList getHandlers() {

--- a/src/com/palmergames/bukkit/towny/event/DeletePlayerEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/DeletePlayerEvent.java
@@ -7,7 +7,7 @@ import org.bukkit.event.HandlerList;
 public class DeletePlayerEvent extends Event {
     private static final HandlerList handlers = new HandlerList();
 
-    private String playerName;
+    private final String playerName;
 
     @Override
     public HandlerList getHandlers() {

--- a/src/com/palmergames/bukkit/towny/event/DeleteTownEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/DeleteTownEvent.java
@@ -9,7 +9,7 @@ public class DeleteTownEvent extends Event  {
 
     private static final HandlerList handlers = new HandlerList();
     
-    private String townName;
+    private final String townName;
 
     @Override
     public HandlerList getHandlers() {

--- a/src/com/palmergames/bukkit/towny/event/EventWarEndEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/EventWarEndEvent.java
@@ -14,8 +14,9 @@ public class EventWarEndEvent extends Event {
 	private static final HandlerList handlers = new HandlerList();
 	private List<Town> warringTowns = new ArrayList<>();
 	private List<Nation> warringNations = new ArrayList<>();
-	private Town winningTown;
-	private double townWinnings, nationWinnings;
+	private final Town winningTown;
+	private final double townWinnings;
+	private final double nationWinnings;
 
 	@Override
 	public HandlerList getHandlers() {

--- a/src/com/palmergames/bukkit/towny/event/EventWarStartEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/EventWarStartEvent.java
@@ -12,9 +12,9 @@ import com.palmergames.bukkit.towny.object.Town;
 
 public class EventWarStartEvent extends Event{
 	private static final HandlerList handlers = new HandlerList();
-	private List<Town> warringTowns = new ArrayList<>();
-	private List<Nation> warringNations = new ArrayList<>();
-	private double warSpoils;
+	private final List<Town> warringTowns;
+	private final List<Nation> warringNations;
+	private final double warSpoils;
 
 	@Override
 	public HandlerList getHandlers() {

--- a/src/com/palmergames/bukkit/towny/event/MobRemovalEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/MobRemovalEvent.java
@@ -11,7 +11,7 @@ public class MobRemovalEvent extends Event implements Cancellable {
 	private static final HandlerList handlers = new HandlerList();
 
 	private boolean cancelled = false;
-	private Entity entity;
+	private final Entity entity;
 	
 	public MobRemovalEvent(Entity entity) {
 		super(!Bukkit.getServer().isPrimaryThread());

--- a/src/com/palmergames/bukkit/towny/event/NationAddEnemyEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/NationAddEnemyEvent.java
@@ -7,10 +7,10 @@ import org.bukkit.event.HandlerList;
 
 public class NationAddEnemyEvent extends Event {
 	
-	private static HandlerList handlers = new HandlerList();
+	private static final HandlerList handlers = new HandlerList();
 
-	private Nation enemy;
-	private Nation nation;
+	private final Nation enemy;
+	private final Nation nation;
 	
 	@Override
 	public HandlerList getHandlers() {

--- a/src/com/palmergames/bukkit/towny/event/NationAddTownEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/NationAddTownEvent.java
@@ -11,8 +11,8 @@ public class NationAddTownEvent extends Event  {
 
     private static final HandlerList handlers = new HandlerList();
     
-    private Town town;
-    private Nation nation;
+    private final Town town;
+    private final Nation nation;
 
     @Override
     public HandlerList getHandlers() {

--- a/src/com/palmergames/bukkit/towny/event/NationBonusCalculationEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/NationBonusCalculationEvent.java
@@ -10,9 +10,9 @@ import org.bukkit.event.HandlerList;
  * Event called whenever nation bonus blocks are being fetched.
  */
 public class NationBonusCalculationEvent extends Event {
-	private static HandlerList handlers = new HandlerList();
+	private static final HandlerList handlers = new HandlerList();
 	
-	private Nation nation;
+	private final Nation nation;
 	private int bonusBlocks;
 	
 	public NationBonusCalculationEvent(Nation nation, int bonusBlocks) {

--- a/src/com/palmergames/bukkit/towny/event/NationInviteTownEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/NationInviteTownEvent.java
@@ -9,7 +9,7 @@ import org.bukkit.event.HandlerList;
 public class NationInviteTownEvent extends Event {
 
 	private static final HandlerList handlers = new HandlerList();
-	private TownJoinNationInvite invite;
+	private final TownJoinNationInvite invite;
 
 	@Override
 	public HandlerList getHandlers() {

--- a/src/com/palmergames/bukkit/towny/event/NationPreAddEnemyEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/NationPreAddEnemyEvent.java
@@ -10,10 +10,10 @@ public class NationPreAddEnemyEvent extends Event implements Cancellable {
 
 	private static final HandlerList handlers = new HandlerList();
 	private boolean cancelled = false;
-	private String enemyName;
-	private Nation enemy;
-	private String nationName;
-	private Nation nation;
+	private final String enemyName;
+	private final Nation enemy;
+	private final String nationName;
+	private final Nation nation;
 	private String cancelMessage = "Sorry this event was cancelled";
 
 	@Override

--- a/src/com/palmergames/bukkit/towny/event/NationPreAddTownEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/NationPreAddTownEvent.java
@@ -10,10 +10,10 @@ import org.bukkit.event.HandlerList;
 public class NationPreAddTownEvent extends Event implements Cancellable {
 
 	private static final HandlerList handlers = new HandlerList();
-	private String townName;
-	private Town town;
-	private String nationName;
-	private Nation nation;
+	private final String townName;
+	private final Town town;
+	private final String nationName;
+	private final Nation nation;
 	private boolean isCancelled = false;
 	private String cancelMessage = "Sorry this event was cancelled";
 

--- a/src/com/palmergames/bukkit/towny/event/NationPreRemoveEnemyEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/NationPreRemoveEnemyEvent.java
@@ -10,10 +10,10 @@ public class NationPreRemoveEnemyEvent extends Event implements Cancellable {
 
 	private static final HandlerList handlers = new HandlerList();
 	private boolean cancelled = false;
-	private String enemyName;
-	private Nation enemy;
-	private String nationName;
-	private Nation nation;
+	private final String enemyName;
+	private final Nation enemy;
+	private final String nationName;
+	private final Nation nation;
 	private String cancelMessage = "Sorry this event was cancelled";
 
 	@Override

--- a/src/com/palmergames/bukkit/towny/event/NationPreRenameEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/NationPreRenameEvent.java
@@ -10,8 +10,9 @@ import com.palmergames.bukkit.towny.object.Nation;
 public class NationPreRenameEvent extends Event implements Cancellable {
 
 	private static final HandlerList handlers = new HandlerList();
-	private String oldName, newName;
-	private Nation nation;
+	private final String oldName;
+	private final String newName;
+	private final Nation nation;
 	private boolean isCancelled = false;
 
 	@Override

--- a/src/com/palmergames/bukkit/towny/event/NationPreTransactionEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/NationPreTransactionEvent.java
@@ -10,9 +10,9 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.Bukkit;
 
 public class NationPreTransactionEvent extends Event implements Cancellable {
-	private Nation nation;
+	private final Nation nation;
 	private static final HandlerList handlers = new HandlerList();
-	private Transaction transaction;
+	private final Transaction transaction;
 	private String cancelMessage = "Sorry this event was cancelled.";
 	private boolean isCancelled = false;
 

--- a/src/com/palmergames/bukkit/towny/event/NationRemoveEnemyEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/NationRemoveEnemyEvent.java
@@ -7,10 +7,10 @@ import org.bukkit.event.HandlerList;
 
 public class NationRemoveEnemyEvent extends Event {
 
-	private static HandlerList handlers = new HandlerList();
+	private static final HandlerList handlers = new HandlerList();
 
-	private Nation enemy;
-	private Nation nation;
+	private final Nation enemy;
+	private final Nation nation;
 
 	@Override
 	public HandlerList getHandlers() {

--- a/src/com/palmergames/bukkit/towny/event/NationRemoveTownEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/NationRemoveTownEvent.java
@@ -11,8 +11,8 @@ public class NationRemoveTownEvent extends Event  {
 
     private static final HandlerList handlers = new HandlerList();
     
-    private Town town;
-    private Nation nation;
+    private final Town town;
+    private final Nation nation;
 
     @Override
     public HandlerList getHandlers() {

--- a/src/com/palmergames/bukkit/towny/event/NationRequestAllyNationEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/NationRequestAllyNationEvent.java
@@ -9,7 +9,7 @@ import org.bukkit.event.HandlerList;
 public class NationRequestAllyNationEvent extends Event {
 
 	private static final HandlerList handlers = new HandlerList();
-	private NationAllyNationInvite invite;
+	private final NationAllyNationInvite invite;
 
 	@Override
 	public HandlerList getHandlers() {

--- a/src/com/palmergames/bukkit/towny/event/NationTagChangeEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/NationTagChangeEvent.java
@@ -8,8 +8,8 @@ import org.bukkit.event.HandlerList;
 public class NationTagChangeEvent extends Event {
     private static final HandlerList handlers = new HandlerList();
 
-    private String newTag;
-    private Nation nation;
+    private final String newTag;
+    private final Nation nation;
 
     @Override
     public HandlerList getHandlers() {

--- a/src/com/palmergames/bukkit/towny/event/NationTransactionEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/NationTransactionEvent.java
@@ -7,9 +7,9 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.Bukkit;
 
 public class NationTransactionEvent extends Event {
-	private Nation nation;
+	private final Nation nation;
 	private static final HandlerList handlers = new HandlerList();
-	private Transaction transaction;
+	private final Transaction transaction;
 
 	public NationTransactionEvent(Nation nation, Transaction transaction) {
 		super(!Bukkit.getServer().isPrimaryThread());

--- a/src/com/palmergames/bukkit/towny/event/NewNationEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/NewNationEvent.java
@@ -10,7 +10,7 @@ public class NewNationEvent extends Event  {
 
     private static final HandlerList handlers = new HandlerList();
     
-    private Nation nation;
+    private final Nation nation;
 
     @Override
     public HandlerList getHandlers() {

--- a/src/com/palmergames/bukkit/towny/event/NewTownEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/NewTownEvent.java
@@ -10,7 +10,7 @@ public class NewTownEvent extends Event  {
 
     private static final HandlerList handlers = new HandlerList();
     
-    private Town town;
+    private final Town town;
 
     @Override
     public HandlerList getHandlers() {

--- a/src/com/palmergames/bukkit/towny/event/PlayerChangePlotEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/PlayerChangePlotEvent.java
@@ -15,10 +15,10 @@ public class PlayerChangePlotEvent extends Event {
 
 	private static final HandlerList handlers = new HandlerList();
 	
-	private Player player;
-	private WorldCoord from;
-	private WorldCoord to;
-	private PlayerMoveEvent moveEvent;
+	private final Player player;
+	private final WorldCoord from;
+	private final WorldCoord to;
+	private final PlayerMoveEvent moveEvent;
 	
 	@Override
     public HandlerList getHandlers() {

--- a/src/com/palmergames/bukkit/towny/event/PlayerEnterTownEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/PlayerEnterTownEvent.java
@@ -11,11 +11,11 @@ import org.bukkit.event.player.PlayerMoveEvent;
 public class PlayerEnterTownEvent extends Event {
 	private static final HandlerList handlers = new HandlerList();
 
-	private Town enteredtown;
-	private PlayerMoveEvent pme;
-	private WorldCoord from;
-	private WorldCoord to;
-	private Player player;
+	private final Town enteredtown;
+	private final PlayerMoveEvent pme;
+	private final WorldCoord from;
+	private final WorldCoord to;
+	private final Player player;
 
 	@Override
 	public HandlerList getHandlers() {

--- a/src/com/palmergames/bukkit/towny/event/PlayerLeaveTownEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/PlayerLeaveTownEvent.java
@@ -11,11 +11,11 @@ import org.bukkit.event.player.PlayerMoveEvent;
 public class PlayerLeaveTownEvent extends Event {
 	private static final HandlerList handlers = new HandlerList();
 
-	private Town lefttown;
-	private PlayerMoveEvent pme;
-	private WorldCoord from;
-	private Player player;
-	private WorldCoord to;
+	private final Town lefttown;
+	private final PlayerMoveEvent pme;
+	private final WorldCoord from;
+	private final Player player;
+	private final WorldCoord to;
 
 	@Override
 	public HandlerList getHandlers() {

--- a/src/com/palmergames/bukkit/towny/event/PlotChangeOwnerEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/PlotChangeOwnerEvent.java
@@ -8,9 +8,9 @@ import org.bukkit.event.HandlerList;
 
 public class PlotChangeOwnerEvent extends Event {
     public static final HandlerList handlers = new HandlerList();
-    private Resident oldowner;
-    private Resident newowner;
-    private TownBlock townBlock;
+    private final Resident oldowner;
+    private final Resident newowner;
+    private final TownBlock townBlock;
 
     @Override
     public HandlerList getHandlers() {

--- a/src/com/palmergames/bukkit/towny/event/PlotChangeTypeEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/PlotChangeTypeEvent.java
@@ -8,9 +8,9 @@ import org.bukkit.event.HandlerList;
 
 public class PlotChangeTypeEvent extends Event {
     public static final HandlerList handlers = new HandlerList();
-    private TownBlockType oldType;
-    private TownBlockType newType;
-    private TownBlock townBlock;
+    private final TownBlockType oldType;
+    private final TownBlockType newType;
+    private final TownBlock townBlock;
 
     @Override
     public HandlerList getHandlers() {

--- a/src/com/palmergames/bukkit/towny/event/PlotClearEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/PlotClearEvent.java
@@ -10,7 +10,7 @@ public class PlotClearEvent extends Event {
 
 	private static final HandlerList handlers = new HandlerList();
 
-	private TownBlock townBlock;
+	private final TownBlock townBlock;
 
 	@Override
 	public HandlerList getHandlers() {

--- a/src/com/palmergames/bukkit/towny/event/PlotPreChangeTypeEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/PlotPreChangeTypeEvent.java
@@ -10,10 +10,10 @@ import org.bukkit.event.HandlerList;
 
 public class PlotPreChangeTypeEvent extends Event implements Cancellable {
     public static final HandlerList handlers = new HandlerList();
-    private TownBlockType newType;
-    private TownBlock townBlock;
+    private final TownBlockType newType;
+    private final TownBlock townBlock;
 	private String cancelMessage = "Sorry this event was cancelled";
-	private Resident resident;
+	private final Resident resident;
 	private boolean isCancelled = false;
 
     @Override

--- a/src/com/palmergames/bukkit/towny/event/PlotPreClearEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/PlotPreClearEvent.java
@@ -10,8 +10,8 @@ public class PlotPreClearEvent extends Event implements Cancellable {
 
 	private static final HandlerList handlers = new HandlerList();
 	private boolean isCancelled = false;
-	private String cancelMessage = "Sorry this event was cancelled";
-	private TownBlock townBlock;
+	private final String cancelMessage = "Sorry this event was cancelled";
+	private final TownBlock townBlock;
 
 	@Override
 	public HandlerList getHandlers() {

--- a/src/com/palmergames/bukkit/towny/event/PreDeleteNationEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/PreDeleteNationEvent.java
@@ -9,7 +9,7 @@ public class PreDeleteNationEvent extends Event implements Cancellable {
 
 	private static final HandlerList handlers = new HandlerList();
 	
-	private String nationName;
+	private final String nationName;
 	private boolean isCancelled = false;
 	
 	public PreDeleteNationEvent(String nation) {

--- a/src/com/palmergames/bukkit/towny/event/PreDeleteTownEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/PreDeleteTownEvent.java
@@ -14,8 +14,8 @@ import org.bukkit.event.HandlerList;
 public class PreDeleteTownEvent extends Event implements Cancellable {
 	private static final HandlerList handlers = new HandlerList();
 
-	private String townName;
-	private Town town;
+	private final String townName;
+	private final Town town;
 	private boolean isCancelled = false;
 	private String cancelMessage = "Sorry this event was cancelled";
 

--- a/src/com/palmergames/bukkit/towny/event/PreNewTownEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/PreNewTownEvent.java
@@ -10,8 +10,8 @@ public class PreNewTownEvent extends Event implements Cancellable {
 
 	private static final HandlerList handlers = new HandlerList();
 	
-	private Player player;
-	private String townName;
+	private final Player player;
+	private final String townName;
 	private boolean isCancelled = false;
 	private String cancelMessage = "Sorry this event was cancelled";
 	

--- a/src/com/palmergames/bukkit/towny/event/RenameNationEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/RenameNationEvent.java
@@ -10,8 +10,8 @@ public class RenameNationEvent extends Event  {
 
     private static final HandlerList handlers = new HandlerList();
     
-    private String oldName;
-    private Nation nation;
+    private final String oldName;
+    private final Nation nation;
 
     @Override
     public HandlerList getHandlers() {

--- a/src/com/palmergames/bukkit/towny/event/RenameResidentEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/RenameResidentEvent.java
@@ -9,8 +9,8 @@ public class RenameResidentEvent extends Event{
 
 	private static final HandlerList handlers = new HandlerList();
 	
-	private String oldName;
-	private Resident resident;
+	private final String oldName;
+	private final Resident resident;
 
 	@Override
 	public HandlerList getHandlers() {

--- a/src/com/palmergames/bukkit/towny/event/RenameTownEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/RenameTownEvent.java
@@ -10,8 +10,8 @@ public class RenameTownEvent extends Event  {
 
     private static final HandlerList handlers = new HandlerList();
     
-    private String oldName;
-    private Town town;
+    private final String oldName;
+    private final Town town;
 
     @Override
     public HandlerList getHandlers() {

--- a/src/com/palmergames/bukkit/towny/event/SpawnEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/SpawnEvent.java
@@ -13,9 +13,9 @@ import org.bukkit.event.HandlerList;
  * @author Suneet Tipirneni (Siris)
  */
 public abstract class SpawnEvent extends Event implements Cancellable {
-	private Location from;
-	private Location to;
-	private Player player;
+	private final Location from;
+	private final Location to;
+	private final Player player;
 	private String cancelMessage = "Sorry, this event was cancelled.";
 	private static final HandlerList handlers = new HandlerList();
 	private boolean isCancelled;

--- a/src/com/palmergames/bukkit/towny/event/TownAddResidentEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/TownAddResidentEvent.java
@@ -16,8 +16,8 @@ public class TownAddResidentEvent extends Event {
 
     private static final HandlerList handlers = new HandlerList();
     
-    private Resident resident;
-    private Town town;
+    private final Resident resident;
+    private final Town town;
 
     @Override
     public HandlerList getHandlers() {

--- a/src/com/palmergames/bukkit/towny/event/TownAddResidentRankEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/TownAddResidentRankEvent.java
@@ -15,9 +15,9 @@ public class TownAddResidentRankEvent extends Event
 {
 	private static final HandlerList handlers = new HandlerList();
 	
-    private Resident resident;
-    private String rank;
-    private Town town;
+    private final Resident resident;
+    private final String rank;
+    private final Town town;
     
     public TownAddResidentRankEvent(Resident resident, String rank, Town town) {
         super(!Bukkit.getServer().isPrimaryThread());

--- a/src/com/palmergames/bukkit/towny/event/TownInvitePlayerEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/TownInvitePlayerEvent.java
@@ -9,7 +9,7 @@ import org.bukkit.event.HandlerList;
 public class TownInvitePlayerEvent extends Event {
 
 	private static final HandlerList handlers = new HandlerList();
-	private PlayerJoinTownInvite invite;
+	private final PlayerJoinTownInvite invite;
 
 	@Override
 	public HandlerList getHandlers() {

--- a/src/com/palmergames/bukkit/towny/event/TownPreAddResidentEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/TownPreAddResidentEvent.java
@@ -10,9 +10,9 @@ import org.bukkit.event.HandlerList;
 public class TownPreAddResidentEvent extends Event implements Cancellable {
 
 	private static final HandlerList handlers = new HandlerList();
-	private String townName;
-	private Town town;
-	private Resident resident;
+	private final String townName;
+	private final Town town;
+	private final Resident resident;
 	private boolean isCancelled = false;
 	private String cancelMessage = "Sorry this event was cancelled";
 	

--- a/src/com/palmergames/bukkit/towny/event/TownPreClaimEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/TownPreClaimEvent.java
@@ -16,9 +16,9 @@ import org.bukkit.event.HandlerList;
 public class TownPreClaimEvent extends Event implements Cancellable{
 
     private static final HandlerList handlers = new HandlerList();
-    private TownBlock townBlock;
-    private Town town;
-    private Player player;
+    private final TownBlock townBlock;
+    private final Town town;
+    private final Player player;
     private boolean isCancelled = false;
     private String cancelMessage = TownySettings.getLangString("msg_claim_error");
 

--- a/src/com/palmergames/bukkit/towny/event/TownPreRenameEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/TownPreRenameEvent.java
@@ -10,8 +10,9 @@ import com.palmergames.bukkit.towny.object.Town;
 public class TownPreRenameEvent extends Event implements Cancellable {
 
 	private static final HandlerList handlers = new HandlerList();
-	private String oldName, newName;
-	private Town town;
+	private final String oldName;
+	private final String newName;
+	private final Town town;
 	private boolean isCancelled = false;
 
 	@Override

--- a/src/com/palmergames/bukkit/towny/event/TownPreTransactionEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/TownPreTransactionEvent.java
@@ -10,9 +10,9 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.Bukkit;
 
 public class TownPreTransactionEvent extends Event implements Cancellable {
-	private Town town;
+	private final Town town;
 	private static final HandlerList handlers = new HandlerList();
-	private Transaction transaction;
+	private final Transaction transaction;
 	private String cancelMessage = "Sorry this event was cancelled.";
 	private boolean isCancelled = false;
 

--- a/src/com/palmergames/bukkit/towny/event/TownPreUnclaimEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/TownPreUnclaimEvent.java
@@ -12,7 +12,7 @@ import org.bukkit.event.HandlerList;
 public class TownPreUnclaimEvent extends Event implements Cancellable {
 
     private static final HandlerList handlers = new HandlerList();
-    private TownBlock townBlock;
+    private final TownBlock townBlock;
     private Town town;
     private boolean isCancelled = false;
 

--- a/src/com/palmergames/bukkit/towny/event/TownRemoveResidentEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/TownRemoveResidentEvent.java
@@ -16,8 +16,8 @@ public class TownRemoveResidentEvent extends Event {
 
     private static final HandlerList handlers = new HandlerList();
     
-    private Resident resident;
-    private Town town;
+    private final Resident resident;
+    private final Town town;
 
     @Override
     public HandlerList getHandlers() {

--- a/src/com/palmergames/bukkit/towny/event/TownRemoveResidentRankEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/TownRemoveResidentRankEvent.java
@@ -15,9 +15,9 @@ public class TownRemoveResidentRankEvent extends Event
 {
 	private static final HandlerList handlers = new HandlerList();
 
-    private Resident resident;
-    private String rank;
-    private Town town;
+    private final Resident resident;
+    private final String rank;
+    private final Town town;
     
     public TownRemoveResidentRankEvent(Resident resident, String rank, Town town) {
         super(!Bukkit.getServer().isPrimaryThread());

--- a/src/com/palmergames/bukkit/towny/event/TownTagChangeEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/TownTagChangeEvent.java
@@ -8,8 +8,8 @@ import org.bukkit.event.HandlerList;
 public class TownTagChangeEvent extends Event {
     private static final HandlerList handlers = new HandlerList();
 
-    private Town town;
-    private String newTag;
+    private final Town town;
+    private final String newTag;
 
     @Override
     public HandlerList getHandlers() {

--- a/src/com/palmergames/bukkit/towny/event/TownTransactionEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/TownTransactionEvent.java
@@ -7,9 +7,9 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.Bukkit;
 
 public class TownTransactionEvent extends Event {
-	private Town town;
+	private final Town town;
 	private static final HandlerList handlers = new HandlerList();
-	private Transaction transaction;
+	private final Transaction transaction;
 	
 	public TownTransactionEvent(Town town, Transaction transaction) {
 		super(!Bukkit.getServer().isPrimaryThread());

--- a/src/com/palmergames/bukkit/towny/event/TownUnclaimEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/TownUnclaimEvent.java
@@ -11,8 +11,8 @@ public class TownUnclaimEvent extends Event  {
 
     private static final HandlerList handlers = new HandlerList();
     
-    private Town town;
-    private WorldCoord worldCoord;
+    private final Town town;
+    private final WorldCoord worldCoord;
 
     @Override
     public HandlerList getHandlers() {

--- a/src/com/palmergames/bukkit/towny/event/TownyPreTransactionEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/TownyPreTransactionEvent.java
@@ -8,10 +8,10 @@ import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
 public class TownyPreTransactionEvent extends Event implements Cancellable {
-	private Transaction transaction;
+	private final Transaction transaction;
 	private static final HandlerList handlers = new HandlerList();
 	private boolean isCancelled = false;
-	private String cancelMessage = "Sorry this event was cancelled.";
+	private final String cancelMessage = "Sorry this event was cancelled.";
 
 	public TownyPreTransactionEvent(Transaction transaction) {
 		super(!Bukkit.getServer().isPrimaryThread());

--- a/src/com/palmergames/bukkit/towny/event/TownyTransactionEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/TownyTransactionEvent.java
@@ -7,7 +7,7 @@ import org.bukkit.event.HandlerList;
 
 public class TownyTransactionEvent extends Event {
 	
-	private Transaction transaction;
+	private final Transaction transaction;
 	private static final HandlerList handlers = new HandlerList();
 	
 	public TownyTransactionEvent(Transaction transaction) {

--- a/src/com/palmergames/bukkit/towny/invites/Invite.java
+++ b/src/com/palmergames/bukkit/towny/invites/Invite.java
@@ -8,6 +8,7 @@ import com.palmergames.bukkit.towny.exceptions.TownyException;
  * @author Articdive
  */
 public interface Invite {
+
 	/**
 	 * @return - Playername of who sent the invite or null (Console).
 	 */

--- a/src/com/palmergames/bukkit/towny/invites/Invite.java
+++ b/src/com/palmergames/bukkit/towny/invites/Invite.java
@@ -3,10 +3,11 @@ package com.palmergames.bukkit.towny.invites;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 
 /**
+ * An object that represents an invitation.
+ * 
  * @author Articdive
  */
 public interface Invite {
-
 	/**
 	 * @return - Playername of who sent the invite or null (Console).
 	 */

--- a/src/com/palmergames/bukkit/towny/invites/InviteHandler.java
+++ b/src/com/palmergames/bukkit/towny/invites/InviteHandler.java
@@ -9,6 +9,7 @@ import com.palmergames.bukkit.towny.object.Town;
 
 import java.io.InvalidObjectException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -50,7 +51,7 @@ public class InviteHandler {
 	}
 	
 	public static List<Invite> getActiveInvites() {
-		return activeInvites;
+		return Collections.unmodifiableList(activeInvites);
 	}
 	
 	public static boolean inviteIsActive(Invite invite) {

--- a/src/com/palmergames/bukkit/towny/invites/InviteHandler.java
+++ b/src/com/palmergames/bukkit/towny/invites/InviteHandler.java
@@ -18,7 +18,7 @@ public class InviteHandler {
 	@SuppressWarnings("unused")
 	private static Towny plugin;
 	
-	private static List<Invite> activeInvites = new ArrayList<>();
+	private static final List<Invite> activeInvites = new ArrayList<>();
 
 	public static void initialize(Towny plugin) {
 

--- a/src/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
@@ -40,7 +40,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class TownyCustomListener implements Listener {
 	private final Towny plugin;
-	private Map<Player, Integer> playerActionTasks = new HashMap<>();
+	private final Map<Player, Integer> playerActionTasks = new HashMap<>();
 
 	public TownyCustomListener(Towny instance) {
 		plugin = instance;
@@ -122,7 +122,7 @@ public class TownyCustomListener implements Listener {
 	@EventHandler(priority = EventPriority.NORMAL)
 	public void onPlayerCreateTown(NewTownEvent event) {
 		Town town = event.getTown();
-		Double upkeep = TownySettings.getTownUpkeepCost(town);
+		double upkeep = TownySettings.getTownUpkeepCost(town);
 		if (TownySettings.isTaxingDaily() && upkeep > 0) {
 			String cost = TownyEconomyHandler.getFormattedBalance(upkeep);
 			String time = TimeMgmt.formatCountdownTime(TownyTimerHandler.townyTime());

--- a/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -1087,7 +1087,6 @@ public class TownyPlayerListener implements Listener {
 	/**
 	 * Blocks jailed players using blacklisted commands.
 	 * @param event - PlayerCommandPreprocessEvent
-	 * @throws NotRegisteredException - Generic NotRegisteredException
 	 */
 	@EventHandler(priority = EventPriority.NORMAL)
 	public void onJailedPlayerUsesCommand(PlayerCommandPreprocessEvent event) {

--- a/src/com/palmergames/bukkit/towny/object/Coord.java
+++ b/src/com/palmergames/bukkit/towny/object/Coord.java
@@ -19,29 +19,35 @@ public class Coord {
 	private final int z;
 
 	public Coord(int x, int z) {
+
 		this.x = x;
 		this.z = z;
 	}
 
 	public Coord(Coord coord) {
+
 		this.x = coord.getX();
 		this.z = coord.getZ();
 	}
 
 	public int getX() {
+
 		return x;
 	}
 
 	public int getZ() {
+
 		return z;
 	}
 
 	public Coord add(int xOffset, int zOffset) {
+
 		return new Coord(getX() + xOffset, getZ() + zOffset);
 	}
 
 	@Override
 	public int hashCode() {
+
 		int result = 17;
 		result = 27 * result + x;
 		result = 27 * result + z;
@@ -50,6 +56,7 @@ public class Coord {
 
 	@Override
 	public boolean equals(Object obj) {
+
 		if (obj == this)
 			return true;
 		if (!(obj instanceof Coord))
@@ -70,7 +77,6 @@ public class Coord {
 
 	/**
 	 * Convert a value to the grid cell counterpart
-	 * 
 	 * @param value x/z integer
 	 * @return cell position
 	 */
@@ -86,29 +92,35 @@ public class Coord {
 	 * @param x - X int (Coordinates)
 	 * @param z - Z int (Coordinates)
 	 * @return a new instance of Coord.
+	 * 
 	 */
 	public static Coord parseCoord(int x, int z) {
 		return new Coord(toCell(x), toCell(z));
 	}
 
 	public static Coord parseCoord(Entity entity) {
+
 		return parseCoord(entity.getLocation());
 	}
 
 	public static Coord parseCoord(Location loc) {
+
 		return parseCoord(loc.getBlockX(), loc.getBlockZ());
 	}
 
 	public static Coord parseCoord(Block block) {
+
 		return parseCoord(block.getX(), block.getZ());
 	}
 
 	@Override
 	public String toString() {
+
 		return getX() + "," + getZ();
 	}
 
 	public static int getCellSize() {
+
 		return cellSize;
 	}
 }

--- a/src/com/palmergames/bukkit/towny/object/Coord.java
+++ b/src/com/palmergames/bukkit/towny/object/Coord.java
@@ -1,5 +1,6 @@
 package com.palmergames.bukkit.towny.object;
 
+import com.palmergames.bukkit.towny.TownySettings;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
@@ -13,49 +14,34 @@ import org.bukkit.entity.Entity;
  */
 public class Coord {
 
-	protected static int cellSize = 16;
-	protected int x, z;
+	private static final int cellSize = TownySettings.getTownBlockSize(); // This should never change during runtime.
+	private final int x;
+	private final int z;
 
 	public Coord(int x, int z) {
-
 		this.x = x;
 		this.z = z;
 	}
 
 	public Coord(Coord coord) {
-
 		this.x = coord.getX();
 		this.z = coord.getZ();
 	}
 
 	public int getX() {
-
 		return x;
 	}
 
-	public void setX(int x) {
-
-		this.x = x;
-	}
-
 	public int getZ() {
-
 		return z;
 	}
 
-	public void setZ(int z) {
-
-		this.z = z;
-	}
-
 	public Coord add(int xOffset, int zOffset) {
-
 		return new Coord(getX() + xOffset, getZ() + zOffset);
 	}
 
 	@Override
 	public int hashCode() {
-
 		int result = 17;
 		result = 27 * result + x;
 		result = 27 * result + z;
@@ -64,7 +50,6 @@ public class Coord {
 
 	@Override
 	public boolean equals(Object obj) {
-
 		if (obj == this)
 			return true;
 		if (!(obj instanceof Coord))
@@ -85,6 +70,7 @@ public class Coord {
 
 	/**
 	 * Convert a value to the grid cell counterpart
+	 * 
 	 * @param value x/z integer
 	 * @return cell position
 	 */
@@ -100,40 +86,29 @@ public class Coord {
 	 * @param x - X int (Coordinates)
 	 * @param z - Z int (Coordinates)
 	 * @return a new instance of Coord.
-	 * 
 	 */
 	public static Coord parseCoord(int x, int z) {
 		return new Coord(toCell(x), toCell(z));
 	}
 
 	public static Coord parseCoord(Entity entity) {
-
 		return parseCoord(entity.getLocation());
 	}
 
 	public static Coord parseCoord(Location loc) {
-
 		return parseCoord(loc.getBlockX(), loc.getBlockZ());
 	}
 
 	public static Coord parseCoord(Block block) {
-
 		return parseCoord(block.getX(), block.getZ());
 	}
 
 	@Override
 	public String toString() {
-
 		return getX() + "," + getZ();
 	}
 
-	public static void setCellSize(int cellSize) {
-
-		Coord.cellSize = cellSize;
-	}
-
 	public static int getCellSize() {
-
 		return cellSize;
 	}
 }

--- a/src/com/palmergames/bukkit/towny/object/NationSpawnLevel.java
+++ b/src/com/palmergames/bukkit/towny/object/NationSpawnLevel.java
@@ -40,8 +40,12 @@ public enum NationSpawnLevel {
 			null,
 			null);
 
-	private ConfigNodes isAllowingConfigNode, ecoPriceConfigNode;
-	private String permissionNode, notAllowedLangNode, notAllowedLangNodeWar, notAllowedLangNodePeace;
+	private final ConfigNodes isAllowingConfigNode;
+	private final ConfigNodes ecoPriceConfigNode;
+	private final String permissionNode;
+	private final String notAllowedLangNode;
+	private final String notAllowedLangNodeWar;
+	private final String notAllowedLangNodePeace;
 
 	NationSpawnLevel(ConfigNodes isAllowingConfigNode, String notAllowedLangNode, String notAllowedLangNodeWar, String notAllowedLangNodePeace, ConfigNodes ecoPriceConfigNode, String permissionNode) {
 

--- a/src/com/palmergames/bukkit/towny/object/PlayerCache.java
+++ b/src/com/palmergames/bukkit/towny/object/PlayerCache.java
@@ -10,15 +10,15 @@ import java.util.HashMap;
 
 public class PlayerCache {
 
-	private HashMap<Material, Boolean> buildMatPermission = new HashMap<Material,Boolean>();
-	private HashMap<Material, Boolean> destroyMatPermission = new HashMap<Material,Boolean>();
-	private HashMap<Material, Boolean> switchMatPermission = new HashMap<Material,Boolean>();
-	private HashMap<Material, Boolean> itemUseMatPermission = new HashMap<Material,Boolean>();
+	private final HashMap<Material, Boolean> buildMatPermission = new HashMap<>();
+	private final HashMap<Material, Boolean> destroyMatPermission = new HashMap<>();
+	private final HashMap<Material, Boolean> switchMatPermission = new HashMap<>();
+	private final HashMap<Material, Boolean> itemUseMatPermission = new HashMap<>();
 	
-	private HashMap<Integer, HashMap<Byte, Boolean>> buildPermission = new HashMap<Integer, HashMap<Byte,Boolean>>();
-	private HashMap<Integer, HashMap<Byte, Boolean>> destroyPermission = new HashMap<Integer, HashMap<Byte,Boolean>>();
-	private HashMap<Integer, HashMap<Byte, Boolean>> switchPermission = new HashMap<Integer, HashMap<Byte,Boolean>>();
-	private HashMap<Integer, HashMap<Byte, Boolean>> itemUsePermission = new HashMap<Integer, HashMap<Byte,Boolean>>();
+	private final HashMap<Integer, HashMap<Byte, Boolean>> buildPermission = new HashMap<>();
+	private final HashMap<Integer, HashMap<Byte, Boolean>> destroyPermission = new HashMap<>();
+	private final HashMap<Integer, HashMap<Byte, Boolean>> switchPermission = new HashMap<>();
+	private final HashMap<Integer, HashMap<Byte, Boolean>> itemUsePermission = new HashMap<>();
 	
 	private WorldCoord lastWorldCoord;
 	private String blockErrMsg;
@@ -186,10 +186,11 @@ public class PlayerCache {
 		townBlockStatus = null;
 		blockErrMsg = null;
 		
-		buildMatPermission = new HashMap<Material,Boolean>();
-		destroyMatPermission = new HashMap<Material,Boolean>();
-		switchMatPermission = new HashMap<Material,Boolean>();
-		itemUseMatPermission = new HashMap<Material,Boolean>();
+		// Clear all maps
+		buildMatPermission.clear();
+		destroyMatPermission.clear();
+		switchMatPermission.clear();
+		itemUseMatPermission.clear();
 //		
 //		// Pre 1.13 hashmaps here.
 //		buildPermission = new HashMap<Integer, HashMap<Byte,Boolean>>();

--- a/src/com/palmergames/bukkit/towny/object/TownyPermissionChange.java
+++ b/src/com/palmergames/bukkit/towny/object/TownyPermissionChange.java
@@ -11,9 +11,9 @@ public class TownyPermissionChange {
 		ALL_PERMS, SINGLE_PERM, PERM_LEVEL, ACTION_TYPE, RESET
 	}
 
-	private Object[] args;
-	private Action changeAction;
-	private boolean changeValue;
+	private final Object[] args;
+	private final Action changeAction;
+	private final boolean changeValue;
 
 	public TownyPermissionChange(Action changeAction, boolean changeValue, Object... args) {
 		this.changeAction = changeAction;

--- a/src/com/palmergames/bukkit/towny/object/Transaction.java
+++ b/src/com/palmergames/bukkit/towny/object/Transaction.java
@@ -3,9 +3,9 @@ package com.palmergames.bukkit.towny.object;
 import org.bukkit.entity.Player;
 
 public class Transaction {
-	private TransactionType type;
-	private Player player;
-	private int amount;
+	private final TransactionType type;
+	private final Player player;
+	private final int amount;
 	
 	public Transaction(TransactionType type, Player player, int amount) {
 		this.type = type;

--- a/src/com/palmergames/bukkit/towny/object/TransactionType.java
+++ b/src/com/palmergames/bukkit/towny/object/TransactionType.java
@@ -3,7 +3,7 @@ package com.palmergames.bukkit.towny.object;
 public enum TransactionType {
 	DEPOSIT("Deposit"), WITHDRAW("Withdraw"), ADD("Add"), SUBTRACT("Subtract");
 	
-	private String name;
+	private final String name;
 	
 	TransactionType(String name) {
 		this.name = name;

--- a/src/com/palmergames/bukkit/towny/object/WorldCoord.java
+++ b/src/com/palmergames/bukkit/towny/object/WorldCoord.java
@@ -12,7 +12,7 @@ import java.util.Objects;
 
 public class WorldCoord extends Coord {
 
-	private String worldName;
+	private final String worldName;
 
 	public WorldCoord(String worldName, int x, int z) {
 		super(x, z);
@@ -34,7 +34,7 @@ public class WorldCoord extends Coord {
 	}
 
 	public Coord getCoord() {
-		return new Coord(x, z);
+		return new Coord(getX(), getZ());
 	}
 
 	@Deprecated
@@ -80,8 +80,8 @@ public class WorldCoord extends Coord {
 
 		int hash = 17;
 		hash = hash * 27 + (worldName == null ? 0 : worldName.hashCode());
-		hash = hash * 27 + x;
-		hash = hash * 27 + z;
+		hash = hash * 27 + getX();
+		hash = hash * 27 + getZ();
 		return hash;
 	}
 
@@ -94,11 +94,11 @@ public class WorldCoord extends Coord {
 
 		if (!(obj instanceof WorldCoord)) {
 			Coord that = (Coord) obj;
-			return this.x == that.x && this.z == that.z;
+			return this.getX() == that.getZ() && this.getZ() == that.getZ();
 		}
 
 		WorldCoord that = (WorldCoord) obj;
-		return this.x == that.x && this.z == that.z && (this.worldName == null ? that.worldName == null : this.worldName.equals(that.worldName));
+		return this.getX() == that.getX() && this.getZ() == that.getZ() && (Objects.equals(this.worldName, that.worldName));
 	}
 
 	@Override

--- a/src/com/palmergames/bukkit/towny/object/inviteobjects/NationAllyNationInvite.java
+++ b/src/com/palmergames/bukkit/towny/object/inviteobjects/NationAllyNationInvite.java
@@ -5,61 +5,65 @@ import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.invites.Invite;
-import com.palmergames.bukkit.towny.invites.TownyInviteReceiver;
-import com.palmergames.bukkit.towny.invites.TownyInviteSender;
 import com.palmergames.bukkit.towny.object.Nation;
 
 public class NationAllyNationInvite implements Invite {
 
-	public NationAllyNationInvite(String directsender, TownyInviteSender sender, TownyInviteReceiver receiver) {
-		this.directsender = directsender;
+	private final String directSender;
+	private final Nation receiver;
+	private final Nation sender;
+
+	public NationAllyNationInvite(String directSender, Nation sender, Nation receiver) {
+		this.directSender = directSender;
 		this.sender = sender;
 		this.receiver = receiver;
 	}
 
-	private String directsender;
-	private TownyInviteReceiver receiver;
-	private TownyInviteSender sender;
-
 	@Override
 	public String getDirectSender() {
-		return directsender;
+		return directSender;
 	}
 
 	@Override
-	public TownyInviteReceiver getReceiver() {
+	public Nation getReceiver() {
 		return receiver;
 	}
 
 	@Override
-	public TownyInviteSender getSender() {
+	public Nation getSender() {
 		return sender;
 	}
 
 	@Override
 	public void accept() throws TownyException {
-			Nation receivernation = (Nation) getReceiver();
-			Nation sendernation = (Nation) getSender();
-			receivernation.addAlly(sendernation);
-			sendernation.addAlly(receivernation);
-			TownyMessaging.sendPrefixedNationMessage(receivernation, String.format(TownySettings.getLangString("msg_added_ally"), sendernation.getName()));
-			TownyMessaging.sendPrefixedNationMessage(sendernation, String.format(TownySettings.getLangString("msg_accept_ally"), receivernation.getName()));
-			receivernation.deleteReceivedInvite(this);
-			sendernation.deleteSentAllyInvite(this);
-			TownyUniverse.getInstance().getDataSource().saveNation(receivernation);
-			TownyUniverse.getInstance().getDataSource().saveNation(sendernation);
+			Nation receiverNation = getReceiver();
+			Nation senderNation = getSender();
+			
+			receiverNation.addAlly(senderNation);
+			senderNation.addAlly(receiverNation);
+			
+			TownyMessaging.sendPrefixedNationMessage(receiverNation, String.format(TownySettings.getLangString("msg_added_ally"), senderNation.getName()));
+			TownyMessaging.sendPrefixedNationMessage(senderNation, String.format(TownySettings.getLangString("msg_accept_ally"), receiverNation.getName()));
+			
+			receiverNation.deleteReceivedInvite(this);
+			senderNation.deleteSentAllyInvite(this);
+			
+			TownyUniverse.getInstance().getDataSource().saveNation(receiverNation);
+			TownyUniverse.getInstance().getDataSource().saveNation(senderNation);
 	}
 
 	@Override
 	public void decline(boolean fromSender) {
-		Nation receivernation = (Nation) getReceiver();
-		Nation sendernation = (Nation) getSender();
-		receivernation.deleteReceivedInvite(this);
-		sendernation.deleteSentAllyInvite(this);
+		Nation receiverNation = getReceiver();
+		Nation senderNation = getSender();
+		
+		receiverNation.deleteReceivedInvite(this);
+		senderNation.deleteSentAllyInvite(this);
+		
 		if (!fromSender) {
-			TownyMessaging.sendPrefixedNationMessage(sendernation, String.format(TownySettings.getLangString("msg_deny_ally"), TownySettings.getLangString("nation_sing") + ": " + receivernation.getName()));
+			TownyMessaging.sendPrefixedNationMessage(senderNation, String.format(TownySettings.getLangString("msg_deny_ally"), TownySettings.getLangString("nation_sing") + ": " + receiverNation.getName()));
 		} else {
-			TownyMessaging.sendPrefixedNationMessage(receivernation, String.format(TownySettings.getLangString("nation_revoke_ally"), sendernation.getName()));
+			TownyMessaging.sendPrefixedNationMessage(receiverNation, String.format(TownySettings.getLangString("nation_revoke_ally"), senderNation.getName()));
 		}
 	}
 }

--- a/src/com/palmergames/bukkit/towny/object/inviteobjects/PlayerJoinTownInvite.java
+++ b/src/com/palmergames/bukkit/towny/object/inviteobjects/PlayerJoinTownInvite.java
@@ -12,47 +12,51 @@ import com.palmergames.bukkit.towny.object.Town;
 
 public class PlayerJoinTownInvite implements Invite {
 
-	public PlayerJoinTownInvite(String directsender, TownyInviteSender sender, TownyInviteReceiver receiver) {
-		this.directsender = directsender;
+	private final String directSender;
+	private final Resident receiver;
+	private final Town sender;
+
+	public PlayerJoinTownInvite(String directSender, Town sender, Resident receiver) {
+		this.directSender = directSender;
 		this.sender = sender;
 		this.receiver = receiver;
 	}
 
-	private String directsender;
-	private TownyInviteReceiver receiver;
-	private TownyInviteSender sender;
-
 	@Override
 	public String getDirectSender() {
-		return directsender;
+		return directSender;
 	}
 
 	@Override
-	public TownyInviteReceiver getReceiver() {
+	public Resident getReceiver() {
 		return receiver;
 	}
 
 	@Override
-	public TownyInviteSender getSender() {
+	public Town getSender() {
 		return sender;
 	}
 	
 	@Override
 	public void accept() throws TownyException {
-		Resident resident = (Resident) getReceiver();
-		Town town = (Town) getSender();
+		Resident resident = getReceiver();
+		Town town = getSender();
+		
 		TownCommand.townAddResident(town, resident);
 		TownyMessaging.sendPrefixedTownMessage(town, String.format(TownySettings.getLangString("msg_join_town"), resident.getName()));
+		
 		resident.deleteReceivedInvite(this);
 		town.deleteSentInvite(this);
 	}
 
 	@Override
 	public void decline(boolean fromSender) {
-		Resident resident = (Resident) getReceiver();
-		Town town = (Town) getSender();
+		Resident resident = getReceiver();
+		Town town = getSender();
+		
 		resident.deleteReceivedInvite(this);
 		town.deleteSentInvite(this);
+		
 		if (!fromSender) {
 			TownyMessaging.sendPrefixedTownMessage(town, String.format(TownySettings.getLangString("msg_deny_invite"), resident.getName()));
 			TownyMessaging.sendMsg(getReceiver(), TownySettings.getLangString("successful_deny"));

--- a/src/com/palmergames/bukkit/towny/object/inviteobjects/TownJoinNationInvite.java
+++ b/src/com/palmergames/bukkit/towny/object/inviteobjects/TownJoinNationInvite.java
@@ -15,37 +15,37 @@ import java.util.List;
 
 public class TownJoinNationInvite implements Invite {
 
-	public TownJoinNationInvite(String directsender, TownyInviteSender sender, TownyInviteReceiver receiver) {
-		this.directsender = directsender;
+	private final String directSender;
+	private final Town receiver;
+	private final Nation sender;
+
+	public TownJoinNationInvite(String directSender, Nation sender, Town receiver) {
+		this.directSender = directSender;
 		this.sender = sender;
 		this.receiver = receiver;
 	}
-
-	private String directsender;
-	private TownyInviteReceiver receiver;
-	private TownyInviteSender sender;
-
+	
 	@Override
 	public String getDirectSender() {
-		return directsender;
+		return directSender;
 	}
 
 	@Override
-	public TownyInviteReceiver getReceiver() {
+	public Town getReceiver() {
 		return receiver;
 	}
 
 	@Override
-	public TownyInviteSender getSender() {
+	public Nation getSender() {
 		return sender;
 	}
 
 	@Override
 	public void accept() throws TownyException {
-		Town town = (Town) getReceiver();
+		Town town = getReceiver();
 		List<Town> towns = new ArrayList<>();
 		towns.add(town);
-		Nation nation = (Nation) getSender();
+		Nation nation = getSender();
 		NationCommand.nationAdd(nation, towns);
 		// Message handled in nationAdd()
 		town.deleteReceivedInvite(this);
@@ -54,8 +54,8 @@ public class TownJoinNationInvite implements Invite {
 
 	@Override
 	public void decline(boolean fromSender) {
-		Town town = (Town) getReceiver();
-		Nation nation = (Nation) getSender();
+		Town town = getReceiver();
+		Nation nation = getSender();
 		town.deleteReceivedInvite(this);
 		nation.deleteSentInvite(this);
 		if (!fromSender) {

--- a/src/com/palmergames/bukkit/towny/object/metadata/CustomDataField.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/CustomDataField.java
@@ -3,9 +3,9 @@ package com.palmergames.bukkit.towny.object.metadata;
 import com.palmergames.bukkit.towny.exceptions.InvalidMetadataTypeException;
 
 public abstract class CustomDataField<T> {
-    private CustomDataFieldType type;
+    private final CustomDataFieldType type;
     private T value;
-    private String key;
+    private final String key;
     
     private String label;
     

--- a/src/com/palmergames/bukkit/towny/object/metadata/CustomDataFieldType.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/CustomDataFieldType.java
@@ -3,8 +3,8 @@ package com.palmergames.bukkit.towny.object.metadata;
 public enum CustomDataFieldType {
     IntegerField(0, "Integer"), StringField(1, "String"), BooleanField(2, "Boolean"), DecimalField(3,"Decimal");
     
-    private Integer value;
-    private String typeName;
+    private final Integer value;
+    private final String typeName;
     
     CustomDataFieldType(Integer type, String typeName) {
         this.value = type;

--- a/src/com/palmergames/bukkit/towny/tasks/CooldownTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/CooldownTimerTask.java
@@ -14,7 +14,7 @@ public class CooldownTimerTask extends TownyTimerTask {
 		PVP(TownySettings.getPVPCoolDownTime()),
 		TELEPORT(TownySettings.getSpawnCooldownTime());
 		
-		private int seconds;
+		private final int seconds;
 		
 		private int getSeconds() {
 			return seconds;

--- a/src/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
@@ -32,8 +32,8 @@ public class DailyTimerTask extends TownyTimerTask {
 	
 	private double totalTownUpkeep = 0.0;
 	private double totalNationUpkeep = 0.0;
-	private List<String> removedTowns = new ArrayList<>();
-	private List<String> removedNations = new ArrayList<>();
+	private final List<String> removedTowns = new ArrayList<>();
+	private final List<String> removedNations = new ArrayList<>();
 
 	public DailyTimerTask(Towny plugin) {
 

--- a/src/com/palmergames/bukkit/towny/tasks/HealthRegenTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/HealthRegenTimerTask.java
@@ -18,7 +18,7 @@ import com.palmergames.bukkit.towny.utils.CombatUtil;
 
 public class HealthRegenTimerTask extends TownyTimerTask {
 
-	private Server server;
+	private final Server server;
 
 	public HealthRegenTimerTask(Towny plugin, Server server) {
 

--- a/src/com/palmergames/bukkit/towny/tasks/MobRemovalTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/MobRemovalTimerTask.java
@@ -24,10 +24,10 @@ import java.util.List;
 
 public class MobRemovalTimerTask extends TownyTimerTask {
 
-	private Server server;
+	private final Server server;
 	public static List<Class<?>> classesOfWorldMobsToRemove = new ArrayList<>();
 	public static List<Class<?>> classesOfTownMobsToRemove = new ArrayList<>();
-	private boolean isRemovingKillerBunny;
+	private final boolean isRemovingKillerBunny;
 
 	public MobRemovalTimerTask(Towny plugin, Server server) {
 

--- a/src/com/palmergames/bukkit/towny/tasks/PlotClaim.java
+++ b/src/com/palmergames/bukkit/towny/tasks/PlotClaim.java
@@ -31,12 +31,12 @@ import java.util.List;
 public class PlotClaim extends Thread {
 
 	Towny plugin;
-	private volatile Player player;
-	private volatile Resident resident;
-	@SuppressWarnings("unused")
-	private volatile TownyWorld world;
-	private List<WorldCoord> selection;
-	private boolean claim, admin, groupClaim;
+	private final Player player;
+	private final Resident resident;
+	private final List<WorldCoord> selection;
+	private final boolean claim;
+	private final boolean admin;
+	private final boolean groupClaim;
 
 	/**
 	 * @param plugin reference to towny
@@ -126,7 +126,7 @@ public class PlotClaim extends Thread {
 
 				// Make sure this is a valid world (mainly when unclaiming).
 				try {
-					this.world = worldCoord.getTownyWorld();
+					TownyWorld world = worldCoord.getTownyWorld();
 				} catch (NotRegisteredException e) {
 					TownyMessaging.sendMsg(player, TownySettings.getLangString("msg_err_not_configured"));
 					continue;

--- a/src/com/palmergames/bukkit/towny/tasks/ProtectionRegenTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/ProtectionRegenTask.java
@@ -16,7 +16,7 @@ import org.bukkit.inventory.ItemStack;
 
 public class ProtectionRegenTask extends TownyTimerTask {
 
-	private BlockState state;
+	private final BlockState state;
 	private BlockLocation blockLocation;
 	private int TaskId;
 	private ItemStack[] contents;

--- a/src/com/palmergames/bukkit/towny/tasks/ResidentPurge.java
+++ b/src/com/palmergames/bukkit/towny/tasks/ResidentPurge.java
@@ -15,10 +15,10 @@ import java.util.ArrayList;
  */
 public class ResidentPurge extends Thread {
 
-	Towny plugin;
-	private CommandSender sender = null;
-	long deleteTime;
-	boolean townless;
+	final Towny plugin;
+	private final CommandSender sender;
+	final long deleteTime;
+	final boolean townless;
 
 	/**
 	 * @param plugin reference to Towny

--- a/src/com/palmergames/bukkit/towny/tasks/TownClaim.java
+++ b/src/com/palmergames/bukkit/towny/tasks/TownClaim.java
@@ -34,11 +34,13 @@ import java.util.List;
 public class TownClaim extends Thread {
 
 	Towny plugin;
-	private volatile Player player;
+	private final Player player;
 	private Location outpostLocation;
 	private volatile Town town;
-	private List<WorldCoord> selection;
-	private boolean outpost, claim, forced;
+	private final List<WorldCoord> selection;
+	private boolean outpost;
+	private final boolean claim;
+	private final boolean forced;
 
 	/**
 	 * @param plugin reference to towny

--- a/src/com/palmergames/bukkit/towny/tasks/TownyTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/TownyTimerTask.java
@@ -13,5 +13,6 @@ public abstract class TownyTimerTask extends TimerTask {
 	public TownyTimerTask(Towny plugin) {
 		this.plugin = plugin;
 		this.universe = TownyUniverse.getInstance();
+		
 	}
 }

--- a/src/com/palmergames/bukkit/towny/tasks/TownyTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/TownyTimerTask.java
@@ -7,12 +7,11 @@ import java.util.TimerTask;
 
 public abstract class TownyTimerTask extends TimerTask {
 
-	protected TownyUniverse universe;
-	protected Towny plugin;
+	protected final TownyUniverse universe;
+	protected final Towny plugin;
 
 	public TownyTimerTask(Towny plugin) {
 		this.plugin = plugin;
 		this.universe = TownyUniverse.getInstance();
-		
 	}
 }


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This makes the fields of objects that don't change `final` it also prevents data-only objects from being mutable. Why does this matter? Mainly because objects with an unchangeable state are automatically thread-safe, and they don't suffer from weird state side effects. 

**It's worth noting that the thread-safe point only applies to objects containing fields that are 1) *all* immutable or 2) some that *are* mutable and the mutable fields aren't publicly accessible.**

This is important as many of our tasks run async whilst using these objects.

Some objects simply hold data, and have no reason to be mutable, therefore:
- `WorldCoord` - Now an immutable object
- `Coord` - Now An immutable object

Also in many methods to reset a map we were using:
`myMap = new HashMap<>();` 
This is not that efficient so it's been corrected to this:
`myMap.clear();`

____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
