### PR TITLE
Fix Maven Javadoc Error, resolve minor warnings

### DIFF
--- a/src/com/palmergames/bukkit/towny/TownyAPI.java
+++ b/src/com/palmergames/bukkit/towny/TownyAPI.java
@@ -200,7 +200,7 @@ public class TownyAPI {
     /**
      * Returns {@link TownyWorld} unless it is null.
      * 
-     * @param world - the name of the world to get.
+     * @param worldName - the name of the world to get.
      * @return TownyWorld or null.
      */
     public TownyWorld getTownyWorld(String worldName) {

--- a/src/com/palmergames/bukkit/towny/object/Town.java
+++ b/src/com/palmergames/bukkit/towny/object/Town.java
@@ -200,7 +200,10 @@ public class Town extends Government implements TownBlockOwner {
 
 	/**
 	 * @deprecated Since 0.96.2.5, use {@link Resident#hasTownRank(String)} (using "assistant" as argument) instead. 
+	 * @param resident Resident to check
+	 * @return Currently, runs {@link Resident#hasTownRank(String)} to return the assistant.   
 	 */
+	@Deprecated
 	public boolean hasAssistant(Resident resident) {
 
 		return resident.hasTownRank("assistant");


### PR DESCRIPTION
Fix Error thrown by maven-javadoc-plugin w/ TownyAPI#getTownyWorld(String) - minor warns for Town#hasAssistant(Resident)

<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Fixes error that prevents maven-javadoc-plugin from running properly.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
N/A

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
N/A

____
- [ N/A ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
