### PR TITLE
GM Source fetching player suffix instead of prefix

### DIFF
--- a/src/com/palmergames/bukkit/towny/permissions/GroupManagerSource.java
+++ b/src/com/palmergames/bukkit/towny/permissions/GroupManagerSource.java
@@ -63,7 +63,7 @@ public class GroupManagerSource extends TownyPermissionSource {
 			user = handler.getUserSuffix(player.getName());
 		} else if (node == "userprefix") {
 			group = "";
-			user = handler.getUserSuffix(player.getName());					
+			user = handler.getUserPrefix(player.getName());					
 		} else if (node == "usersuffix") {
 			group = "";
 			user = handler.getUserSuffix(player.getName());					


### PR DESCRIPTION
A simple typo/copy paste error.

<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
GM Source fetching player suffix instead of prefix

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
