### PR TITLE
Dragon Fireball Damage handling.

### DIFF
--- a/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
@@ -28,7 +28,6 @@ import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Creature;
 import org.bukkit.entity.DragonFireball;
-import org.bukkit.entity.EnderCrystal;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;

--- a/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
@@ -291,7 +291,7 @@ public class TownyEntityListener implements Listener {
 	}
 
 	/**
-	 * Handles dragon fireball's cloud damage to players.
+	 * Removes dragon fireball AreaEffectClouds when they would spawn somewhere with PVP disabled.
 	 * 
 	 * @param event AreaEffectCloudApplyEvent
 	 */
@@ -306,8 +306,6 @@ public class TownyEntityListener implements Listener {
 		if (!(event.getEntity().getSource() instanceof Player) || !(event.getEntity().getSource() instanceof DragonFireball))
 			return;
 
-		List<LivingEntity> entities = event.getAffectedEntities();
-
 		TownyWorld townyWorld = null;
 		try {
 			townyWorld = TownyUniverse.getInstance().getDataSource().getWorld(event.getEntity().getWorld().getName());
@@ -315,13 +313,12 @@ public class TownyEntityListener implements Listener {
 			// Failed to fetch a world
 			return;
 		}
-		
-		for (LivingEntity entity : entities) {
-			TownBlock townBlock = TownyAPI.getInstance().getTownBlock(entity.getLocation());
-			if (CombatUtil.preventPvP(townyWorld, townBlock)) {
-				event.setCancelled(true);
-			}	
+		TownBlock townBlock = TownyAPI.getInstance().getTownBlock(event.getEntity().getLocation());
+		if (CombatUtil.preventPvP(townyWorld, townBlock)) {
+			event.setCancelled(true);
+			event.getEntity().remove();
 		}
+
 	}
 	
 	/**

--- a/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
@@ -62,7 +62,7 @@ import org.bukkit.event.hanging.HangingBreakEvent;
 import org.bukkit.event.hanging.HangingBreakEvent.RemoveCause;
 import org.bukkit.event.hanging.HangingPlaceEvent;
 import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionType;
+import org.bukkit.potion.PotionEffectType;
 import org.bukkit.projectiles.BlockProjectileSource;
 import org.bukkit.projectiles.ProjectileSource;
 import java.util.ArrayList;
@@ -300,7 +300,7 @@ public class TownyEntityListener implements Listener {
 		if (!TownyAPI.getInstance().isTownyWorld(event.getEntity().getWorld()))
 			return;
 		
-		if (!event.getEntity().getBasePotionData().getType().equals(PotionType.UNCRAFTABLE))
+		if (!event.getEntity().getCustomEffects().stream().anyMatch(effect -> effect.getType().equals(PotionEffectType.HARM)))
 			return;
 
 		if (!(event.getEntity().getSource() instanceof Player) || !(event.getEntity().getSource() instanceof DragonFireball))

--- a/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
@@ -27,6 +27,8 @@ import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Creature;
+import org.bukkit.entity.DragonFireball;
+import org.bukkit.entity.EnderCrystal;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
@@ -39,6 +41,7 @@ import org.bukkit.entity.Villager;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.AreaEffectCloudApplyEvent;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.entity.EntityCombustByEntityEvent;
@@ -59,6 +62,7 @@ import org.bukkit.event.hanging.HangingBreakEvent;
 import org.bukkit.event.hanging.HangingBreakEvent.RemoveCause;
 import org.bukkit.event.hanging.HangingPlaceEvent;
 import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionType;
 import org.bukkit.projectiles.BlockProjectileSource;
 import org.bukkit.projectiles.ProjectileSource;
 import java.util.ArrayList;
@@ -286,6 +290,40 @@ public class TownyEntityListener implements Listener {
 		}
 	}
 
+	/**
+	 * Handles dragon fireball's cloud damage to players.
+	 * 
+	 * @param event AreaEffectCloudApplyEvent
+	 */
+	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+	public void onDragonFireBallCloudDamage(AreaEffectCloudApplyEvent event) {
+		if (!TownyAPI.getInstance().isTownyWorld(event.getEntity().getWorld()))
+			return;
+		
+		if (!event.getEntity().getBasePotionData().getType().equals(PotionType.UNCRAFTABLE))
+			return;
+
+		if (!(event.getEntity().getSource() instanceof Player) || !(event.getEntity().getSource() instanceof DragonFireball))
+			return;
+
+		List<LivingEntity> entities = event.getAffectedEntities();
+
+		TownyWorld townyWorld = null;
+		try {
+			townyWorld = TownyUniverse.getInstance().getDataSource().getWorld(event.getEntity().getWorld().getName());
+		} catch (NotRegisteredException e) {
+			// Failed to fetch a world
+			return;
+		}
+		
+		for (LivingEntity entity : entities) {
+			TownBlock townBlock = TownyAPI.getInstance().getTownBlock(entity.getLocation());
+			if (CombatUtil.preventPvP(townyWorld, townBlock)) {
+				event.setCancelled(true);
+			}	
+		}
+	}
+	
 	/**
 	 * Prevent lingering potion damage on players in non PVP areas
 	 * 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
 - Potential solution for #4100.
 - Not ideal.
 - So far I have not found a way to handle Dragon Fireballs better.
 - They fire a ProjectileHitEvent which cannot be cancelled.
 - They generate an AreaEffectCloud which only returns the type
UNCRAFTABLE.
 - The only way so far is to listen for the AreaEffectCloudApplyEvent
and if it is UNCRAFTABLE, check the hurt entities one by one using the
CombatUtil.
 - As this is technically a mob damage, it shouldn't really be
considered PVP (arrows fired by a skeleton from outside of town still
hurts players with PVP off.)
 - Some people are using slimefun to have dragon pets that end up
shooting these fireballs...

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

#4100
____
- [X] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
