### PR TITLE
Reducy repeated getResident logic

### DIFF
--- a/src/com/palmergames/bukkit/towny/Towny.java
+++ b/src/com/palmergames/bukkit/towny/Towny.java
@@ -619,7 +619,7 @@ public class Towny extends JavaPlugin {
 			return;
 
 		try {
-			Resident resident = TownyUniverse.getInstance().getDataSource().getResident(player.getName());
+			Resident resident = TownyUniverse.getInstance().getDataSource().getResident(player);
 			resident.setModes(modes, notify);
 
 		} catch (NotRegisteredException e) {
@@ -635,7 +635,7 @@ public class Towny extends JavaPlugin {
 	public void removePlayerMode(Player player) {
 
 		try {
-			Resident resident = TownyUniverse.getInstance().getDataSource().getResident(player.getName());
+			Resident resident = TownyUniverse.getInstance().getDataSource().getResident(player);
 			resident.clearModes();
 
 		} catch (NotRegisteredException e) {

--- a/src/com/palmergames/bukkit/towny/TownyAPI.java
+++ b/src/com/palmergames/bukkit/towny/TownyAPI.java
@@ -52,7 +52,7 @@ public class TownyAPI {
      */
     public Location getTownSpawnLocation(Player player) {
         try {
-            Resident resident = townyUniverse.getDataSource().getResident(player.getName());
+            Resident resident = townyUniverse.getDataSource().getResident(player);
             Town town = resident.getTown();
             return town.getSpawn();
         } catch (TownyException x) {
@@ -68,7 +68,7 @@ public class TownyAPI {
      */
     public Location getNationSpawnLocation(Player player) {
         try {
-            Resident resident = townyUniverse.getDataSource().getResident(player.getName());
+            Resident resident = townyUniverse.getDataSource().getResident(player);
             Nation nation = resident.getTown().getNation();
             return nation.getSpawn();
         } catch (TownyException x) {
@@ -379,7 +379,7 @@ public class TownyAPI {
     public void requestTeleport(Player player, Location spawnLoc) {
         
         try {
-            TeleportWarmupTimerTask.requestTeleport(getDataSource().getResident(player.getName().toLowerCase()), spawnLoc);
+            TeleportWarmupTimerTask.requestTeleport(getDataSource().getResident(player), spawnLoc);
         } catch (TownyException x) {
             TownyMessaging.sendErrorMsg(player, x.getMessage());
         }

--- a/src/com/palmergames/bukkit/towny/TownyAsciiMap.java
+++ b/src/com/palmergames/bukkit/towny/TownyAsciiMap.java
@@ -46,7 +46,7 @@ public class TownyAsciiMap {
 		Resident resident;
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
 		try {
-			resident = townyUniverse.getDataSource().getResident(player.getName());
+			resident = townyUniverse.getDataSource().getResident(player);
 			if (resident.hasTown())
 				hasTown = true;
 		} catch (TownyException x) {

--- a/src/com/palmergames/bukkit/towny/TownyPlaceholderExpansion.java
+++ b/src/com/palmergames/bukkit/towny/TownyPlaceholderExpansion.java
@@ -112,7 +112,7 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion {
 		}
 		Resident resident;
 		try {
-			resident = TownyAPI.getInstance().getDataSource().getResident(player.getName());
+			resident = TownyAPI.getInstance().getDataSource().getResident(player);
 		} catch (NotRegisteredException e) {
 			return null;
 		}

--- a/src/com/palmergames/bukkit/towny/chat/checks/KingCheck.java
+++ b/src/com/palmergames/bukkit/towny/chat/checks/KingCheck.java
@@ -18,8 +18,8 @@ public class KingCheck extends ChatCheck {
 	public boolean runCheck(Player player, String checkString) {
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
 		try {
-			if(townyUniverse.getDataSource().getResident(player.getName()).hasNation()) {
-				return townyUniverse.getDataSource().getResident(player.getName()).getTown().getNation().isKing(townyUniverse.getDataSource().getResident(player.getName()));
+			if(townyUniverse.getDataSource().getResident(player).hasNation()) {
+				return townyUniverse.getDataSource().getResident(player).getTown().getNation().isKing(townyUniverse.getDataSource().getResident(player));
 			}
 		} catch(NotRegisteredException ignore) {
 		}

--- a/src/com/palmergames/bukkit/towny/chat/checks/MayorCheck.java
+++ b/src/com/palmergames/bukkit/towny/chat/checks/MayorCheck.java
@@ -18,8 +18,8 @@ public class MayorCheck extends ChatCheck {
 	public boolean runCheck(Player player, String checkString) {
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
 		try {
-			if(townyUniverse.getDataSource().getResident(player.getName()).hasTown()) {
-				return townyUniverse.getDataSource().getResident(player.getName()).getTown().isMayor(townyUniverse.getDataSource().getResident(player.getName()));
+			if(townyUniverse.getDataSource().getResident(player).hasTown()) {
+				return townyUniverse.getDataSource().getResident(player).getTown().isMayor(townyUniverse.getDataSource().getResident(player));
 			}
 		} catch(NotRegisteredException ignore) {
 		}

--- a/src/com/palmergames/bukkit/towny/chat/types/AllyType.java
+++ b/src/com/palmergames/bukkit/towny/chat/types/AllyType.java
@@ -20,7 +20,7 @@ public class AllyType extends ChatType {
 	@Override
 	public boolean canChat(Player player) {
 		try {
-			return TownyUniverse.getInstance().getDataSource().getResident(player.getName()).hasTown() && TownyUniverse.getInstance().getDataSource().getResident(player.getName()).getTown().hasNation();
+			return TownyUniverse.getInstance().getDataSource().getResident(player).hasTown() && TownyUniverse.getInstance().getDataSource().getResident(player).getTown().hasNation();
 		} catch(NotRegisteredException ignore) {
 
 		}
@@ -31,13 +31,13 @@ public class AllyType extends ChatType {
 	public Collection<Player> getRecipients(Collection<Player> recipients, Player player) {
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
 		try {
-			final Nation nation = townyUniverse.getDataSource().getResident(player.getName()).getTown().getNation();
+			final Nation nation = townyUniverse.getDataSource().getResident(player).getTown().getNation();
 
 			Collection<Player> newRecipients = new HashSet<>();
 
 			for(Player p : recipients) {
-				if (!townyUniverse.getDataSource().getResident(p.getName()).getTown().getNation().getUuid().equals(nation.getUuid())
-						&& !townyUniverse.getDataSource().getResident(p.getName()).getTown().getNation().hasAlly(nation)) {
+				if (!townyUniverse.getDataSource().getResident(p).getTown().getNation().getUuid().equals(nation.getUuid())
+						&& !townyUniverse.getDataSource().getResident(p).getTown().getNation().hasAlly(nation)) {
 					continue;
 				}
 				newRecipients.add(p);

--- a/src/com/palmergames/bukkit/towny/chat/types/NationType.java
+++ b/src/com/palmergames/bukkit/towny/chat/types/NationType.java
@@ -20,7 +20,7 @@ public class NationType extends ChatType {
 	@Override
 	public boolean canChat(Player player) {
 		try {
-			return TownyUniverse.getInstance().getDataSource().getResident(player.getName()).hasTown() && TownyUniverse.getInstance().getDataSource().getResident(player.getName()).getTown().hasNation();
+			return TownyUniverse.getInstance().getDataSource().getResident(player).hasTown() && TownyUniverse.getInstance().getDataSource().getResident(player).getTown().hasNation();
 		} catch(NotRegisteredException ignore) {
 
 		}
@@ -31,12 +31,12 @@ public class NationType extends ChatType {
 	public Collection<Player> getRecipients(Collection<Player> recipients, Player player) {
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
 		try {
-			final UUID nation = townyUniverse.getDataSource().getResident(player.getName()).getTown().getNation().getUuid();
+			final UUID nation = townyUniverse.getDataSource().getResident(player).getTown().getNation().getUuid();
 
 			Collection<Player> newRecipients = new HashSet<>();
 
 			for(Player p : recipients) {
-				if(townyUniverse.getDataSource().getResident(p.getName()).getTown().getNation().getUuid().equals(nation)) {
+				if(townyUniverse.getDataSource().getResident(p).getTown().getNation().getUuid().equals(nation)) {
 					newRecipients.add(p);
 				}
 			}

--- a/src/com/palmergames/bukkit/towny/chat/types/TownType.java
+++ b/src/com/palmergames/bukkit/towny/chat/types/TownType.java
@@ -20,7 +20,7 @@ public class TownType extends ChatType {
 	@Override
 	public boolean canChat(Player player) {
 		try {
-			return TownyUniverse.getInstance().getDataSource().getResident(player.getName()).hasTown();
+			return TownyUniverse.getInstance().getDataSource().getResident(player).hasTown();
 		} catch(NotRegisteredException ignore) {
 
 		}
@@ -31,12 +31,12 @@ public class TownType extends ChatType {
 	public Collection<Player> getRecipients(Collection<Player> recipients, Player player) {
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
 		try {
-			final UUID town = townyUniverse.getDataSource().getResident(player.getName()).getTown().getUuid();
+			final UUID town = townyUniverse.getDataSource().getResident(player).getTown().getUuid();
 
 			Collection<Player> newRecipients = new HashSet<>();
 
 			for(Player p : recipients) {
-				if(townyUniverse.getDataSource().getResident(p.getName()).getTown().getUuid().equals(town)) {
+				if(townyUniverse.getDataSource().getResident(p).getTown().getUuid().equals(town)) {
 					newRecipients.add(p);
 				}
 			}

--- a/src/com/palmergames/bukkit/towny/chat/variables/NationVariable.java
+++ b/src/com/palmergames/bukkit/towny/chat/variables/NationVariable.java
@@ -17,7 +17,7 @@ public class NationVariable extends ChatVariable {
 	@Override
 	public String parse(Player player, String message) {
 		try {
-			return TownyUniverse.getInstance().getDataSource().getResident(player.getName()).getTown().getNation().getName();
+			return TownyUniverse.getInstance().getDataSource().getResident(player).getTown().getNation().getName();
 		} catch(NotRegisteredException ignore) {
 			return "";
 		}

--- a/src/com/palmergames/bukkit/towny/chat/variables/TitleVariable.java
+++ b/src/com/palmergames/bukkit/towny/chat/variables/TitleVariable.java
@@ -17,7 +17,7 @@ public class TitleVariable extends ChatVariable {
 	@Override
 	public String parse(Player player, String message) {
 		try {
-			return TownyUniverse.getInstance().getDataSource().getResident(player.getName()).getTitle();
+			return TownyUniverse.getInstance().getDataSource().getResident(player).getTitle();
 		} catch(NotRegisteredException ignore) {
 		}
 		return "";

--- a/src/com/palmergames/bukkit/towny/chat/variables/TownVariable.java
+++ b/src/com/palmergames/bukkit/towny/chat/variables/TownVariable.java
@@ -17,7 +17,7 @@ public class TownVariable extends ChatVariable {
 	@Override
 	public String parse(Player player, String message) {
 		try {
-			return TownyUniverse.getInstance().getDataSource().getResident(player.getName()).getTown().getName();
+			return TownyUniverse.getInstance().getDataSource().getResident(player).getTown().getName();
 		} catch(NotRegisteredException ignore) {
 		}
 		return "";

--- a/src/com/palmergames/bukkit/towny/command/BaseCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/BaseCommand.java
@@ -153,7 +153,7 @@ public class BaseCommand implements TabCompleter{
 	 */
 	public static List<String> getTownResidentNamesOfPlayerStartingWith(Player player, String str){
 		try {
-			return NameUtil.filterByStart(NameUtil.getNames(TownyUniverse.getInstance().getDataSource().getResident(player.getName()).getTown().getResidents()), str);
+			return NameUtil.filterByStart(NameUtil.getNames(TownyUniverse.getInstance().getDataSource().getResident(player).getTown().getResidents()), str);
 		} catch (NotRegisteredException e) {
 			return Collections.emptyList();
 		}

--- a/src/com/palmergames/bukkit/towny/command/InviteCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/InviteCommand.java
@@ -103,7 +103,7 @@ public class InviteCommand extends BaseCommand implements CommandExecutor {
 		// /invite args[0] args[1}
 		Resident resident;
 		try {
-			resident = TownyUniverse.getInstance().getDataSource().getResident(player.getName());
+			resident = TownyUniverse.getInstance().getDataSource().getResident(player);
 		} catch (TownyException x) {
 			TownyMessaging.sendErrorMsg(player, x.getMessage());
 			return;
@@ -140,7 +140,7 @@ public class InviteCommand extends BaseCommand implements CommandExecutor {
 		Town town;
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
 		try {
-			resident = townyUniverse.getDataSource().getResident(player.getName());
+			resident = townyUniverse.getDataSource().getResident(player);
 		} catch (TownyException x) {
 			TownyMessaging.sendErrorMsg(player, x.getMessage());
 			return;
@@ -195,7 +195,7 @@ public class InviteCommand extends BaseCommand implements CommandExecutor {
 		Town town;
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
 		try {
-			resident = townyUniverse.getDataSource().getResident(player.getName());
+			resident = townyUniverse.getDataSource().getResident(player);
 		} catch (TownyException x) {
 			TownyMessaging.sendErrorMsg(player, x.getMessage());
 			return;

--- a/src/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -191,7 +191,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 								if (args[args.length - 1].startsWith("-")) {
 									// Return only sent invites to revoked because the nation name starts with a hyphen, e.g. -exampleNationName
 									try {
-										return NameUtil.filterByStart(TownyUniverse.getInstance().getDataSource().getResident(player.getName()).getTown().getNation().getSentAllyInvites()
+										return NameUtil.filterByStart(TownyUniverse.getInstance().getDataSource().getResident(player).getTown().getNation().getSentAllyInvites()
 											// Get names of sent invites
 											.stream()
 											.map(Invite::getReceiver)
@@ -210,13 +210,13 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 							case "remove":
 								// Return current allies to remove
 								try {
-									return NameUtil.filterByStart(NameUtil.getNames(TownyUniverse.getInstance().getDataSource().getResident(player.getName()).getTown().getNation().getAllies()), args[args.length - 1]);
+									return NameUtil.filterByStart(NameUtil.getNames(TownyUniverse.getInstance().getDataSource().getResident(player).getTown().getNation().getAllies()), args[args.length - 1]);
 								} catch (TownyException ignore) {}
 							case "accept":
 							case "deny":
 								// Return sent ally invites to accept or deny
 								try {
-									return NameUtil.filterByStart(TownyUniverse.getInstance().getDataSource().getResident(player.getName()).getTown().getNation().getReceivedInvites()
+									return NameUtil.filterByStart(TownyUniverse.getInstance().getDataSource().getResident(player).getTown().getNation().getReceivedInvites()
 									.stream()
 									.map(Invite::getSender)
 									.map(InviteSender::getName)
@@ -234,7 +234,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 							case "remove":
 								if (args.length == 3) {
 									try {
-										return NameUtil.filterByStart(NameUtil.getNames(TownyUniverse.getInstance().getDataSource().getResident(player.getName()).getTown().getNation().getResidents()), args[2]);
+										return NameUtil.filterByStart(NameUtil.getNames(TownyUniverse.getInstance().getDataSource().getResident(player).getTown().getNation().getResidents()), args[2]);
 									} catch (NotRegisteredException e) {
 										return Collections.emptyList();
 									}
@@ -254,14 +254,14 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 							case "remove":
 								// Return enemies of nation
 								try {
-									return NameUtil.filterByStart(NameUtil.getNames(TownyUniverse.getInstance().getDataSource().getResident(player.getName()).getTown().getNation().getEnemies()), args[2]);
+									return NameUtil.filterByStart(NameUtil.getNames(TownyUniverse.getInstance().getDataSource().getResident(player).getTown().getNation().getEnemies()), args[2]);
 								} catch (TownyException ignored) {}
 						}
 					}
 					break;
 				case "set":
 					try {
-						return nationSetTabComplete(TownyUniverse.getInstance().getDataSource().getResident(player.getName()).getTown().getNation(), args);
+						return nationSetTabComplete(TownyUniverse.getInstance().getDataSource().getResident(player).getTown().getNation(), args);
 					} catch (NotRegisteredException e) {
 						return Collections.emptyList();
 					}
@@ -365,7 +365,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 			if (split.length == 0)
 				Bukkit.getScheduler().runTaskAsynchronously(this.plugin, () -> {
 					try {
-						Resident resident = townyUniverse.getDataSource().getResident(player.getName());
+						Resident resident = townyUniverse.getDataSource().getResident(player);
 						Town town = resident.getTown();
 						Nation nation = town.getNation();
 						TownyMessaging.sendMessage(player, TownyFormatter.getStatus(nation));
@@ -391,7 +391,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 				Nation nation = null;
 				try {
 					if (split.length == 1) {
-						nation = townyUniverse.getDataSource().getResident(player.getName()).getTown().getNation();
+						nation = townyUniverse.getDataSource().getResident(player).getTown().getNation();
 					} else {
 						nation = townyUniverse.getDataSource().getNation(split[1]);
 					}
@@ -410,7 +410,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 				Nation nation = null;
 				try {
 					if (split.length == 1) {
-						nation = townyUniverse.getDataSource().getResident(player.getName()).getTown().getNation();
+						nation = townyUniverse.getDataSource().getResident(player).getTown().getNation();
 					} else {
 						nation = townyUniverse.getDataSource().getNation(split[1]);
 					}
@@ -434,7 +434,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 				Nation nation = null;
 				try {
 					if (split.length == 1) {
-						nation = townyUniverse.getDataSource().getResident(player.getName()).getTown().getNation();
+						nation = townyUniverse.getDataSource().getResident(player).getTown().getNation();
 					} else {
 						nation = townyUniverse.getDataSource().getNation(split[1]);
 					}
@@ -451,7 +451,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 
 			} else if (split[0].equalsIgnoreCase("new")) {
 
-				Resident resident = townyUniverse.getDataSource().getResident(player.getName());
+				Resident resident = townyUniverse.getDataSource().getResident(player);
 
 		        if ((TownySettings.getNumResidentsCreateNation() > 0) && (resident.getTown().getNumResidents() < TownySettings.getNumResidentsCreateNation())) {
 		          TownyMessaging.sendErrorMsg(player, Translation.of("msg_err_not_enough_residents_new_nation"));
@@ -490,7 +490,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 				if (split.length == 1)
 					TownyMessaging.sendErrorMsg(player, Translation.of("msg_specify_nation_name"));
 				else if (split.length == 2) {
-					Resident resident = townyUniverse.getDataSource().getResident(player.getName());
+					Resident resident = townyUniverse.getDataSource().getResident(player);
 					if (!resident.isKing())
 						throw new TownyException(Translation.of("msg_err_merging_for_kings_only"));
 					mergeNation(player, split[1]);
@@ -508,7 +508,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 						throw new TownyException(Translation.of("msg_err_unable_to_use_bank_outside_bank_plot"));
 					TownBlock tb = TownyAPI.getInstance().getTownBlock(player.getLocation());
 					Nation tbNation = tb.getTown().getNation();
-					Nation pNation= townyUniverse.getDataSource().getResident(player.getName()).getTown().getNation();
+					Nation pNation= townyUniverse.getDataSource().getResident(player).getTown().getNation();
 					if ((tbNation != pNation) || (!tb.getTown().isCapital()))
 						throw new TownyException(Translation.of("msg_err_unable_to_use_bank_outside_bank_plot"));
 					boolean goodPlot = false;
@@ -525,7 +525,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 					if (!town.isCapital())
 						throw new TownyException(Translation.of("msg_err_unable_to_use_bank_outside_nation_capital"));
 					Nation nation = town.getNation();
-					if (!townyUniverse.getDataSource().getResident(player.getName()).getTown().getNation().equals(nation))
+					if (!townyUniverse.getDataSource().getResident(player).getTown().getNation().equals(nation))
 						throw new TownyException(Translation.of("msg_err_unable_to_use_bank_outside_nation_capital"));
 				}
 
@@ -570,7 +570,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 					}
 					TownBlock tb = TownyAPI.getInstance().getTownBlock(player.getLocation());
 					Nation tbNation = tb.getTown().getNation();
-					Nation pNation= townyUniverse.getDataSource().getResident(player.getName()).getTown().getNation();
+					Nation pNation= townyUniverse.getDataSource().getResident(player).getTown().getNation();
 					if ((tbNation != pNation) || (!tb.getTown().isCapital()))
 						throw new TownyException(Translation.of("msg_err_unable_to_use_bank_outside_bank_plot"));
 					boolean goodPlot = false;
@@ -587,7 +587,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 					if (!town.isCapital())
 						throw new TownyException(Translation.of("msg_err_unable_to_use_bank_outside_nation_capital"));
 					Nation nation = town.getNation();
-					if (!townyUniverse.getDataSource().getResident(player.getName()).getTown().getNation().equals(nation))
+					if (!townyUniverse.getDataSource().getResident(player).getTown().getNation().equals(nation))
 						throw new TownyException(Translation.of("msg_err_unable_to_use_bank_outside_nation_capital"));
 				}
 
@@ -606,7 +606,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 						throw new TownyException(Translation.of("msg_err_command_disable"));
 					
 					Town town = TownyAPI.getInstance().getDataSource().getTown(split[2]);
-					Nation nation = townyUniverse.getDataSource().getResident(player.getName()).getTown().getNation();
+					Nation nation = townyUniverse.getDataSource().getResident(player).getTown().getNation();
 					if (town != null) {
 						if (!town.hasNation())
 							throw new TownyException(Translation.of("msg_err_not_same_nation", town.getName()));
@@ -702,7 +702,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 						throw new TownyException(Translation.of("msg_err_command_disable"));
 
 					try {
-						Nation nation = townyUniverse.getDataSource().getResident(player.getName()).getTown().getNation();
+						Nation nation = townyUniverse.getDataSource().getResident(player).getTown().getNation();
 						StringBuilder builder = new StringBuilder();
 						for (String s : newSplit) {
 							builder.append(s + " ");
@@ -716,7 +716,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 
 					try {
 						final Nation nation = townyUniverse.getDataSource().getNation(split[0]);
-						Resident resident = townyUniverse.getDataSource().getResident(player.getName());
+						Resident resident = townyUniverse.getDataSource().getResident(player);
 						if (!townyUniverse.getPermissionSource().testPermission(player, PermissionNodes.TOWNY_COMMAND_NATION_OTHERNATION.getNode()) && ( (resident.hasTown() && resident.getTown().hasNation() && (resident.getTown().getNation() != nation) )  || !resident.hasTown() )) {
 							throw new TownyException(Translation.of("msg_err_command_disable"));
 						}
@@ -747,7 +747,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 			nationName = args[0];
 			
 			TownyUniverse townyUniverse = TownyUniverse.getInstance();
-			resident = townyUniverse.getDataSource().getResident(player.getName());
+			resident = townyUniverse.getDataSource().getResident(player);
 			town = resident.getTown();
 			nation = townyUniverse.getDataSource().getNation(nationName);
 
@@ -801,7 +801,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 
 	private void parseInviteCommand(Player player, String[] newSplit) throws TownyException {
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
-		Resident resident = townyUniverse.getDataSource().getResident(player.getName());
+		Resident resident = townyUniverse.getDataSource().getResident(player);
 		String sent = Translation.of("nation_sent_invites")
 				.replace("%a", Integer.toString(resident.getTown().getNation().getSentInvites().size())
 				)
@@ -865,7 +865,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 			}
 		} else {
 			try {
-				Resident resident = townyUniverse.getDataSource().getResident(player.getName());
+				Resident resident = townyUniverse.getDataSource().getResident(player);
 				Town town = resident.getTown();
 				Nation nation = town.getNation();
 				TownyMessaging.sendMessage(player, TownyFormatter.getFormattedOnlineResidents(Translation.of("msg_nation_online"), nation, player));
@@ -899,7 +899,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 			}
 
 			try {
-				resident = townyUniverse.getDataSource().getResident(player.getName());
+				resident = townyUniverse.getDataSource().getResident(player);
 				target = townyUniverse.getDataSource().getResident(split[1]);
 				town = resident.getTown();
 				targetTown = target.getTown();
@@ -989,7 +989,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 			if (amount < 0)
 				throw new TownyException(Translation.of("msg_err_negative_money"));
 
-			resident = TownyUniverse.getInstance().getDataSource().getResident(player.getName());
+			resident = TownyUniverse.getInstance().getDataSource().getResident(player);
 			nation = resident.getTown().getNation();
 
 			boolean underAttack = false;
@@ -1025,7 +1025,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 		Resident resident;
 		Nation nation;
 		try {
-			resident = TownyUniverse.getInstance().getDataSource().getResident(player.getName());
+			resident = TownyUniverse.getInstance().getDataSource().getResident(player);
 			nation = resident.getTown().getNation();
 
 			double bankcap = TownySettings.getNationBankCap();
@@ -1302,7 +1302,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 		
 		try {
 			nation = universe.getDataSource().getNation(name);
-			remainingNation = universe.getDataSource().getResident(player.getName()).getTown().getNation();
+			remainingNation = universe.getDataSource().getResident(player).getTown().getNation();
 		} catch (NotRegisteredException e) {
 			throw new TownyException(Translation.of("msg_err_invalid_name", name));
 		}
@@ -1343,7 +1343,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 		Nation nation = null;
 
 		try {
-			Resident resident = townyUniverse.getDataSource().getResident(player.getName());
+			Resident resident = townyUniverse.getDataSource().getResident(player);
 			town = resident.getTown();
 			nation = town.getNation();
 			
@@ -1374,7 +1374,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
 		if (split.length == 0)
 			try {
-				Resident resident = townyUniverse.getDataSource().getResident(player.getName());
+				Resident resident = townyUniverse.getDataSource().getResident(player);
 				Nation nation = resident.getTown().getNation();
 				Confirmation.runOnAccept(() -> {
 					TownyUniverse.getInstance().getDataSource().removeNation(nation);
@@ -1424,7 +1424,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 		Resident resident;
 		Nation nation;
 		try {
-			resident = townyUniverse.getDataSource().getResident(player.getName());
+			resident = townyUniverse.getDataSource().getResident(player);
 			nation = resident.getTown().getNation();
 
 			if (TownySettings.getMaxTownsPerNation() > 0) {
@@ -1621,7 +1621,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 			if (TownyAPI.getInstance().isWarTime())
 				throw new TownyException(Translation.of("msg_war_cannot_do"));
 			
-			resident = townyUniverse.getDataSource().getResident(player.getName());
+			resident = townyUniverse.getDataSource().getResident(player);
 			nation = resident.getTown().getNation();
 
 		} catch (TownyException x) {
@@ -1674,7 +1674,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 		Resident resident;
 		Nation nation;
 		try {
-			resident = townyUniverse.getDataSource().getResident(player.getName());
+			resident = townyUniverse.getDataSource().getResident(player);
 			nation = resident.getTown().getNation();
 
 		} catch (TownyException x) {
@@ -2062,7 +2062,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 		}
 
 		try {
-			resident = townyUniverse.getDataSource().getResident(player.getName());
+			resident = townyUniverse.getDataSource().getResident(player);
 			nation = resident.getTown().getNation();
 
 		} catch (TownyException x) {
@@ -2182,7 +2182,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 			Resident resident;
 			try {
 				if (!admin) {
-					resident = townyUniverse.getDataSource().getResident(player.getName());
+					resident = townyUniverse.getDataSource().getResident(player);
 					nation = resident.getTown().getNation();
 				} else // treat resident as king for testing purposes.
 					resident = nation.getKing();
@@ -2400,7 +2400,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 					resident = townyUniverse.getDataSource().getResident(split[1]);
 				
 				if (resident.hasNation()) {
-					if (resident.getTown().getNation() != townyUniverse.getDataSource().getResident(player.getName()).getTown().getNation()) {
+					if (resident.getTown().getNation() != townyUniverse.getDataSource().getResident(player).getTown().getNation()) {
 						TownyMessaging.sendErrorMsg(player, Translation.of("msg_err_not_same_nation", resident.getName()));
 						return;
 					}
@@ -2435,7 +2435,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 
 					resident = townyUniverse.getDataSource().getResident(split[1]);
 				if (resident.hasNation()) {
-					if (resident.getTown().getNation() != townyUniverse.getDataSource().getResident(player.getName()).getTown().getNation()) {
+					if (resident.getTown().getNation() != townyUniverse.getDataSource().getResident(player).getTown().getNation()) {
 						TownyMessaging.sendErrorMsg(player, Translation.of("msg_err_not_same_nation", resident.getName()));
 						return;
 					}
@@ -2523,7 +2523,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 
 			try {
 				if (!admin) {
-					resident = townyUniverse.getDataSource().getResident(player.getName());
+					resident = townyUniverse.getDataSource().getResident(player);
 					nation = resident.getTown().getNation();
 				} else  // Treat any resident tests as though the king were doing it.
 					resident = nation.getKing();
@@ -2616,7 +2616,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 
         try {
 
-            Resident resident = townyUniverse.getDataSource().getResident(player.getName());
+            Resident resident = townyUniverse.getDataSource().getResident(player);
             Nation nation;
             String notAffordMSG;
 

--- a/src/com/palmergames/bukkit/towny/command/PlotCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/PlotCommand.java
@@ -223,7 +223,7 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 			String world;
 
 			try {
-				resident = townyUniverse.getDataSource().getResident(player.getName());
+				resident = townyUniverse.getDataSource().getResident(player);
 				world = player.getWorld().getName();
 				//resident.getTown();
 			} catch (TownyException x) {
@@ -1327,7 +1327,7 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
 
-		resident = townyUniverse.getDataSource().getResident(player.getName());
+		resident = townyUniverse.getDataSource().getResident(player);
 		world = player.getWorld().getName();
 		
 		TownBlock townBlock = new WorldCoord(world, Coord.parseCoord(player)).getTownBlock();

--- a/src/com/palmergames/bukkit/towny/command/ResidentCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/ResidentCommand.java
@@ -206,7 +206,7 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 			if (split.length == 0) {
 
 				try {
-					Resident resident = townyUniverse.getDataSource().getResident(player.getName());
+					Resident resident = townyUniverse.getDataSource().getResident(player);
 					TownyMessaging.sendMessage(player, TownyFormatter.getStatus(resident, player));
 				} catch (NotRegisteredException x) {
 					throw new TownyException(Translation.of("msg_err_not_registered"));
@@ -229,7 +229,7 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 					throw new TownyException(Translation.of("msg_err_command_disable"));
 
 				try {
-					Resident resident = townyUniverse.getDataSource().getResident(player.getName());
+					Resident resident = townyUniverse.getDataSource().getResident(player);
 					TownyMessaging.sendMessage(player, TownyFormatter.getTaxStatus(resident));
 				} catch (NotRegisteredException x) {
 					throw new TownyException(Translation.of("msg_err_not_registered"));
@@ -254,13 +254,13 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 					return;
 				}
 
-				if (!townyUniverse.getDataSource().getResident(player.getName()).isJailed()) {
+				if (!townyUniverse.getDataSource().getResident(player).isJailed()) {
 					TownyMessaging.sendErrorMsg(player, Translation.of("msg_err_you_aren't currently jailed"));
 					return;
 				}
 				if (split[1].equalsIgnoreCase("paybail")) {
 					double cost = TownySettings.getBailAmount();					
-					Resident resident = townyUniverse.getDataSource().getResident(player.getName());
+					Resident resident = townyUniverse.getDataSource().getResident(player);
 					if (resident.isMayor())
 						cost = TownySettings.getBailAmountMayor();
 					if (resident.isKing())
@@ -314,7 +314,7 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 				if (!townyUniverse.getPermissionSource().testPermission(player, PermissionNodes.TOWNY_COMMAND_RESIDENT_SPAWN.getNode()))
 					throw new TownyException(Translation.of("msg_err_command_disable"));
 
-				Resident resident = townyUniverse.getDataSource().getResident(player.getName());
+				Resident resident = townyUniverse.getDataSource().getResident(player);
 				SpawnUtil.sendToTownySpawn(player, split, resident, Translation.of("msg_err_cant_afford_tp"), false, false, SpawnType.RESIDENT);
 
 			} else {
@@ -349,7 +349,7 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 		Resident resident;
 
 		try {
-			resident = townyUniverse.getDataSource().getResident(player.getName());
+			resident = townyUniverse.getDataSource().getResident(player);
 
 		} catch (NotRegisteredException e) {
 			// unknown resident
@@ -492,7 +492,7 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 		} else {
 			Resident resident;
 			try {
-				resident = townyUniverse.getDataSource().getResident(player.getName());
+				resident = townyUniverse.getDataSource().getResident(player);
 			} catch (TownyException x) {
 				TownyMessaging.sendErrorMsg(player, x.getMessage());
 				return;
@@ -571,7 +571,7 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 		} else {
 			try {
 				if (!admin)
-					resident = townyUniverse.getDataSource().getResident(player.getName());
+					resident = townyUniverse.getDataSource().getResident(player);
 			} catch (TownyException x) {
 				TownyMessaging.sendErrorMsg(player, x.getMessage());
 				return;

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -231,7 +231,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 									return NameUtil.filterByStart(TownyPerms.getTownRanks(), args[3]);
 								case "remove":
 									try {
-										return NameUtil.filterByStart(TownyUniverse.getInstance().getDataSource().getResident(player.getName()).getTownRanks(), args[3]);
+										return NameUtil.filterByStart(TownyUniverse.getInstance().getDataSource().getResident(player).getTownRanks(), args[3]);
 									} catch (TownyException ignored) {}
 							}
 					}
@@ -246,7 +246,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 									return getTownyStartingWith(args[2], "r");
 								case "remove":
 									try {
-										return NameUtil.filterByStart(NameUtil.getNames(TownyUniverse.getInstance().getDataSource().getResident(player.getName()).getTown().getOutlaws()), args[2]);
+										return NameUtil.filterByStart(NameUtil.getNames(TownyUniverse.getInstance().getDataSource().getResident(player).getTown().getOutlaws()), args[2]);
 									} catch (TownyException ignore) {}
 							}
 					}
@@ -275,7 +275,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 					break;
 				case "set":
 					try {
-						return townSetTabComplete(TownyUniverse.getInstance().getDataSource().getResident(player.getName()).getTown(), args);
+						return townSetTabComplete(TownyUniverse.getInstance().getDataSource().getResident(player).getTown(), args);
 					} catch (TownyException e) {
 						return Collections.emptyList();
 					}
@@ -288,7 +288,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 							} else {
 								if (args[1].startsWith("-")) {
 									try {
-										return NameUtil.filterByStart(TownyUniverse.getInstance().getDataSource().getResident(player.getName()).getTown().getSentInvites()
+										return NameUtil.filterByStart(TownyUniverse.getInstance().getDataSource().getResident(player).getTown().getSentInvites()
 											// Get all sent invites
 											.stream()
 											.map(Invite::getReceiver)
@@ -308,7 +308,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 								case "accept":
 								case "deny":
 									try {
-										return NameUtil.filterByStart(TownyUniverse.getInstance().getDataSource().getResident(player.getName()).getTown().getReceivedInvites()
+										return NameUtil.filterByStart(TownyUniverse.getInstance().getDataSource().getResident(player).getTown().getReceivedInvites()
 											// Get the names of all received invites
 											.stream()
 											.map(Invite::getSender)
@@ -411,7 +411,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 			if (split.length == 0) {
 				Bukkit.getScheduler().runTaskAsynchronously(this.plugin, () -> {
 					try {
-						Resident resident = townyUniverse.getDataSource().getResident(player.getName());
+						Resident resident = townyUniverse.getDataSource().getResident(player);
 						Town town = resident.getTown();
 
 						TownyMessaging.sendMessage(player, TownyFormatter.getStatus(town));
@@ -476,7 +476,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 						throw new TownyException(Translation.of("msg_err_unable_to_use_bank_outside_bank_plot"));
 					TownBlock tb = TownyAPI.getInstance().getTownBlock(player.getLocation());
 					Town tbTown = tb.getTown(); 
-					Town pTown = townyUniverse.getDataSource().getResident(player.getName()).getTown();
+					Town pTown = townyUniverse.getDataSource().getResident(player).getTown();
 					if (tbTown != pTown)
 						throw new TownyException(Translation.of("msg_err_unable_to_use_bank_outside_bank_plot"));
 					boolean goodPlot = false;
@@ -489,7 +489,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 				if (TownySettings.isBankActionDisallowedOutsideTown()) {
 					if (TownyAPI.getInstance().isWilderness(player.getLocation()))
 						throw new TownyException(Translation.of("msg_err_unable_to_use_bank_outside_your_town"));
-					if (!townyUniverse.getDataSource().getResident(player.getName()).getTown().getName().equals(TownyAPI.getInstance().getTownName(player.getLocation()))) 
+					if (!townyUniverse.getDataSource().getResident(player).getTown().getName().equals(TownyAPI.getInstance().getTownName(player.getLocation()))) 
 						throw new TownyException(Translation.of("msg_err_unable_to_use_bank_outside_your_town"));
 				}
 
@@ -516,7 +516,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 					}
 					TownBlock tb = TownyAPI.getInstance().getTownBlock(player.getLocation());
 					Town tbTown = tb.getTown(); 
-					Town pTown = townyUniverse.getDataSource().getResident(player.getName()).getTown();
+					Town pTown = townyUniverse.getDataSource().getResident(player).getTown();
 					if (tbTown != pTown)
 						throw new TownyException(Translation.of("msg_err_unable_to_use_bank_outside_bank_plot"));
 					boolean goodPlot = false;
@@ -530,7 +530,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 					if (TownyAPI.getInstance().isWilderness(player.getLocation())) {
 						throw new TownyException(Translation.of("msg_err_unable_to_use_bank_outside_your_town"));
 					}
-					if (!townyUniverse.getDataSource().getResident(player.getName()).getTown().equals(TownyAPI.getInstance().getTownBlock(player.getLocation()).getTown()))
+					if (!townyUniverse.getDataSource().getResident(player).getTown().equals(TownyAPI.getInstance().getTownBlock(player.getLocation()).getTown()))
 						throw new TownyException(Translation.of("msg_err_unable_to_use_bank_outside_your_town"));
 				}
 
@@ -552,7 +552,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 
 
 					if (split.length == 1) {
-						town = townyUniverse.getDataSource().getResident(player.getName()).getTown();
+						town = townyUniverse.getDataSource().getResident(player).getTown();
 					} else {
 						town = townyUniverse.getDataSource().getTown(split[1]);
 					}
@@ -620,7 +620,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 							if (!townyUniverse.getPermissionSource().testPermission(player, PermissionNodes.TOWNY_COMMAND_TOWN_OUTPOST_LIST.getNode())){
 								throw new TownyException(Translation.of("msg_err_command_disable"));
 							}
-							Resident resident = townyUniverse.getDataSource().getResident(player.getName());
+							Resident resident = townyUniverse.getDataSource().getResident(player);
 							if (resident.hasTown()){
 								Town town = resident.getTown();
 								List<Location> outposts = town.getAllOutpostSpawns();
@@ -703,7 +703,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 					Town town = null;
 					try {
 						if (split.length == 1) {
-							town = townyUniverse.getDataSource().getResident(player.getName()).getTown();
+							town = townyUniverse.getDataSource().getResident(player).getTown();
 						} else {
 							town = townyUniverse.getDataSource().getTown(split[1]);
 						}
@@ -719,7 +719,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 						throw new TownyException(Translation.of("msg_err_command_disable"));
 
 					try {
-						Resident resident = townyUniverse.getDataSource().getResident(player.getName());
+						Resident resident = townyUniverse.getDataSource().getResident(player);
 						Town town = resident.getTown();
 						TownyMessaging.sendMessage(player, TownyFormatter.getRanks(town));
 					} catch (NotRegisteredException x) {
@@ -731,7 +731,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 					Town town;
 					try {
 						if (split.length == 1)
-							town = townyUniverse.getDataSource().getResident(player.getName()).getTown();
+							town = townyUniverse.getDataSource().getResident(player).getTown();
 						else
 							town = townyUniverse.getDataSource().getTown(split[1]);
 					} catch (Exception e) {
@@ -788,7 +788,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 						throw new TownyException(Translation.of("msg_err_command_disable"));
 
 					try {
-						Town town = townyUniverse.getDataSource().getResident(player.getName()).getTown();
+						Town town = townyUniverse.getDataSource().getResident(player).getTown();
 						StringBuilder builder = new StringBuilder();
 						for (String s : newSplit) {
 							builder.append(s + " ");
@@ -803,11 +803,11 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 					if (!townyUniverse.getPermissionSource().testPermission(player, PermissionNodes.TOWNY_COMMAND_TOWN_OUTLAW.getNode()))
 						throw new TownyException(Translation.of("msg_err_command_disable"));
 
-					parseTownOutlawCommand(player, newSplit, false, townyUniverse.getDataSource().getResident(player.getName()).getTown());
+					parseTownOutlawCommand(player, newSplit, false, townyUniverse.getDataSource().getResident(player).getTown());
 				} else {
 					try {
 						final Town town = townyUniverse.getDataSource().getTown(split[0]);
-						Resident resident = townyUniverse.getDataSource().getResident(player.getName());
+						Resident resident = townyUniverse.getDataSource().getResident(player);
 						if (!townyUniverse.getPermissionSource().testPermission(player, PermissionNodes.TOWNY_COMMAND_TOWN_OTHERTOWN.getNode()) && ( (resident.getTown() != town) || (!resident.hasTown()) ) ) {
 							throw new TownyException(Translation.of("msg_err_command_disable"));
 						}
@@ -829,7 +829,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
 		// We know he has the main permission to manage this stuff. So Let's continue:
 
-		Resident resident = townyUniverse.getDataSource().getResident(player.getName());
+		Resident resident = townyUniverse.getDataSource().getResident(player);
 
 		String received = Translation.of("town_received_invites")
 				.replace("%a", Integer.toString(resident.getTown().getReceivedInvites().size())
@@ -1170,7 +1170,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 			}
 		} else {
 			try {
-				Resident resident = townyUniverse.getDataSource().getResident(player.getName());
+				Resident resident = townyUniverse.getDataSource().getResident(player);
 				Town town = resident.getTown();
 				TownyMessaging.sendMessage(player, TownyFormatter.getFormattedOnlineResidents(Translation.of("msg_town_online"), town, player));
 			} catch (NotRegisteredException x) {
@@ -1426,7 +1426,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 				boolean outsiderintown = false;
 				if (TownySettings.getOutsidersPreventPVPToggle()) {
 					for (Player target : Bukkit.getOnlinePlayers()) {
-						Resident targetresident = townyUniverse.getDataSource().getResident(target.getName());
+						Resident targetresident = townyUniverse.getDataSource().getResident(target);
 						Block block = target.getLocation().getBlock().getRelative(BlockFace.DOWN);
 						if (!TownyAPI.getInstance().isWilderness(block.getLocation())) {
 							WorldCoord coord = WorldCoord.parseWorldCoord(target.getLocation());
@@ -1637,7 +1637,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 				throw new TownyException("Eg: /town rank add/remove [resident] [rank]");
 
 			try {
-				resident = townyUniverse.getDataSource().getResident(player.getName());
+				resident = townyUniverse.getDataSource().getResident(player);
 				target = townyUniverse.getDataSource().getResident(split[1]);
 				town = resident.getTown();
 
@@ -1744,7 +1744,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 
 			try {
 				if (!admin) {
-					resident = townyUniverse.getDataSource().getResident(player.getName());
+					resident = townyUniverse.getDataSource().getResident(player);
 					town = resident.getTown();
 				} else // Have the resident being tested be the mayor.
 					resident = town.getMayor();
@@ -1790,7 +1790,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 					resident = townyUniverse.getDataSource().getResident(split[1]);
 				
 				if (resident.hasTown()) {
-					if (resident.getTown() != townyUniverse.getDataSource().getResident(player.getName()).getTown()) {
+					if (resident.getTown() != townyUniverse.getDataSource().getResident(player).getTown()) {
 						TownyMessaging.sendErrorMsg(player, Translation.of("msg_err_not_same_town", resident.getName()));
 						return;
 					}
@@ -1844,7 +1844,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 
 					resident = townyUniverse.getDataSource().getResident(split[1]);
 				if (resident.hasTown()) {
-					if (resident.getTown() != townyUniverse.getDataSource().getResident(player.getName()).getTown()) {
+					if (resident.getTown() != townyUniverse.getDataSource().getResident(player).getTown()) {
 						TownyMessaging.sendErrorMsg(player, Translation.of("msg_err_not_same_town", resident.getName()));
 						return;
 					}
@@ -2301,7 +2301,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 		Resident resident;
 		Town town;
 		try {
-			resident = townyUniverse.getDataSource().getResident(player.getName());
+			resident = townyUniverse.getDataSource().getResident(player);
 			town = resident.getTown();
 
 		} catch (TownyException x) {
@@ -2580,7 +2580,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 			if (TownyAPI.getInstance().isWarTime())
 				throw new TownyException(Translation.of("msg_war_cannot_do"));
 
-			resident = townyUniverse.getDataSource().getResident(player.getName());
+			resident = townyUniverse.getDataSource().getResident(player);
 			town = resident.getTown();
 			
 			if (FlagWar.isUnderAttack(town) && TownySettings.isFlaggedInteractionTown()) {
@@ -2665,7 +2665,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 		
 		try {
 
-			Resident resident = townyUniverse.getDataSource().getResident(player.getName());
+			Resident resident = townyUniverse.getDataSource().getResident(player);
 			Town town;
 			String notAffordMSG;
 
@@ -2702,7 +2702,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 
 		if (split.length == 0) {
 			try {
-				Resident resident = townyUniverse.getDataSource().getResident(player.getName());
+				Resident resident = townyUniverse.getDataSource().getResident(player);
 				town = resident.getTown();
 				Confirmation.runOnAccept(() -> {
 					TownyMessaging.sendGlobalMessage(TownySettings.getDelTownMsg(town));
@@ -2742,7 +2742,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 		Resident resident;
 		Town town;
 		try {
-			resident = TownyUniverse.getInstance().getDataSource().getResident(player.getName());
+			resident = TownyUniverse.getInstance().getDataSource().getResident(player);
 			town = resident.getTown();
 		} catch (TownyException x) {
 			TownyMessaging.sendErrorMsg(player, x.getMessage());
@@ -2929,7 +2929,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 			msg = new StringBuilder(Translation.of("msg_kicked", (player != null) ? player.getName() : "CONSOLE", msg.toString()));
 			TownyMessaging.sendPrefixedTownMessage(town, msg.toString());
 			try {
-				if (!(sender instanceof Player) || !townyUniverse.getDataSource().getResident(player.getName()).hasTown() || !TownyUniverse.getInstance().getDataSource().getResident(player.getName()).getTown().equals(town))
+				if (!(sender instanceof Player) || !townyUniverse.getDataSource().getResident(player).hasTown() || !TownyUniverse.getInstance().getDataSource().getResident(player).getTown().equals(town))
 					// For when the an admin uses /ta town {name} kick {residents}
 					TownyMessaging.sendMessage(sender, msg.toString());
 			} catch (NotRegisteredException e) {
@@ -3324,7 +3324,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 					throw new TownyException(Translation.of("msg_war_cannot_do"));
 				}
 
-				resident = townyUniverse.getDataSource().getResident(player.getName());
+				resident = townyUniverse.getDataSource().getResident(player);
 				town = resident.getTown();
 				world = townyUniverse.getDataSource().getWorld(player.getWorld().getName());
 
@@ -3444,7 +3444,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 				if (TownyAPI.getInstance().isWarTime())
 					throw new TownyException(Translation.of("msg_war_cannot_do"));
 
-				resident = townyUniverse.getDataSource().getResident(player.getName());
+				resident = townyUniverse.getDataSource().getResident(player);
 				town = resident.getTown();
 				world = townyUniverse.getDataSource().getWorld(player.getWorld().getName());
 
@@ -3564,7 +3564,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 			if (amount < 0)
 				throw new TownyException(Translation.of("msg_err_negative_money"));
 
-			resident = TownyUniverse.getInstance().getDataSource().getResident(player.getName());
+			resident = TownyUniverse.getInstance().getDataSource().getResident(player);
 			town = resident.getTown();
 
 			if (System.currentTimeMillis()- FlagWar.lastFlagged(town) < TownySettings.timeToWaitAfterFlag())
@@ -3592,7 +3592,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 		Resident resident;
 		Town town;
 		try {
-			resident = TownyUniverse.getInstance().getDataSource().getResident(player.getName());
+			resident = TownyUniverse.getInstance().getDataSource().getResident(player);
 			town = resident.getTown();
 
 			double bankcap = TownySettings.getTownBankCap();
@@ -3633,7 +3633,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 	 */
 	public static void townDeposit(Player player, Town town, int amount) {
 		try {
-			Resident resident = TownyAPI.getInstance().getDataSource().getResident(player.getName());			
+			Resident resident = TownyAPI.getInstance().getDataSource().getResident(player);			
 			
 			double bankcap = TownySettings.getTownBankCap();
 			if (bankcap > 0) {

--- a/src/com/palmergames/bukkit/towny/command/TownyCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyCommand.java
@@ -218,7 +218,7 @@ public class TownyCommand extends BaseCommand implements CommandExecutor {
 					}
 				} else if (split.length == 1)
 					try {
-						Resident resident = townyUniverse.getDataSource().getResident(player.getName());
+						Resident resident = townyUniverse.getDataSource().getResident(player);
 						town = resident.getTown();
 					} catch (NotRegisteredException e) {
 					}
@@ -260,7 +260,7 @@ public class TownyCommand extends BaseCommand implements CommandExecutor {
 				towny_war.clear();
 			} else if (split[0].equalsIgnoreCase("spy")) {
 				if (townyUniverse.getPermissionSource().has(player, PermissionNodes.TOWNY_CHAT_SPY.getNode())) {
-					Resident resident = townyUniverse.getDataSource().getResident(player.getName());
+					Resident resident = townyUniverse.getDataSource().getResident(player);
 					resident.toggleMode(split, true);
 				} else
 					TownyMessaging.sendErrorMsg(player, Translation.of("msg_err_command_disable"));
@@ -313,10 +313,10 @@ public class TownyCommand extends BaseCommand implements CommandExecutor {
 		String townLine;
 		for (Nation nations : nationsToSort) {
 			nationLine = Colors.Gold + "-" + nations.getName();
-			if (townyUniverse.getDataSource().getResident(player.getName()).hasNation())
-				if (townyUniverse.getDataSource().getResident(player.getName()).getTown().getNation().hasEnemy(nations))
+			if (townyUniverse.getDataSource().getResident(player).hasNation())
+				if (townyUniverse.getDataSource().getResident(player).getTown().getNation().hasEnemy(nations))
 					nationLine += Colors.Red + " (Enemy)";
-				else if (townyUniverse.getDataSource().getResident(player.getName()).getTown().getNation().hasAlly(nations))
+				else if (townyUniverse.getDataSource().getResident(player).getTown().getNation().hasAlly(nations))
 					nationLine += Colors.Green + " (Ally)";
 			output.add(nationLine);
 			for (Town towns : townsToSort) {

--- a/src/com/palmergames/bukkit/towny/command/TownyWorldCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyWorldCommand.java
@@ -256,7 +256,7 @@ public class TownyWorldCommand extends BaseCommand implements CommandExecutor {
 //
 //				if (player != null)
 //					try {
-//						TownyUniverse.getDataSource().getResident(player.getName()).regenUndo();
+//						TownyUniverse.getDataSource().getResident(player).regenUndo();
 //					} catch (NotRegisteredException e) {
 //						// Failed to get resident
 //					}

--- a/src/com/palmergames/bukkit/towny/db/TownyDataSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyDataSource.java
@@ -266,6 +266,10 @@ public abstract class TownyDataSource {
 
 	abstract public Resident getResident(String name) throws NotRegisteredException;
 
+	public Resident getResident(Player player) throws NotRegisteredException {
+		return getResident(player.getName());
+	}
+
 	abstract public void removeNation(Nation nation);
 
 	abstract public boolean hasResident(String name);

--- a/src/com/palmergames/bukkit/towny/event/TownClaimEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/TownClaimEvent.java
@@ -32,7 +32,7 @@ public class TownClaimEvent extends Event  {
     	super(!Bukkit.getServer().isPrimaryThread());
         this.townBlock = townBlock;
 		try {
-			this.resident = TownyUniverse.getInstance().getDataSource().getResident(player.getName());
+			this.resident = TownyUniverse.getInstance().getDataSource().getResident(player);
 		} catch (NotRegisteredException e) {
 			e.printStackTrace();
 		}

--- a/src/com/palmergames/bukkit/towny/huds/WarHUD.java
+++ b/src/com/palmergames/bukkit/towny/huds/WarHUD.java
@@ -87,7 +87,7 @@ public class WarHUD {
 	public static void updateHomeTown(Player p) {
 		String homeTown;
 		try {
-			homeTown = TownyUniverse.getInstance().getDataSource().getResident(p.getName()).getTown().getName();
+			homeTown = TownyUniverse.getInstance().getDataSource().getResident(p).getTown().getName();
 		} catch (NotRegisteredException e) {
 			homeTown = Translation.of("war_hud_townless");
 		}
@@ -97,7 +97,7 @@ public class WarHUD {
 	public static void updateScore(Player p, War war) {
 		String score;
 		try {
-			Town home = TownyUniverse.getInstance().getDataSource().getResident(p.getName()).getTown();
+			Town home = TownyUniverse.getInstance().getDataSource().getResident(p).getTown();
 			Hashtable<Town, Integer> scores = war.getTownScores();
 			if (scores.containsKey(home))
 				score = scores.get(home) + "";

--- a/src/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
@@ -68,7 +68,7 @@ public class TownyCustomListener implements Listener {
 		// Check if player has entered a new town/wilderness
 		try {
 			if (to.getTownyWorld().isUsingTowny() && TownySettings.getShowTownNotifications()) {
-				Resident resident = TownyUniverse.getInstance().getDataSource().getResident(player.getName());
+				Resident resident = TownyUniverse.getInstance().getDataSource().getResident(player);
 				ChunkNotification chunkNotifier = new ChunkNotification(from, to);
 				String msg = null;
 				try {

--- a/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
@@ -146,16 +146,19 @@ public class TownyEntityListener implements Listener {
 				if (!(attacker instanceof Player) || !(defender instanceof Player)) {
 					return;
 				}
+				Player attackerPlayer = (Player) attacker;
+				Player defenderPlayer = (Player) defender; 
+				
 				TownyUniverse universe = TownyUniverse.getInstance();
 				//Cancel because one of two players has no town and should not be interfering during war.
-				if (!universe.getDataSource().getResident(attacker.getName()).hasTown() || !universe.getDataSource().getResident(defender.getName()).hasTown()){
+				if (!universe.getDataSource().getResident(attackerPlayer).hasTown() || !universe.getDataSource().getResident(defenderPlayer).hasTown()){
 					TownyMessaging.sendMessage(attacker, TownySettings.getWarAPlayerHasNoTownMsg());
 					event.setCancelled(true);
 					return;
 				}
 				try {
-					Town attackerTown = universe.getDataSource().getResident(attacker.getName()).getTown();
-					Town defenderTown = universe.getDataSource().getResident(defender.getName()).getTown();
+					Town attackerTown = universe.getDataSource().getResident(attackerPlayer).getTown();
+					Town defenderTown = universe.getDataSource().getResident(defenderPlayer).getTown();
 	
 					//Cancel because one of the two players' town has no nation and should not be interfering during war.  AND towns_are_neutral is true in the config.
 					if ((!attackerTown.hasNation() || !defenderTown.hasNation()) && TownySettings.isWarTimeTownsNeutral()) {
@@ -187,7 +190,7 @@ public class TownyEntityListener implements Listener {
 				} catch (NotRegisteredException e) {
 					//One of the players has no nation.
 				}
-				if (CombatUtil.preventFriendlyFire((Player) attacker, (Player) defender)) {
+				if (CombatUtil.preventFriendlyFire(attackerPlayer, defenderPlayer)) {
 					// Remove the projectile here so no
 					// other events can fire to cause damage
 					if (attacker instanceof Projectile)

--- a/src/com/palmergames/bukkit/towny/listeners/TownyEntityMonitorListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyEntityMonitorListener.java
@@ -98,7 +98,7 @@ public class TownyEntityMonitorListener implements Listener {
 			Player defenderPlayer = (Player) defenderEntity;
 			Resident defenderResident;
 			try {
-				defenderResident = townyUniverse.getDataSource().getResident(defenderPlayer.getName());
+				defenderResident = townyUniverse.getDataSource().getResident(defenderPlayer);
 			} catch (NotRegisteredException e1) {
 				// Usually an NPC or a Bot of some kind.
 				return;
@@ -118,7 +118,7 @@ public class TownyEntityMonitorListener implements Listener {
 					if (projectile.getShooter() instanceof Player) { // Player shot a projectile.
 						attackerPlayer = (Player) projectile.getShooter();
 						try {
-							attackerResident = townyUniverse.getDataSource().getResident(attackerPlayer.getName());
+							attackerResident = townyUniverse.getDataSource().getResident(attackerPlayer);
 						} catch (NotRegisteredException e) {
 							// Usually an NPC or a Bot of some kind.
 							attackerPlayer = null;
@@ -134,7 +134,7 @@ public class TownyEntityMonitorListener implements Listener {
 					// This was a player kill
 					attackerPlayer = (Player) attackerEntity;
 					try {
-						attackerResident = townyUniverse.getDataSource().getResident(attackerPlayer.getName());
+						attackerResident = townyUniverse.getDataSource().getResident(attackerPlayer);
 					} catch (NotRegisteredException e) {
 						// Usually an NPC or a Bot of some kind.
 						attackerPlayer = null;

--- a/src/com/palmergames/bukkit/towny/listeners/TownyLoginListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyLoginListener.java
@@ -26,7 +26,7 @@ public class TownyLoginListener implements Listener {
 		
 		if (player.getName().startsWith(npcPrefix)) {
 			if (townyUniverse.getDataSource().hasResident(player.getName()))
-			    if (townyUniverse.getDataSource().getResident(player.getName()).isMayor()){
+			    if (townyUniverse.getDataSource().getResident(player).isMayor()){
 			    	// Deny because this is an NPC account which is a mayor of a town.
 			    	event.disallow(null, "Towny is preventing you from logging in using this account name.");
 			    	disallowed = true;

--- a/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -130,9 +130,10 @@ public class TownyPlayerListener implements Listener {
 			return;
 		}
 		
+		Player quittingPlayer = event.getPlayer();
 		TownyDataSource dataSource = TownyUniverse.getInstance().getDataSource();
 		try {
-			Resident resident = dataSource.getResident(event.getPlayer().getName());
+			Resident resident = dataSource.getResident(quittingPlayer);
 			resident.setLastOnline(System.currentTimeMillis());
 			resident.clearModes();
 			dataSource.saveResident(resident);
@@ -142,13 +143,13 @@ public class TownyPlayerListener implements Listener {
 		// Remove from teleport queue (if exists)
 		try {
 			if (TownyTimerHandler.isTeleportWarmupRunning()) {
-				TownyAPI.getInstance().abortTeleportRequest(dataSource.getResident(event.getPlayer().getName().toLowerCase()));
+				TownyAPI.getInstance().abortTeleportRequest(dataSource.getResident(quittingPlayer));
 			}
 		} catch (NotRegisteredException ignored) {
 		}
 
-		plugin.deleteCache(event.getPlayer());
-		TownyPerms.removeAttachment(event.getPlayer().getName());
+		plugin.deleteCache(quittingPlayer);
+		TownyPerms.removeAttachment(quittingPlayer.getName());
 	}
 	
 	@EventHandler(priority = EventPriority.NORMAL)
@@ -200,7 +201,7 @@ public class TownyPlayerListener implements Listener {
 	
 		try {
 			Location respawn = null;			
-			Resident resident = townyUniverse.getDataSource().getResident(event.getPlayer().getName());
+			Resident resident = townyUniverse.getDataSource().getResident(event.getPlayer());
 			// If player is jailed send them to their jailspawn.
 			if (resident.isJailed()) {
 				Town respawnTown = townyUniverse.getDataSource().getTown(resident.getJailTown());
@@ -561,7 +562,7 @@ public class TownyPlayerListener implements Listener {
 		PlayerCache cache = plugin.getCache(player);
 		Resident resident = null;
 		try {
-			resident = townyUniverse.getDataSource().getResident(player.getName());
+			resident = townyUniverse.getDataSource().getResident(player);
 		} catch (NotRegisteredException ignored) {
 		}
 		
@@ -613,7 +614,7 @@ public class TownyPlayerListener implements Listener {
 		Player player = event.getPlayer();
 		// Cancel teleport if Jailed by Towny.
 		try {
-			if (TownyUniverse.getInstance().getDataSource().getResident(player.getName()).isJailed()) {
+			if (TownyUniverse.getInstance().getDataSource().getResident(player).isJailed()) {
 				if ((event.getCause() == TeleportCause.COMMAND)) {
 					TownyMessaging.sendErrorMsg(event.getPlayer(), Translation.of("msg_err_jailed_players_no_teleport"));
 					event.setCancelled(true);
@@ -675,7 +676,7 @@ public class TownyPlayerListener implements Listener {
 
 		try {
 			
-			Resident resident = TownyUniverse.getInstance().getDataSource().getResident(event.getPlayer().getName());
+			Resident resident = TownyUniverse.getInstance().getDataSource().getResident(event.getPlayer());
 			
 			WorldCoord worldCoord = new WorldCoord(event.getPlayer().getWorld().getName(), Coord.parseCoord(event.getBed().getLocation()));
 
@@ -899,7 +900,7 @@ public class TownyPlayerListener implements Listener {
 		try {
 			@SuppressWarnings("unused")
 			// Required so we don't fire events on NPCs from plugins like citizens.
-			Resident resident = TownyUniverse.getInstance().getDataSource().getResident(player.getName());
+			Resident resident = TownyUniverse.getInstance().getDataSource().getResident(player);
 			try {
 				to.getTownBlock();
 				if (to.getTownBlock().hasTown()) { 
@@ -936,7 +937,7 @@ public class TownyPlayerListener implements Listener {
 		
 		Player player = event.getPlayer();		
 		WorldCoord to = event.getTo();
-		Resident resident = TownyUniverse.getInstance().getDataSource().getResident(player.getName());
+		Resident resident = TownyUniverse.getInstance().getDataSource().getResident(player);
 
 		if (to.getTownBlock().getTown().hasOutlaw(resident))
 			TownyMessaging.sendMsg(player, Translation.of("msg_you_are_an_outlaw_in_this_town", to.getTownBlock().getTown()));
@@ -1003,7 +1004,7 @@ public class TownyPlayerListener implements Listener {
 	@EventHandler(priority = EventPriority.NORMAL)
 	public void onPlayerEnterTown(PlayerEnterTownEvent event) throws TownyException {
 		
-		Resident resident = TownyUniverse.getInstance().getDataSource().getResident(event.getPlayer().getName());
+		Resident resident = TownyUniverse.getInstance().getDataSource().getResident(event.getPlayer());
 		WorldCoord to = event.getTo();
 		if (TownySettings.isNotificationUsingTitles()) {
 			String title = ChatColor.translateAlternateColorCodes('&', TownySettings.getNotificationTitlesTownTitle());
@@ -1036,7 +1037,7 @@ public class TownyPlayerListener implements Listener {
 	public void onPlayerLeaveTown(PlayerLeaveTownEvent event) throws TownyException {
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
 		
-		Resident resident = townyUniverse.getDataSource().getResident(event.getPlayer().getName());
+		Resident resident = townyUniverse.getDataSource().getResident(event.getPlayer());
 		WorldCoord to = event.getTo();
 		if (TownySettings.isNotificationUsingTitles()) {
 			try {
@@ -1056,7 +1057,7 @@ public class TownyPlayerListener implements Listener {
 		}
 
 		Player player = event.getPlayer();
-		if (townyUniverse.getDataSource().getResident(player.getName()).isJailed()) {
+		if (townyUniverse.getDataSource().getResident(player).isJailed()) {
 			resident.freeFromJail(resident.getJailSpawn(), true);
 			townyUniverse.getDataSource().saveResident(resident);
 		}		
@@ -1096,7 +1097,7 @@ public class TownyPlayerListener implements Listener {
 		}
 		Resident resident = null;
 		try {
-			resident = TownyAPI.getInstance().getDataSource().getResident(event.getPlayer().getName());
+			resident = TownyAPI.getInstance().getDataSource().getResident(event.getPlayer());
 		} catch (NotRegisteredException e) {
 			// More than likely another plugin using a fake player to run a command. 
 		} 

--- a/src/com/palmergames/bukkit/towny/permissions/TownyPerms.java
+++ b/src/com/palmergames/bukkit/towny/permissions/TownyPerms.java
@@ -96,7 +96,7 @@ public class TownyPerms {
 
 		if (resident == null) {
 			try {
-				resident = townyUniverse.getDataSource().getResident(player.getName());
+				resident = townyUniverse.getDataSource().getResident(player);
 			} catch (NotRegisteredException e) {
 				// failed to get resident
 				e.printStackTrace();

--- a/src/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
+++ b/src/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
@@ -248,7 +248,7 @@ public class TownyRegenAPI {
 //				}
 //			}
 //			
-//			TownyUniverse.getDataSource().getResident(player.getName()).addUndo(snapshot);
+//			TownyUniverse.getDataSource().getResident(player).addUndo(snapshot);
 //
 //			Bukkit.getWorld(player.getWorld().getName()).regenerateChunk(coord.getX(), coord.getZ());
 //

--- a/src/com/palmergames/bukkit/towny/tasks/HealthRegenTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/HealthRegenTimerTask.java
@@ -42,7 +42,7 @@ public class HealthRegenTimerTask extends TownyTimerTask {
 				
 				TownBlock townBlock = TownyUniverse.getInstance().getTownBlock(new WorldCoord(WorldCoord.parseWorldCoord(player.getLocation())));
 				
-				if (townBlock != null && CombatUtil.isAlly(townBlock.getTown(), TownyUniverse.getInstance().getDataSource().getResident(player.getName()).getTown()))
+				if (townBlock != null && CombatUtil.isAlly(townBlock.getTown(), TownyUniverse.getInstance().getDataSource().getResident(player).getTown()))
 					if (!townBlock.getType().equals(TownBlockType.ARENA)) // only regen if not in an arena
 						incHealth(player);
 			} catch (TownyException x) {

--- a/src/com/palmergames/bukkit/towny/tasks/OnPlayerLogin.java
+++ b/src/com/palmergames/bukkit/towny/tasks/OnPlayerLogin.java
@@ -55,7 +55,7 @@ public class OnPlayerLogin implements Runnable {
 			 */
 			try {
 				universe.getDataSource().newResident(player.getName());
-				resident = universe.getDataSource().getResident(player.getName());
+				resident = universe.getDataSource().getResident(player);
 				
 				if (TownySettings.isShowingRegistrationMessage())				
 					TownyMessaging.sendMessage(player, Translation.of("msg_registration", player.getName()));
@@ -83,7 +83,7 @@ public class OnPlayerLogin implements Runnable {
 			 * This resident is known so fetch the data and update it.
 			 */
 			try {
-				resident = universe.getDataSource().getResident(player.getName());
+				resident = universe.getDataSource().getResident(player);
 				if (TownySettings.isUsingEssentials()) {
 					Essentials ess = (Essentials) Bukkit.getPluginManager().getPlugin("Essentials");
 					/*

--- a/src/com/palmergames/bukkit/towny/tasks/TownClaim.java
+++ b/src/com/palmergames/bukkit/towny/tasks/TownClaim.java
@@ -129,7 +129,7 @@ public class TownClaim extends Thread {
 
 			Resident resident = null;
 			try {
-				resident = townyUniverse.getDataSource().getResident(player.getName());
+				resident = townyUniverse.getDataSource().getResident(player);
 			} catch (TownyException e) {
 				// Yeah the resident has to exist!
 			}

--- a/src/com/palmergames/bukkit/towny/utils/CombatUtil.java
+++ b/src/com/palmergames/bukkit/towny/utils/CombatUtil.java
@@ -572,7 +572,7 @@ public class CombatUtil {
 	public boolean isEnemyTownBlock(Player player, WorldCoord worldCoord) {
 
 		try {
-			return CombatUtil.isEnemy(TownyUniverse.getInstance().getDataSource().getResident(player.getName()).getTown(), worldCoord.getTownBlock().getTown());
+			return CombatUtil.isEnemy(TownyUniverse.getInstance().getDataSource().getResident(player).getTown(), worldCoord.getTownBlock().getTown());
 		} catch (NotRegisteredException e) {
 			return false;
 		}

--- a/src/com/palmergames/bukkit/towny/utils/PlayerCacheUtil.java
+++ b/src/com/palmergames/bukkit/towny/utils/PlayerCacheUtil.java
@@ -281,7 +281,7 @@ public class PlayerCacheUtil {
 		 */
 		Resident resident = null;
 		try {
-			resident = TownyUniverse.getInstance().getDataSource().getResident(player.getName());
+			resident = TownyUniverse.getInstance().getDataSource().getResident(player);
 		} catch (TownyException e) {
 			// Check if entity is a Citizens NPC
 			if (plugin.isCitizens2()) {
@@ -400,7 +400,7 @@ public class PlayerCacheUtil {
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
 
 		try {
-			playersTown = townyUniverse.getDataSource().getResident(player.getName()).getTown();
+			playersTown = townyUniverse.getDataSource().getResident(player).getTown();
 		} catch (NotRegisteredException e) {
 		}
 

--- a/src/com/palmergames/bukkit/towny/utils/ResidentUtil.java
+++ b/src/com/palmergames/bukkit/towny/utils/ResidentUtil.java
@@ -66,7 +66,7 @@ public class ResidentUtil {
 			} else if (matches.size() == 1) {
 				// Match found online
 				try {
-					Resident target = townyUniverse.getDataSource().getResident(matches.get(0).getName());
+					Resident target = townyUniverse.getDataSource().getResident(matches.get(0));
 					residents.add(target);
 				} catch (TownyException x) {
 					TownyMessaging.sendErrorMsg(sender, x.getMessage());

--- a/src/com/palmergames/bukkit/towny/utils/ShopPlotUtil.java
+++ b/src/com/palmergames/bukkit/towny/utils/ShopPlotUtil.java
@@ -31,7 +31,7 @@ public class ShopPlotUtil {
 	public static boolean doesPlayerOwnShopPlot(Player player, Location location) {
 		boolean owner = false;
 		try {
-			owner = TownyAPI.getInstance().getTownBlock(location).getResident().equals(TownyAPI.getInstance().getDataSource().getResident(player.getName()));
+			owner = TownyAPI.getInstance().getTownBlock(location).getResident().equals(TownyAPI.getInstance().getDataSource().getResident(player));
 		} catch (NotRegisteredException e) {
 			return false;
 		} catch (NullPointerException npe) {

--- a/src/com/palmergames/bukkit/towny/utils/SpawnUtil.java
+++ b/src/com/palmergames/bukkit/towny/utils/SpawnUtil.java
@@ -61,7 +61,7 @@ public class SpawnUtil {
 	public static void sendToTownySpawn(Player player, String[] split, TownyObject townyObject, String notAffordMSG, boolean outpost, boolean ignoreWarn, SpawnType spawnType) throws TownyException {
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
 
-		Resident resident = townyUniverse.getDataSource().getResident(player.getName());
+		Resident resident = townyUniverse.getDataSource().getResident(player);
 		// Test if the resident is in a teleport cooldown.
 		if (TownySettings.getSpawnCooldownTime() > 0
 				&& CooldownTimerTask.hasCooldown(resident.getName(), CooldownType.TELEPORT))

--- a/src/com/palmergames/bukkit/towny/war/eventwar/War.java
+++ b/src/com/palmergames/bukkit/towny/war/eventwar/War.java
@@ -462,7 +462,7 @@ public class War {
 		String healString =  Colors.Gray + "[Heal](" + townBlock.getCoord().toString() + ") HP: " + hp + " (" + Colors.LightGreen + "+" + healthChange + Colors.Gray + ")";
 		TownyMessaging.sendMessageToMode(townBlock.getTown(), healString, "");
 		for (Player p : wzd.getDefenders()) {
-			if (com.palmergames.bukkit.towny.TownyUniverse.getInstance().getDataSource().getResident(p.getName()).getTown() != townBlock.getTown())
+			if (com.palmergames.bukkit.towny.TownyUniverse.getInstance().getDataSource().getResident(p).getTown() != townBlock.getTown())
 				TownyMessaging.sendMessage(p, healString);
 		}
 		launchFireworkAtPlot (townBlock, wzd.getRandomDefender(), Type.BALL, Color.LIME);
@@ -481,7 +481,7 @@ public class War {
 	private void attackPlot(TownBlock townBlock, WarZoneData wzd) throws NotRegisteredException {
 
 		Player attackerPlayer = wzd.getRandomAttacker();
-		Resident attackerResident = com.palmergames.bukkit.towny.TownyUniverse.getInstance().getDataSource().getResident(attackerPlayer.getName());
+		Resident attackerResident = com.palmergames.bukkit.towny.TownyUniverse.getInstance().getDataSource().getResident(attackerPlayer);
 		Town attacker = attackerResident.getTown();
 
 		//Health, messaging, fireworks..

--- a/src/com/palmergames/bukkit/towny/war/eventwar/WarTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/war/eventwar/WarTimerTask.java
@@ -47,7 +47,7 @@ public class WarTimerTask extends TownyTimerTask {
 				numPlayers += 1;
 				TownyMessaging.sendDebugMsg("[War] " + player.getName() + ": ");
 				try {
-					Resident resident = TownyUniverse.getInstance().getDataSource().getResident(player.getName());
+					Resident resident = TownyUniverse.getInstance().getDataSource().getResident(player);
 					if (!resident.hasTown() || !warEvent.isWarringTown(resident.getTown()))
 						continue;
 					

--- a/src/com/palmergames/bukkit/towny/war/eventwar/WarUtil.java
+++ b/src/com/palmergames/bukkit/towny/war/eventwar/WarUtil.java
@@ -18,7 +18,7 @@ public class WarUtil {
 	public static boolean isPlayerNeutral(Player player) {
 		if (TownyAPI.getInstance().isWarTime()) {
 			try {
-				Resident resident = TownyUniverse.getInstance().getDataSource().getResident(player.getName());
+				Resident resident = TownyUniverse.getInstance().getDataSource().getResident(player);
 				if (resident.isJailed())
 					return true;
 				if (resident.hasTown())

--- a/src/com/palmergames/bukkit/towny/war/eventwar/WarZoneData.java
+++ b/src/com/palmergames/bukkit/towny/war/eventwar/WarZoneData.java
@@ -29,7 +29,7 @@ public class WarZoneData {
 	
 	public void addAttacker (Player p) throws NotRegisteredException {
 		if (!p.isDead()){
-			Resident resident = TownyUniverse.getInstance().getDataSource().getResident(p.getName());
+			Resident resident = TownyUniverse.getInstance().getDataSource().getResident(p);
 			attackerTowns.add(resident.getTown());
 			allPlayers.add(p);
 			attackers.add(p);

--- a/src/com/palmergames/bukkit/towny/war/flagwar/FlagWar.java
+++ b/src/com/palmergames/bukkit/towny/war/flagwar/FlagWar.java
@@ -244,7 +244,7 @@ public class FlagWar {
 		TownBlock townBlock;
 
 		try {
-			attackingResident = townyUniverse.getDataSource().getResident(player.getName());
+			attackingResident = townyUniverse.getDataSource().getResident(player);
 			attackingTown = attackingResident.getTown();
 			attackingNation = attackingTown.getNation();
 		} catch (NotRegisteredException e) {

--- a/src/com/palmergames/bukkit/towny/war/flagwar/listeners/FlagWarCustomListener.java
+++ b/src/com/palmergames/bukkit/towny/war/flagwar/listeners/FlagWarCustomListener.java
@@ -75,7 +75,7 @@ public class FlagWarCustomListener implements Listener {
 		} else {
 			playerName = player.getName();
 			try {
-				playerName = universe.getDataSource().getResident(player.getName()).getFormattedName();
+				playerName = universe.getDataSource().getResident(player).getFormattedName();
 			} catch (TownyException ignored) {
 			}
 		}
@@ -91,7 +91,7 @@ public class FlagWarCustomListener implements Listener {
 				attackingPlayer = universe.getDataSource().getResident(cell.getNameOfFlagOwner());
 				if (player != null) {
 					try {
-						defendingPlayer = universe.getDataSource().getResident(player.getName());
+						defendingPlayer = universe.getDataSource().getResident(player);
 					} catch (NotRegisteredException ignored) {
 					}
 				}


### PR DESCRIPTION
#### Description: 

There's a lot of places in the code base where you look up residents by their Player's name. This results in a lot of `player.getName()` calls throughout the code base. Some locations call `player.getName().toLowerCase()` and others just use `player.getName()`. It's difficult to tell if these are done for a reason or if these are just artifacts of time. 

This is a really small change. The first commit adds in a helper function on the data source to allow accessing `Resident`s via a `Player` object. The second commit switches all possible locations to using this new method. 

Please don't merge this yet. I'm going to test this tomorrow. 

@LlmDl are changes like these OK? I might be bored for a bit and I might submit some smaller cleanups like this. If you don't have time to review small/unimportant changes like these I'd understand! 

____
#### New Nodes/Commands/ConfigOptions: 

N/A


____
#### Relevant Towny Issue ticket:

N/A


____
- [ ] I have tested this pull request for defects on a server. 


By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
