### PR TITLE
Fix ClassNotFound exception due to old bungeecord version

### DIFF
--- a/src/com/palmergames/bukkit/towny/TownySpigotMessaging.java
+++ b/src/com/palmergames/bukkit/towny/TownySpigotMessaging.java
@@ -30,8 +30,13 @@ public class TownySpigotMessaging {
 		
 		public void setHoverText(String hoverText) {
 			if (Towny.is116Plus()) {
-				base.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(hoverText)));
-				return;
+				try {
+					base.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(hoverText)));
+					return;
+				} catch (Exception ignore) {
+					// The above code can throw a ClassNotFoundException if there is an old version of BungeeCord installed.
+					// Default to the code below.
+				}
 			}
 
 			base.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new ComponentBuilder(hoverText).create()));


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
We had assumed that if you are running 1.16, you are running the latest version of BungeeCord. However, not everyone is and this assumption breaks when we try to use a `Content` class that is not on older versions of bungeecord that support 1.16.
This PR just catches the exception so it falls through. The recommended course of action still is for users to update Bungeecord.
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.

Compiled Jar: [Towny-0.96.2.9.jar.zip](https://github.com/TownyAdvanced/Towny/files/5026168/Towny-0.96.2.9.jar.zip)

