### PR TITLE
Prevent residents from being able to unclaim homeblocks.

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -3447,8 +3447,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 
 				if (System.currentTimeMillis()- FlagWar.lastFlagged(town) < TownySettings.timeToWaitAfterFlag())
 					throw new TownyException(Translation.of("msg_war_flag_deny_recently_attacked"));
-
-				List<WorldCoord> selection;
+				
 				if (split.length == 1 && split[0].equalsIgnoreCase("all")) {
 					if (!townyUniverse.getPermissionSource().testPermission(player, PermissionNodes.TOWNY_COMMAND_TOWN_UNCLAIM_ALL.getNode()))
 						throw new TownyException(Translation.of("msg_err_command_disable"));
@@ -3457,13 +3456,18 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 					// If the unclaim code knows its an outpost or not, doesnt matter its only used once the world deletes the townblock, where it takes the value from the townblock.
 					// Which is why in AreaSelectionUtil, since outpost is not parsed in the main claiming of a section, it is parsed in the unclaiming with the circle, rect & all options.
 				} else {
-					selection = AreaSelectionUtil.selectWorldCoordArea(town, new WorldCoord(world.getName(), Coord.parseCoord(plugin.getCache(player).getLastLocation())), split);
+					List<WorldCoord> selection = AreaSelectionUtil.selectWorldCoordArea(town, new WorldCoord(world.getName(), Coord.parseCoord(plugin.getCache(player).getLastLocation())), split);
 					selection = AreaSelectionUtil.filterOwnedBlocks(town, selection);
 					if (selection.isEmpty())
 						throw new TownyException(Translation.of("msg_err_empty_area_selection"));
 
 					if (selection.get(0).getTownBlock().isHomeBlock())
 						throw new TownyException(Translation.of("msg_err_cannot_unclaim_homeblock"));
+					
+					if (AreaSelectionUtil.filterHomeBlock(town, selection)) {
+						// Do not stop the entire unclaim, just warn that the homeblock cannot be unclaimed
+						TownyMessaging.sendErrorMsg(player, Translation.of("msg_err_cannot_unclaim_homeblock"));
+					}
 					
 					// Set the area to unclaim
 					new TownClaim(plugin, player, town, selection, false, false, false).start();

--- a/src/com/palmergames/bukkit/towny/object/TownyWorld.java
+++ b/src/com/palmergames/bukkit/towny/object/TownyWorld.java
@@ -608,7 +608,7 @@ public class TownyWorld extends TownyObject {
 				if (homeTown != null)
 					// If the townblock either: the town is the same as homeTown OR
 					// both towns are in the same nation (and this is set to ignore distance in the config,) skip over the proximity filter.
-					if (homeTown.getHomeBlock().equals(town.getHomeBlock()) || (TownySettings.isMinDistanceIgnoringTownsInSameNation() && homeTown.hasNation() && town.hasNation() && town.getNation().equals(homeTown.getNation())))
+					if (homeTown.getUuid().equals(town.getUuid()) || (TownySettings.isMinDistanceIgnoringTownsInSameNation() && homeTown.hasNation() && town.hasNation() && town.getNation().equals(homeTown.getNation())))
 						continue;
 				
 				if (!town.getHomeblockWorld().equals(this)) continue;
@@ -648,7 +648,7 @@ public class TownyWorld extends TownyObject {
 				if (homeTown != null)
 					// If the townblock either: the town is the same as homeTown OR 
 					// both towns are in the same nation (and this is set to ignore distance in the config,) skip over the proximity filter.
-					if (homeTown.getHomeBlock().equals(town.getHomeBlock()) || (TownySettings.isMinDistanceIgnoringTownsInSameNation() && homeTown.hasNation() && town.hasNation() && town.getNation().equals(homeTown.getNation())))
+					if (homeTown.getUuid().equals(town.getUuid()) || (TownySettings.isMinDistanceIgnoringTownsInSameNation() && homeTown.hasNation() && town.hasNation() && town.getNation().equals(homeTown.getNation())))
 						continue;
 				for (TownBlock b : town.getTownBlocks()) {
 					if (!b.getWorld().equals(this)) continue;

--- a/src/com/palmergames/bukkit/towny/tasks/TownClaim.java
+++ b/src/com/palmergames/bukkit/towny/tasks/TownClaim.java
@@ -25,6 +25,7 @@ import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -246,7 +247,17 @@ public class TownClaim extends Thread {
 
 		Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, () -> {
 
-			TownyUniverse.getInstance().getDataSource().removeTownBlocks(town);
+			// Prevent removing the homeblock
+			Collection<TownBlock> townBlocks = new ArrayList<>(town.getTownBlocks());
+			for (TownBlock townBlock : townBlocks) {
+				try {
+					if (!town.hasHomeBlock() || !townBlock.equals(town.getHomeBlock())) {
+						TownyUniverse.getInstance().getDataSource().removeTownBlock(townBlock);
+					}
+				} catch (TownyException ignore) {
+				}
+			}
+			
 			TownyMessaging.sendPrefixedTownMessage(town, Translation.of("msg_abandoned_area_1"));
 
 		}, 1);

--- a/src/com/palmergames/bukkit/towny/utils/AreaSelectionUtil.java
+++ b/src/com/palmergames/bukkit/towny/utils/AreaSelectionUtil.java
@@ -236,6 +236,18 @@ public class AreaSelectionUtil {
 			}
 		return out;
 	}
+	
+	public static boolean filterHomeBlock(Town town, List<WorldCoord> selection) {
+		WorldCoord homeCoord;
+		
+		try {
+			homeCoord = town.getHomeBlock().getWorldCoord();
+		} catch (TownyException ignore) {
+			return false;
+		}
+		
+		return selection.removeIf(worldCoord -> worldCoord.equals(homeCoord));
+	}
 
 	/**
 	 * Gives a list of townblocks that have membership to the specified group.


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Residents were able to unclaim the town's homeblock through two methods: using `unclaim all` and `unclaim [rect/circle]`. This PR aims to prevent both of those because unclaiming the homeblock can result in desyncs and cause issues on loading the DB. 
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
