### PR TITLE
Per-world Block Explosion Revert Setting.

### DIFF
--- a/resources/english.yml
+++ b/resources/english.yml
@@ -1169,3 +1169,5 @@ msg_town_reached_debtcap_and_is_disbanded_multiple: '&bThe following towns could
 msg_unable_to_deposit_x: 'Unable to deposit %s into that town''s bank.'
 msg_unable_to_withdraw_x: 'Unable to withdraw %s from that town''s bank.'
 status_debtcap: '&2Debt Cap: &a%s'
+status_world_explrevert_entity: '&2Entity Explosion Revert: '
+status_world_explrevert_block: '&2Block Explosion Revert: '

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -391,9 +391,6 @@ public enum ConfigNodes {
 			"new_world_settings.plot_management.wild_revert_on_block_explosion.blocks",
 			"WHITE_BED,ORANGE_BED,MAGENTA_BED,LIGHT_BLUE_BED,YELLOW_BED,LIME_BED,PINK_BED,GRAY_BED,LIGHT_GRAY_BED,CYAN_BED,PURPLE_BED,BLUE_BED,BROWN_BED,GREEN_BED,RED_BED,BLACK_BED",
 			"# The list of blocks whose explosions should be reverted."),
-	NWS_PLOT_MANAGEMENT_WILD_BLOCK_REVERT_TIME(
-			"new_world_settings.plot_management.wild_revert_on_block_explosion.delay",
-			"20s"),
 		
 
 	GTOWN_SETTINGS(

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -372,10 +372,29 @@ public enum ConfigNodes {
 			"# wilderness by monsters exploding."),
 	NWS_PLOT_MANAGEMENT_WILD_ENTITY_REVERT_LIST(
 			"new_world_settings.plot_management.wild_revert_on_mob_explosion.entities",			
-			"Creeper,EnderCrystal,EnderDragon,Fireball,SmallFireball,LargeFireball,TNTPrimed,ExplosiveMinecart,Wither,WitherSkull"),
+			"Creeper,EnderCrystal,EnderDragon,Fireball,SmallFireball,LargeFireball,TNTPrimed,ExplosiveMinecart,Wither,WitherSkull",
+			"# The list of entities whose explosions should be reverted."),
 	NWS_PLOT_MANAGEMENT_WILD_MOB_REVERT_TIME(
 			"new_world_settings.plot_management.wild_revert_on_mob_explosion.delay",
 			"20s"),
+	NWS_PLOT_MANAGEMENT_WILD_BLOCK_REVERT_HEADER(
+			"new_world_settings.plot_management.wild_revert_on_block_explosion",
+			"",
+			"",
+			"# This section is applied to new worlds as default settings when new worlds are detected."),
+	NWS_PLOT_MANAGEMENT_WILD_BLOCK_REVERT_ENABLE(
+			"new_world_settings.plot_management.wild_revert_on_block_explosion.enabled",
+			"true",
+			"# Enabling this will slowly regenerate holes created in the",
+			"# wilderness by exploding blocks like beds."),
+	NWS_PLOT_MANAGEMENT_WILD_BLOCK_REVERT_LIST(
+			"new_world_settings.plot_management.wild_revert_on_block_explosion.blocks",
+			"WHITE_BED,ORANGE_BED,MAGENTA_BED,LIGHT_BLUE_BED,YELLOW_BED,LIME_BED,PINK_BED,GRAY_BED,LIGHT_GRAY_BED,CYAN_BED,PURPLE_BED,BLUE_BED,BROWN_BED,GREEN_BED,RED_BED,BLACK_BED",
+			"# The list of blocks whose explosions should be reverted."),
+	NWS_PLOT_MANAGEMENT_WILD_BLOCK_REVERT_TIME(
+			"new_world_settings.plot_management.wild_revert_on_block_explosion.delay",
+			"20s"),
+		
 
 	GTOWN_SETTINGS(
 			"global_town_settings",

--- a/src/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/src/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -595,8 +595,9 @@ public class TownyFormatter {
 			// (world.isUsingDefault() ? Colors.LightGreen + "Yes" : Colors.Rose
 			// + "No"));
 
-			out.add(Translation.of("status_world_unclaimrevert") + (world.isUsingPlotManagementRevert() ? Translation.of("status_on_good") : Translation.of("status_off_bad")) + Colors.Gray + " | " + 
-			        Translation.of("status_world_explrevert") + (world.isUsingPlotManagementWildRevert() ? Translation.of("status_on_good") : Translation.of("status_off_bad")));
+			out.add(Translation.of("status_world_unclaimrevert") + (world.isUsingPlotManagementRevert() ? Translation.of("status_on_good") : Translation.of("status_off_bad"))); 
+			out.add(Translation.of("status_world_explrevert_entity") + (world.isUsingPlotManagementWildEntityRevert() ? Translation.of("status_on_good") : Translation.of("status_off_bad")) + Colors.Gray + " | " +
+			        Translation.of("status_world_explrevert_block") + (world.isUsingPlotManagementWildBlockRevert() ? Translation.of("status_on_good") : Translation.of("status_off_bad")));
 			// Wilderness:
 			// Build, Destroy, Switch
 			// Ignored Blocks: 34, 45, 64

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -2041,7 +2041,7 @@ public class TownySettings {
 		return getSeconds(ConfigNodes.NWS_PLOT_MANAGEMENT_REVERT_TIME);
 	}
 
-	public static boolean isUsingPlotManagementWildRegen() {
+	public static boolean isUsingPlotManagementWildEntityRegen() {
 
 		return getBoolean(ConfigNodes.NWS_PLOT_MANAGEMENT_WILD_MOB_REVERT_ENABLE);
 	}
@@ -2056,11 +2056,6 @@ public class TownySettings {
 		return getBoolean(ConfigNodes.NWS_PLOT_MANAGEMENT_WILD_BLOCK_REVERT_ENABLE);
 	}
 
-	public static long getPlotManagementWildBlockRegenDelay() {
-
-		return getSeconds(ConfigNodes.NWS_PLOT_MANAGEMENT_WILD_BLOCK_REVERT_TIME);
-	}
-	
 	public static List<String> getPlotManagementIgnoreIds() {
 
 		return getStrArr(ConfigNodes.NWS_PLOT_MANAGEMENT_REVERT_IGNORE);

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -1283,6 +1283,13 @@ public class TownySettings {
 			System.out.println("[Towny] Debug: Wilderness explosion protection entities. ");
 		return getStrArr(ConfigNodes.NWS_PLOT_MANAGEMENT_WILD_ENTITY_REVERT_LIST);
 	}
+	
+	public static List<String> getWildExplosionProtectionBlocks() {
+
+		if (getDebug())
+			System.out.println("[Towny] Debug: Wilderness explosion protection blocks. ");
+		return getStrArr(ConfigNodes.NWS_PLOT_MANAGEMENT_WILD_BLOCK_REVERT_LIST);
+	}
 
 	public static long getMobRemovalSpeed() {
 
@@ -2043,7 +2050,17 @@ public class TownySettings {
 
 		return getSeconds(ConfigNodes.NWS_PLOT_MANAGEMENT_WILD_MOB_REVERT_TIME);
 	}
+	
+	public static boolean isUsingPlotManagementWildBlockRegen() {
 
+		return getBoolean(ConfigNodes.NWS_PLOT_MANAGEMENT_WILD_BLOCK_REVERT_ENABLE);
+	}
+
+	public static long getPlotManagementWildBlockRegenDelay() {
+
+		return getSeconds(ConfigNodes.NWS_PLOT_MANAGEMENT_WILD_BLOCK_REVERT_TIME);
+	}
+	
 	public static List<String> getPlotManagementIgnoreIds() {
 
 		return getStrArr(ConfigNodes.NWS_PLOT_MANAGEMENT_REVERT_IGNORE);

--- a/src/com/palmergames/bukkit/towny/command/TownyWorldCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyWorldCommand.java
@@ -59,7 +59,8 @@ public class TownyWorldCommand extends BaseCommand implements CommandExecutor {
 		"townmobs",
 		"worldmobs",
 		"revertunclaim",
-		"revertexpl",
+		"revertentityexpl",
+		"revertblockexpl",
 		"warallowed"
 	);
 	
@@ -315,7 +316,8 @@ public class TownyWorldCommand extends BaseCommand implements CommandExecutor {
 				player.sendMessage(ChatTools.formatCommand("", "/TownyWorld toggle", "explosion/forceexplosion", ""));
 				player.sendMessage(ChatTools.formatCommand("", "/TownyWorld toggle", "fire/forcefire", ""));
 				player.sendMessage(ChatTools.formatCommand("", "/TownyWorld toggle", "townmobs/worldmobs", ""));
-				player.sendMessage(ChatTools.formatCommand("", "/TownyWorld toggle", "revertunclaim/revertexpl", ""));
+				player.sendMessage(ChatTools.formatCommand("", "/TownyWorld {world} toggle", "revertunclaim", ""));
+				player.sendMessage(ChatTools.formatCommand("", "/TownyWorld {world} toggle", "revertentityexpl/revertblockexpl", ""));
 			} else {
 				sender.sendMessage(ChatTools.formatTitle("/TownyWorld toggle"));
 				sender.sendMessage(ChatTools.formatCommand("", "/TownyWorld {world} toggle", "claimable", ""));
@@ -325,7 +327,8 @@ public class TownyWorldCommand extends BaseCommand implements CommandExecutor {
 				sender.sendMessage(ChatTools.formatCommand("", "/TownyWorld {world} toggle", "explosion/forceexplosion", ""));
 				sender.sendMessage(ChatTools.formatCommand("", "/TownyWorld {world} toggle", "fire/forcefire", ""));
 				sender.sendMessage(ChatTools.formatCommand("", "/TownyWorld {world} toggle", "townmobs/worldmobs", ""));
-				sender.sendMessage(ChatTools.formatCommand("", "/TownyWorld {world} toggle", "revertunclaim/revertexpl", ""));
+				sender.sendMessage(ChatTools.formatCommand("", "/TownyWorld {world} toggle", "revertunclaim", ""));
+				sender.sendMessage(ChatTools.formatCommand("", "/TownyWorld {world} toggle", "revertentityexpl/revertblockexpl", ""));
 			}
 		} else {
 
@@ -450,15 +453,24 @@ public class TownyWorldCommand extends BaseCommand implements CommandExecutor {
 				else
 					TownyMessaging.sendMsg(msg);
 
-			} else if (split[0].equalsIgnoreCase("revertexpl")) {
+			} else if (split[0].equalsIgnoreCase("revertentityexpl")) {
 
-				Globalworld.setUsingPlotManagementWildRevert(!Globalworld.isUsingPlotManagementWildRevert());
-				msg = Translation.of("msg_changed_world_setting", "Wilderness Explosion Revert", Globalworld.getName(), Globalworld.isUsingPlotManagementWildRevert() ? Translation.of("enabled") : Translation.of("disabled"));
+				Globalworld.setUsingPlotManagementWildEntityRevert(!Globalworld.isUsingPlotManagementWildEntityRevert());
+				msg = Translation.of("msg_changed_world_setting", "Wilderness Entity Explosion Revert", Globalworld.getName(), Globalworld.isUsingPlotManagementWildEntityRevert() ? Translation.of("enabled") : Translation.of("disabled"));
 				if (player != null)
 					TownyMessaging.sendMsg(player, msg);
 				else
 					TownyMessaging.sendMsg(msg);
 
+			} else if (split[0].equalsIgnoreCase("revertblockexpl")) {
+
+				Globalworld.setUsingPlotManagementWildBlockRevert(!Globalworld.isUsingPlotManagementWildBlockRevert());
+				msg = Translation.of("msg_changed_world_setting", "Wilderness Block Explosion Revert", Globalworld.getName(), Globalworld.isUsingPlotManagementWildBlockRevert() ? Translation.of("enabled") : Translation.of("disabled"));
+				if (player != null)
+					TownyMessaging.sendMsg(player, msg);
+				else
+					TownyMessaging.sendMsg(msg);
+				
 			} else {
 				msg = Translation.of("msg_err_invalid_property", "'" + split[0] + "'");
 				if (player != null)

--- a/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
+++ b/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
@@ -57,7 +57,7 @@ public class SQL_Schema {
 		columns.add("`usingPlotManagementWildRegen` bool NOT NULL DEFAULT '0'");
 		columns.add("`plotManagementWildRegenEntities` mediumtext NOT NULL");
 		columns.add("`plotManagementWildRegenSpeed` long NOT NULL");
-		columns.add("`usingPlotManagementWildBlockRegen` bool NOT NULL DEFAULT '0'");
+		columns.add("`usingPlotManagementWildRegenBlocks` bool NOT NULL DEFAULT '0'");
 		columns.add("`plotManagementWildRegenBlocks` mediumtext NOT NULL");		
 		columns.add("`usingTowny` bool NOT NULL DEFAULT '0'");
 		columns.add("`warAllowed` bool NOT NULL DEFAULT '0'");

--- a/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
+++ b/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
@@ -57,6 +57,8 @@ public class SQL_Schema {
 		columns.add("`usingPlotManagementWildRegen` bool NOT NULL DEFAULT '0'");
 		columns.add("`plotManagementWildRegenEntities` mediumtext NOT NULL");
 		columns.add("`plotManagementWildRegenSpeed` long NOT NULL");
+		columns.add("`usingPlotManagementWildBlockRegen` bool NOT NULL DEFAULT '0'");
+		columns.add("`plotManagementWildRegenBlocks` mediumtext NOT NULL");		
 		columns.add("`usingTowny` bool NOT NULL DEFAULT '0'");
 		columns.add("`warAllowed` bool NOT NULL DEFAULT '0'");
 		columns.add("`metadata` text DEFAULT NULL");

--- a/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -1384,6 +1384,34 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 					} catch (Exception ignored) {
 					}
 				
+				line = keys.get("usingPlotManagementWildBlockRegen");
+				if (line != null)
+					try {
+						world.setUsingPlotManagementWildBlockRevert(Boolean.parseBoolean(line));
+					} catch (Exception ignored) {
+					}
+				
+				line = keys.get("PlotManagementWildRegenBlocks");
+				if (line != null)
+					try {
+						List<String> mats = new ArrayList<>();
+						for (String s : line.split(","))
+							if (!s.isEmpty())
+								try {
+									mats.add(s.trim());
+								} catch (NumberFormatException ignored) {
+								}
+						world.setPlotManagementWildRevertMaterials(mats);
+					} catch (Exception ignored) {
+					}
+				
+				line = keys.get("usingPlotManagementWildBlockRegenDelay");
+				if (line != null)
+					try {
+						world.setPlotManagementWildBlockRevertDelay(Long.parseLong(line));
+					} catch (Exception ignored) {
+					}
+				
 				line = keys.get("usingTowny");
 				if (line != null)
 					try {
@@ -2002,6 +2030,16 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 
 		// Using PlotManagement Wild Regen Delay
 		list.add("usingPlotManagementWildRegenDelay=" + world.getPlotManagementWildRevertDelay());
+		
+		// Using PlotManagement Wild Block Regen
+		list.add("usingPlotManagementWildBlockRegen=" + world.isUsingPlotManagementWildBlockRevert());
+
+		// Wilderness Explosion Protection blocks
+		if (world.getPlotManagementWildRevertBlocks() != null)
+			list.add("PlotManagementWildRegenBlocks=" + StringMgmt.join(world.getPlotManagementWildRevertBlocks(), ","));
+
+		// Using PlotManagement Wild Regen Block Delay
+		list.add("usingPlotManagementWildBlockRegenDelay=" + world.getPlotManagementWildBlockRevertDelay());
 
 		// Using Towny
 		list.add("");

--- a/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -1384,7 +1384,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 					} catch (Exception ignored) {
 					}
 				
-				line = keys.get("usingPlotManagementWildBlockRegen");
+				line = keys.get("usingPlotManagementWildRegenBlocks");
 				if (line != null)
 					try {
 						world.setUsingPlotManagementWildBlockRevert(Boolean.parseBoolean(line));
@@ -1404,14 +1404,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 						world.setPlotManagementWildRevertMaterials(mats);
 					} catch (Exception ignored) {
 					}
-				
-				line = keys.get("usingPlotManagementWildBlockRegenDelay");
-				if (line != null)
-					try {
-						world.setPlotManagementWildBlockRevertDelay(Long.parseLong(line));
-					} catch (Exception ignored) {
-					}
-				
+
 				line = keys.get("usingTowny");
 				if (line != null)
 					try {
@@ -2032,14 +2025,11 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 		list.add("usingPlotManagementWildRegenDelay=" + world.getPlotManagementWildRevertDelay());
 		
 		// Using PlotManagement Wild Block Regen
-		list.add("usingPlotManagementWildBlockRegen=" + world.isUsingPlotManagementWildBlockRevert());
+		list.add("usingPlotManagementWildRegenBlocks=" + world.isUsingPlotManagementWildRevertBlocks());
 
 		// Wilderness Explosion Protection blocks
 		if (world.getPlotManagementWildRevertBlocks() != null)
 			list.add("PlotManagementWildRegenBlocks=" + StringMgmt.join(world.getPlotManagementWildRevertBlocks(), ","));
-
-		// Using PlotManagement Wild Regen Block Delay
-		list.add("usingPlotManagementWildBlockRegenDelay=" + world.getPlotManagementWildBlockRevertDelay());
 
 		// Using Towny
 		list.add("");

--- a/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -1949,7 +1949,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 		list.add("disablecreaturetrample=" + world.isDisableCreatureTrample());
 
 		// Unclaimed
-		list.add(newLine);
+		list.add("");
 		list.add("# Unclaimed Zone settings.");
 
 		// Unclaimed Zone Build
@@ -1976,9 +1976,8 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 			list.add("unclaimedZoneIgnoreIds=" + StringMgmt.join(world.getUnclaimedZoneIgnoreMaterials(), ","));
 
 		// PlotManagement Delete
-		list.add(newLine);
+		list.add("");
 		list.add("# The following settings control what blocks are deleted upon a townblock being unclaimed");
-
 		// Using PlotManagement Delete
 		list.add("usingPlotManagementDelete=" + world.isUsingPlotManagementDelete());
 		// Plot Management Delete Ids
@@ -1986,9 +1985,8 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 			list.add("plotManagementDeleteIds=" + StringMgmt.join(world.getPlotManagementDeleteIds(), ","));
 
 		// PlotManagement
-		list.add(newLine);
+		list.add("");
 		list.add("# The following settings control what blocks are deleted upon a mayor issuing a '/plot clear' command");
-
 		// Using PlotManagement Mayor Delete
 		list.add("usingPlotManagementMayorDelete=" + world.isUsingPlotManagementMayorDelete());
 		// Plot Management Mayor Delete
@@ -1996,45 +1994,46 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 			list.add("plotManagementMayorDelete=" + StringMgmt.join(world.getPlotManagementMayorDelete(), ","));
 
 		// PlotManagement Revert
-		list.add(newLine + "# If enabled when a town claims a townblock a snapshot will be taken at the time it is claimed.");
-		list.add("# When the townblock is unclaimded its blocks will begin to revert to the original snapshot.");
-
+		list.add("");
+		list.add("# If enabled when a town claims a townblock a snapshot will be taken at the time it is claimed.");
+		list.add("# When the townblock is unclaimed its blocks will begin to revert to the original snapshot.");
 		// Using PlotManagement Revert
 		list.add("usingPlotManagementRevert=" + world.isUsingPlotManagementRevert());
-		// Using PlotManagement Revert Speed
-		//list.add("usingPlotManagementRevertSpeed=" + Long.toString(world.getPlotManagementRevertSpeed()));
 
 		list.add("# Any block Id's listed here will not be respawned. Instead it will revert to air.");
-
 		// Plot Management Ignore Ids
 		if (world.getPlotManagementIgnoreIds() != null)
 			list.add("plotManagementIgnoreIds=" + StringMgmt.join(world.getPlotManagementIgnoreIds(), ","));
 
 		// PlotManagement Wild Regen
 		list.add("");
-		list.add("# If enabled any damage caused by explosions will repair itself.");
-
+		list.add("# The following settings control which entities/blocks' explosions are reverted in the wilderness.");
+		list.add("# If enabled any damage caused by entity explosions will repair itself.");
 		// Using PlotManagement Wild Regen
 		list.add("usingPlotManagementWildRegen=" + world.isUsingPlotManagementWildEntityRevert());
 
+		list.add("# The list of entities whose explosions would be reverted.");
 		// Wilderness Explosion Protection entities
 		if (world.getPlotManagementWildRevertEntities() != null)
 			list.add("PlotManagementWildRegenEntities=" + StringMgmt.join(world.getPlotManagementWildRevertEntities(), ","));
 
-		// Using PlotManagement Wild Regen Delay
-		list.add("usingPlotManagementWildRegenDelay=" + world.getPlotManagementWildRevertDelay());
-		
+		list.add("# If enabled any damage caused by block explosions will repair itself.");
 		// Using PlotManagement Wild Block Regen
 		list.add("usingPlotManagementWildRegenBlocks=" + world.isUsingPlotManagementWildBlockRevert());
 
+		list.add("# The list of entities whose explosions would be reverted.");
 		// Wilderness Explosion Protection blocks
 		if (world.getPlotManagementWildRevertBlocks() != null)
 			list.add("PlotManagementWildRegenBlocks=" + StringMgmt.join(world.getPlotManagementWildRevertBlocks(), ","));
 
+		list.add("# The delay after which the explosion reverts will begin.");
+		// Using PlotManagement Wild Regen Delay
+		list.add("usingPlotManagementWildRegenDelay=" + world.getPlotManagementWildRevertDelay());
+
+		
 		// Using Towny
 		list.add("");
 		list.add("# This setting is used to enable or disable Towny in this world.");
-
 		// Using Towny
 		list.add("usingTowny=" + world.isUsingTowny());
 
@@ -2044,6 +2043,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 		list.add("warAllowed=" + world.isWarAllowed());
 
 		// Metadata
+		list.add("");
 		list.add("metadata=" + serializeMetadata(world));
 		
 		/*

--- a/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -1359,7 +1359,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 				line = keys.get("usingPlotManagementWildRegen");
 				if (line != null)
 					try {
-						world.setUsingPlotManagementWildRevert(Boolean.parseBoolean(line));
+						world.setUsingPlotManagementWildEntityRevert(Boolean.parseBoolean(line));
 					} catch (Exception ignored) {
 					}
 				
@@ -2015,7 +2015,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 		list.add("# If enabled any damage caused by explosions will repair itself.");
 
 		// Using PlotManagement Wild Regen
-		list.add("usingPlotManagementWildRegen=" + world.isUsingPlotManagementWildRevert());
+		list.add("usingPlotManagementWildRegen=" + world.isUsingPlotManagementWildEntityRevert());
 
 		// Wilderness Explosion Protection entities
 		if (world.getPlotManagementWildRevertEntities() != null)
@@ -2025,7 +2025,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 		list.add("usingPlotManagementWildRegenDelay=" + world.getPlotManagementWildRevertDelay());
 		
 		// Using PlotManagement Wild Block Regen
-		list.add("usingPlotManagementWildRegenBlocks=" + world.isUsingPlotManagementWildRevertBlocks());
+		list.add("usingPlotManagementWildRegenBlocks=" + world.isUsingPlotManagementWildBlockRevert());
 
 		// Wilderness Explosion Protection blocks
 		if (world.getPlotManagementWildRevertBlocks() != null)

--- a/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -1553,7 +1553,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			} catch (Exception ignored) {
 			}
 			
-			result = rs.getBoolean("usingPlotManagementWildBlockRegen");
+			result = rs.getBoolean("usingPlotManagementWildRegenBlocks");
 			try {
 				world.setUsingPlotManagementWildBlockRevert(result);
 			} catch (Exception ignored) {
@@ -1573,12 +1573,6 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 					world.setPlotManagementWildRevertMaterials(materials);
 				} catch (Exception ignored) {
 				}
-
-			resultLong = rs.getLong("plotManagementWildBlockRegenSpeed");
-			try {
-				world.setPlotManagementWildBlockRevertDelay(resultLong);
-			} catch (Exception ignored) {
-			}
 
 			result = rs.getBoolean("usingTowny");
 			try {
@@ -2015,15 +2009,12 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			nat_hm.put("plotManagementWildRegenSpeed", world.getPlotManagementWildRevertDelay());
 			
 			// Using PlotManagement Wild Block Regen
-			nat_hm.put("usingPlotManagementWildBlockRegen", world.isUsingPlotManagementWildBlockRevert());
+			nat_hm.put("usingPlotManagementWildRegenBlocks", world.isUsingPlotManagementWildRevertBlocks());
 
 			// Wilderness Explosion Protection blocks
 			if (world.getPlotManagementWildRevertBlocks() != null)
 				nat_hm.put("PlotManagementWildRegenBlocks",
 						StringMgmt.join(world.getPlotManagementWildRevertBlocks(), "#"));
-
-			// Using PlotManagement Wild Block Regen Delay
-			nat_hm.put("plotManagementWildBlockRegenSpeed", world.getPlotManagementWildBlockRevertDelay());
 
 			// Using Towny
 			nat_hm.put("usingTowny", world.isUsingTowny());

--- a/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -1552,6 +1552,33 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 				world.setPlotManagementWildRevertDelay(resultLong);
 			} catch (Exception ignored) {
 			}
+			
+			result = rs.getBoolean("usingPlotManagementWildBlockRegen");
+			try {
+				world.setUsingPlotManagementWildBlockRevert(result);
+			} catch (Exception ignored) {
+			}
+
+			line = rs.getString("plotManagementWildRegenBlocks");
+			if (line != null)
+				try {
+					List<String> materials = new ArrayList<>();
+					search = (line.contains("#")) ? "#" : ",";
+					for (String split : line.split(search))
+						if (!split.isEmpty())
+							try {
+								materials.add(split.trim());
+							} catch (NumberFormatException ignored) {
+							}
+					world.setPlotManagementWildRevertMaterials(materials);
+				} catch (Exception ignored) {
+				}
+
+			resultLong = rs.getLong("plotManagementWildBlockRegenSpeed");
+			try {
+				world.setPlotManagementWildBlockRevertDelay(resultLong);
+			} catch (Exception ignored) {
+			}
 
 			result = rs.getBoolean("usingTowny");
 			try {
@@ -1986,6 +2013,17 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 
 			// Using PlotManagement Wild Regen Delay
 			nat_hm.put("plotManagementWildRegenSpeed", world.getPlotManagementWildRevertDelay());
+			
+			// Using PlotManagement Wild Block Regen
+			nat_hm.put("usingPlotManagementWildBlockRegen", world.isUsingPlotManagementWildBlockRevert());
+
+			// Wilderness Explosion Protection blocks
+			if (world.getPlotManagementWildRevertBlocks() != null)
+				nat_hm.put("PlotManagementWildRegenBlocks",
+						StringMgmt.join(world.getPlotManagementWildRevertBlocks(), "#"));
+
+			// Using PlotManagement Wild Block Regen Delay
+			nat_hm.put("plotManagementWildBlockRegenSpeed", world.getPlotManagementWildBlockRevertDelay());
 
 			// Using Towny
 			nat_hm.put("usingTowny", world.isUsingTowny());

--- a/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -1528,7 +1528,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 
 			result = rs.getBoolean("usingPlotManagementWildRegen");
 			try {
-				world.setUsingPlotManagementWildRevert(result);
+				world.setUsingPlotManagementWildEntityRevert(result);
 			} catch (Exception ignored) {
 			}
 
@@ -1998,7 +1998,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 				nat_hm.put("plotManagementIgnoreIds", StringMgmt.join(world.getPlotManagementIgnoreIds(), "#"));
 
 			// Using PlotManagement Wild Regen
-			nat_hm.put("usingPlotManagementWildRegen", world.isUsingPlotManagementWildRevert());
+			nat_hm.put("usingPlotManagementWildRegen", world.isUsingPlotManagementWildEntityRevert());
 
 			// Wilderness Explosion Protection entities
 			if (world.getPlotManagementWildRevertEntities() != null)
@@ -2009,7 +2009,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			nat_hm.put("plotManagementWildRegenSpeed", world.getPlotManagementWildRevertDelay());
 			
 			// Using PlotManagement Wild Block Regen
-			nat_hm.put("usingPlotManagementWildRegenBlocks", world.isUsingPlotManagementWildRevertBlocks());
+			nat_hm.put("usingPlotManagementWildRegenBlocks", world.isUsingPlotManagementWildBlockRevert());
 
 			// Wilderness Explosion Protection blocks
 			if (world.getPlotManagementWildRevertBlocks() != null)

--- a/src/com/palmergames/bukkit/towny/event/BedExplodeEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/BedExplodeEvent.java
@@ -1,0 +1,46 @@
+package com.palmergames.bukkit.towny.event;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class BedExplodeEvent extends Event {
+
+	private static final HandlerList handlers = new HandlerList();
+	
+	private final Player player;
+	private final Location location1;
+	private final Location location2;
+	
+	public BedExplodeEvent(Player player, Location loc1, Location loc2) {
+		super(!Bukkit.getServer().isPrimaryThread());
+		this.player = player;
+		this.location1 = loc1;
+		this.location2 = loc2;
+	}
+	
+	@Override
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+	
+    public static HandlerList getHandlerList() {
+
+		return handlers;
+	}
+	
+	public Location getLocation() {
+		return location1;
+	}
+	
+	public Location getLocation2() {
+		return location2;
+	}
+	
+	public Player getPlayer() {
+		return player;
+	}
+
+}

--- a/src/com/palmergames/bukkit/towny/event/BedExplodeEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/BedExplodeEvent.java
@@ -2,6 +2,7 @@ package com.palmergames.bukkit.towny.event;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -13,12 +14,14 @@ public class BedExplodeEvent extends Event {
 	private final Player player;
 	private final Location location1;
 	private final Location location2;
+	private final Material material;
 	
-	public BedExplodeEvent(Player player, Location loc1, Location loc2) {
+	public BedExplodeEvent(Player player, Location loc1, Location loc2, Material mat) {
 		super(!Bukkit.getServer().isPrimaryThread());
 		this.player = player;
 		this.location1 = loc1;
 		this.location2 = loc2;
+		this.material = mat;
 	}
 	
 	@Override
@@ -37,6 +40,10 @@ public class BedExplodeEvent extends Event {
 	
 	public Location getLocation2() {
 		return location2;
+	}
+	
+	public Material getMaterial() {
+		return material;
 	}
 	
 	public Player getPlayer() {

--- a/src/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
@@ -361,6 +361,14 @@ public class TownyBlockListener implements Listener {
 			e.printStackTrace();
 			return;
 		}
+		System.out.println("Exploded Block location " + event.getBlock().getLocation());
+		
+		if (townyWorld.hasBedExplosionAtBlock(event.getBlock().getLocation())) {
+			event.setCancelled(true); // Doesn't actually cancel the event.
+			System.out.println("stopped exploding bed"); // This is a lie. Exploding bed isn't actually stopped.
+			townyWorld.removeBedExplosionAtBlock(event.getBlock().getLocation());
+			return; // We would have to return here in order to stop any sort of reverting.
+		}
 		for (Block block : blocks) {
 			count++;
 			

--- a/src/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
@@ -349,14 +349,16 @@ public class TownyBlockListener implements Listener {
 			return;
 		}
 		
+
+		if (!TownyAPI.getInstance().isTownyWorld(event.getBlock().getWorld()))
+			return;
+		
 		TownyWorld townyWorld;
 		List<Block> blocks = event.blockList();
 		int count = 0;
 
 		try {
 			townyWorld = TownyUniverse.getInstance().getDataSource().getWorld(event.getBlock().getLocation().getWorld().getName());			
-			if (!townyWorld.isUsingTowny())
-				return; 
 		} catch (NotRegisteredException e) {
 			e.printStackTrace();
 			return;

--- a/src/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
@@ -375,7 +375,7 @@ public class TownyBlockListener implements Listener {
 		/*
 		 * Don't regenerate block explosions unless they are on the list of blocks whose explosions regenerate.
 		 */
-		if (townyWorld.isUsingPlotManagementWildRevert() && townyWorld.getPlotManagementWildRevertBlocks().contains(material.toString().toLowerCase()) )
+		if (townyWorld.isUsingPlotManagementWildRevert() && townyWorld.isProtectingExplosionBlock(material))
 			revertingThisMaterial = true;
 		
 		for (Block block : blocks) {

--- a/src/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
@@ -348,7 +348,6 @@ public class TownyBlockListener implements Listener {
 			event.setCancelled(true);
 			return;
 		}
-		
 
 		if (!TownyAPI.getInstance().isTownyWorld(event.getBlock().getWorld()))
 			return;
@@ -363,14 +362,22 @@ public class TownyBlockListener implements Listener {
 			e.printStackTrace();
 			return;
 		}
-		System.out.println("Exploded Block location " + event.getBlock().getLocation());
+
+		Material material = event.getBlock().getType();
+		boolean revertingThisMaterial = false;
 		
-		if (townyWorld.hasBedExplosionAtBlock(event.getBlock().getLocation())) {
-			event.setCancelled(true); // Doesn't actually cancel the event.
-			System.out.println("stopped exploding bed"); // This is a lie. Exploding bed isn't actually stopped.
-			townyWorld.removeBedExplosionAtBlock(event.getBlock().getLocation());
-			return; // We would have to return here in order to stop any sort of reverting.
-		}
+		/*
+		 * event.getBlock() doesn't return the bed when the bed is the cause of the explosion, so we use this workaround.
+		 */
+		if (townyWorld.hasBedExplosionAtBlock(event.getBlock().getLocation()))
+			material = townyWorld.getBedExplosionMaterial(event.getBlock().getLocation());
+		
+		/*
+		 * Don't regenerate block explosions unless they are on the list of blocks whose explosions regenerate.
+		 */
+		if (townyWorld.isUsingPlotManagementWildRevert() && townyWorld.getPlotManagementWildRevertBlocks().contains(material.toString().toLowerCase()) )
+			revertingThisMaterial = true;
+		
 		for (Block block : blocks) {
 			count++;
 			
@@ -379,7 +386,7 @@ public class TownyBlockListener implements Listener {
 				return;
 			}
 			
-			if (TownyAPI.getInstance().isWilderness(block.getLocation()) && townyWorld.isUsingPlotManagementWildRevert()) {
+			if (TownyAPI.getInstance().isWilderness(block.getLocation()) && revertingThisMaterial) {
 				event.setCancelled(!TownyRegenAPI.beginProtectionRegenTask(block, count));
 			}
 		}

--- a/src/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
@@ -375,7 +375,7 @@ public class TownyBlockListener implements Listener {
 		/*
 		 * Don't regenerate block explosions unless they are on the list of blocks whose explosions regenerate.
 		 */
-		if (townyWorld.isUsingPlotManagementWildRevert() && townyWorld.isProtectingExplosionBlock(material))
+		if (townyWorld.isUsingPlotManagementWildBlockRevert() && townyWorld.isProtectingExplosionBlock(material))
 			revertingThisMaterial = true;
 		
 		for (Block block : blocks) {

--- a/src/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
@@ -10,12 +10,14 @@ import com.palmergames.bukkit.towny.TownyTimerHandler;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.command.TownCommand;
 import com.palmergames.bukkit.towny.command.TownyCommand;
+import com.palmergames.bukkit.towny.event.BedExplodeEvent;
 import com.palmergames.bukkit.towny.event.NewTownEvent;
 import com.palmergames.bukkit.towny.event.PlayerChangePlotEvent;
 import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
 import com.palmergames.bukkit.towny.object.CellBorder;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
+import com.palmergames.bukkit.towny.object.TownyWorld;
 import com.palmergames.bukkit.towny.object.Translation;
 import com.palmergames.bukkit.towny.object.WorldCoord;
 import com.palmergames.bukkit.towny.utils.BorderUtil;
@@ -133,5 +135,24 @@ public class TownyCustomListener implements Listener {
 		// which could contain the above advice about depositing money, or containing
 		// links to the commands page on the wiki.
 		
+	}
+	
+	@EventHandler(priority = EventPriority.NORMAL) 
+	public void onBedExplodeEvent(BedExplodeEvent event) {
+		System.out.println("BEDEXPLODEEVENT");
+		TownyWorld world = null;
+		try {
+			world = TownyUniverse.getInstance().getDataSource().getWorld(event.getLocation().getWorld().getName());
+		} catch (NotRegisteredException ignored) {}
+		
+		world.addBedExplosionAtBlock(event.getLocation(), event);
+		world.addBedExplosionAtBlock(event.getLocation2(), event);
+//		final TownyWorld finalWorld = world;
+//		Bukkit.getScheduler().scheduleSyncDelayedTask(plugin ,new Runnable() {
+//            @Override
+//            public void run() {
+//                finalWorld.removeBedExplosionAtBlock(event.getLocation());
+//            }
+//        }, 20L);
 	}
 }

--- a/src/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
@@ -145,14 +145,14 @@ public class TownyCustomListener implements Listener {
 			world = TownyUniverse.getInstance().getDataSource().getWorld(event.getLocation().getWorld().getName());
 		} catch (NotRegisteredException ignored) {}
 		
-		world.addBedExplosionAtBlock(event.getLocation(), event);
-		world.addBedExplosionAtBlock(event.getLocation2(), event);
-//		final TownyWorld finalWorld = world;
-//		Bukkit.getScheduler().scheduleSyncDelayedTask(plugin ,new Runnable() {
-//            @Override
-//            public void run() {
-//                finalWorld.removeBedExplosionAtBlock(event.getLocation());
-//            }
-//        }, 20L);
+		world.addBedExplosionAtBlock(event.getLocation(), event.getMaterial());
+		world.addBedExplosionAtBlock(event.getLocation2(), event.getMaterial());
+		final TownyWorld finalWorld = world;
+		Bukkit.getScheduler().scheduleSyncDelayedTask(plugin ,new Runnable() {
+            @Override
+            public void run() {
+                finalWorld.removeBedExplosionAtBlock(event.getLocation());
+            }
+        }, 20L);
 	}
 }

--- a/src/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
@@ -139,7 +139,6 @@ public class TownyCustomListener implements Listener {
 	
 	@EventHandler(priority = EventPriority.NORMAL) 
 	public void onBedExplodeEvent(BedExplodeEvent event) {
-		System.out.println("BEDEXPLODEEVENT");
 		TownyWorld world = null;
 		try {
 			world = TownyUniverse.getInstance().getDataSource().getWorld(event.getLocation().getWorld().getName());
@@ -148,10 +147,11 @@ public class TownyCustomListener implements Listener {
 		world.addBedExplosionAtBlock(event.getLocation(), event.getMaterial());
 		world.addBedExplosionAtBlock(event.getLocation2(), event.getMaterial());
 		final TownyWorld finalWorld = world;
-		Bukkit.getScheduler().scheduleSyncDelayedTask(plugin ,new Runnable() {
+		Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, new Runnable() {
             @Override
             public void run() {
                 finalWorld.removeBedExplosionAtBlock(event.getLocation());
+                finalWorld.removeBedExplosionAtBlock(event.getLocation2());
             }
         }, 20L);
 	}

--- a/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
@@ -800,7 +800,7 @@ public class TownyEntityListener implements Listener {
 							// Wilderness explosion regeneration
 
 							if (townyWorld.isExpl()) {
-								if (townyWorld.isUsingPlotManagementWildRevert() && entity != null && townyWorld.isProtectingExplosionEntity(entity)) {										
+								if (townyWorld.isUsingPlotManagementWildEntityRevert() && entity != null && townyWorld.isProtectingExplosionEntity(entity)) {										
 									TownyRegenAPI.beginProtectionRegenTask(block, count);
 								}
 							} else {
@@ -842,7 +842,7 @@ public class TownyEntityListener implements Listener {
 				} else {
 					// Wilderness explosion regeneration
 					if (townyWorld.isExpl()) {
-						if (townyWorld.isUsingPlotManagementWildRevert() && entity != null && townyWorld.isProtectingExplosionEntity(entity)) {
+						if (townyWorld.isUsingPlotManagementWildEntityRevert() && entity != null && townyWorld.isProtectingExplosionEntity(entity)) {
 							event.setCancelled(!TownyRegenAPI.beginProtectionRegenTask(block, count));
 						}
 					} else {
@@ -1002,7 +1002,7 @@ public class TownyEntityListener implements Listener {
 					if (tb == null) {
 					    // We're in the wilderness because the townblock is null;
 						if (townyWorld.isExpl())
-							if (townyWorld.isUsingPlotManagementWildRevert() && (remover != null))
+							if (townyWorld.isUsingPlotManagementWildEntityRevert() && (remover != null))
 								if (townyWorld.isProtectingExplosionEntity((Entity)remover))
 									event.setCancelled(true);
 					}

--- a/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -47,11 +47,9 @@ import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Tag;
-import org.bukkit.World;
 import org.bukkit.World.Environment;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
-import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.type.Sign;
 import org.bukkit.block.data.type.WallSign;
 import org.bukkit.entity.Entity;
@@ -353,18 +351,14 @@ public class TownyPlayerListener implements Listener {
 			return;
 		}
 
-		Player player = event.getPlayer();
-		Block block = event.getClickedBlock();
-		World world = event.getPlayer().getWorld();
 		if (!TownyAPI.getInstance().isTownyWorld(event.getPlayer().getWorld()))
 			return;
 
+		Block block = event.getClickedBlock();
 		if (event.hasBlock()) {
-			if (Tag.BEDS.isTagged(block.getType()) && world.getEnvironment().equals(Environment.NETHER)) {
-				System.out.println("bed clicked in nether.");
-				BlockData data = block.getBlockData();
-				org.bukkit.block.data.type.Bed bed = ((org.bukkit.block.data.type.Bed) data);
-				BukkitTools.getPluginManager().callEvent(new BedExplodeEvent(player, event.getClickedBlock().getLocation(), block.getRelative(bed.getFacing()).getLocation()));
+			if (Tag.BEDS.isTagged(block.getType()) && event.getPlayer().getWorld().getEnvironment().equals(Environment.NETHER)) {
+				org.bukkit.block.data.type.Bed bed = ((org.bukkit.block.data.type.Bed) block.getBlockData());
+				BukkitTools.getPluginManager().callEvent(new BedExplodeEvent(event.getPlayer(), block.getLocation(), block.getRelative(bed.getFacing()).getLocation(), block.getType()));
 			}
 		}
 	}

--- a/src/com/palmergames/bukkit/towny/object/TownyWorld.java
+++ b/src/com/palmergames/bukkit/towny/object/TownyWorld.java
@@ -33,12 +33,11 @@ public class TownyWorld extends TownyObject {
 	private boolean isUsingPlotManagementRevert = TownySettings.isUsingPlotManagementRevert();
 	private List<String> plotManagementIgnoreIds = null;
 
-	private boolean isUsingPlotManagementWildRevert = TownySettings.isUsingPlotManagementWildRegen();	
+	private boolean isUsingPlotManagementWildRevert = TownySettings.isUsingPlotManagementWildEntityRegen();	
 	private long plotManagementWildRevertDelay = TownySettings.getPlotManagementWildRegenDelay();
 	private List<String> entityExplosionProtection = null;
 	
 	private boolean isUsingPlotManagementWildBlockRevert = TownySettings.isUsingPlotManagementWildBlockRegen();
-	private long plotManagementWildBlockRevertDelay = TownySettings.getPlotManagementWildBlockRegenDelay();
 	private List<String> blockExplosionProtection = null;
 	
 	private List<String> unclaimedZoneIgnoreBlockMaterials = null;
@@ -414,7 +413,7 @@ public class TownyWorld extends TownyObject {
 	/**
 	 * @return the isUsingPlotManagementWildRevert
 	 */
-	public boolean isUsingPlotManagementWildBlockRevert() {
+	public boolean isUsingPlotManagementWildRevertBlocks() {
 
 		return isUsingPlotManagementWildBlockRevert;
 	}
@@ -480,23 +479,6 @@ public class TownyWorld extends TownyObject {
 
 		return (entityExplosionProtection.contains(entity.getType().getEntityClass().getSimpleName().toLowerCase()));
 
-	}
-	
-	/**
-	 * @return the plotManagementWildRevertDelay
-	 */
-	public long getPlotManagementWildBlockRevertDelay() {
-
-		return plotManagementWildBlockRevertDelay;
-	}
-
-	/**
-	 * @param plotManagementWildRevertDelay the plotManagementWildRevertDelay to
-	 *            set
-	 */
-	public void setPlotManagementWildBlockRevertDelay(long plotManagementWildBlockRevertDelay) {
-
-		this.plotManagementWildBlockRevertDelay = plotManagementWildBlockRevertDelay;
 	}
 
 	public void setPlotManagementWildRevertMaterials(List<String> mats) {
@@ -827,26 +809,34 @@ public class TownyWorld extends TownyObject {
 		TownyUniverse.getInstance().getDataSource().saveWorld(this);
 	}
 	
-	public boolean hasBedExplosionAtBlock(Location loc) {
-		return bedMap.containsKey(loc);
+	/**
+	 * Does this world have an exploded bet at the location?
+	 * @param location Location to test.
+	 * @return true when the bed map contains the location.
+	 */
+	public boolean hasBedExplosionAtBlock(Location location) {
+		return bedMap.containsKey(location);
 	}
-	
-	public void addBedExplosionAtBlock(Location loc, Material mat) {
-		bedMap.put(loc, mat);
-	}
-	
+
+	/**
+	 * Gets the exploded bed material.
+	 * @param location Location to get the material.
+	 * @return material of the bed or null if the bedMap doesn't contain the location.
+	 */
 	@Nullable
-	public Material getBedExplosionMaterial(Location loc) {
-		if (hasBedExplosionAtBlock(loc))
-			return bedMap.get(loc);
+	public Material getBedExplosionMaterial(Location location) {
+		if (hasBedExplosionAtBlock(location))
+			return bedMap.get(location);
 		return null;
 	}
 	
-	public void removeBedExplosionAtBlock(Location loc) {
-		if (hasBedExplosionAtBlock(loc)) {
-			bedMap.remove(loc);
-			System.out.println("bedremoved");
-		}
+	public void addBedExplosionAtBlock(Location location, Material material) {
+		bedMap.put(location, material);
+	}
+
+	public void removeBedExplosionAtBlock(Location location) {
+		if (hasBedExplosionAtBlock(location))
+			bedMap.remove(location);
 	}
 	
 }

--- a/src/com/palmergames/bukkit/towny/object/TownyWorld.java
+++ b/src/com/palmergames/bukkit/towny/object/TownyWorld.java
@@ -33,7 +33,7 @@ public class TownyWorld extends TownyObject {
 	private boolean isUsingPlotManagementRevert = TownySettings.isUsingPlotManagementRevert();
 	private List<String> plotManagementIgnoreIds = null;
 
-	private boolean isUsingPlotManagementWildRevert = TownySettings.isUsingPlotManagementWildEntityRegen();	
+	private boolean isUsingPlotManagementWildEntityRevert = TownySettings.isUsingPlotManagementWildEntityRegen();	
 	private long plotManagementWildRevertDelay = TownySettings.getPlotManagementWildRegenDelay();
 	private List<String> entityExplosionProtection = null;
 	
@@ -403,28 +403,28 @@ public class TownyWorld extends TownyObject {
 	}
 
 	/**
-	 * @return the isUsingPlotManagementWildRevert
+	 * @return the isUsingPlotManagementWildEntityRevert
 	 */
-	public boolean isUsingPlotManagementWildRevert() {
+	public boolean isUsingPlotManagementWildEntityRevert() {
 
-		return isUsingPlotManagementWildRevert;
+		return isUsingPlotManagementWildEntityRevert;
 	}
 	
 	/**
-	 * @return the isUsingPlotManagementWildRevert
+	 * @return the isUsingPlotManagementWildBlockRevert
 	 */
-	public boolean isUsingPlotManagementWildRevertBlocks() {
+	public boolean isUsingPlotManagementWildBlockRevert() {
 
 		return isUsingPlotManagementWildBlockRevert;
 	}
 
 	/**
-	 * @param isUsingPlotManagementWildRevert the
+	 * @param isUsingPlotManagementWildEntityRevert the
 	 *            isUsingPlotManagementWildRevert to set
 	 */
-	public void setUsingPlotManagementWildRevert(boolean isUsingPlotManagementWildRevert) {
+	public void setUsingPlotManagementWildEntityRevert(boolean isUsingPlotManagementWildEntityRevert) {
 
-		this.isUsingPlotManagementWildRevert = isUsingPlotManagementWildRevert;
+		this.isUsingPlotManagementWildEntityRevert = isUsingPlotManagementWildEntityRevert;
 	}
 	
 	/**

--- a/src/com/palmergames/bukkit/towny/object/TownyWorld.java
+++ b/src/com/palmergames/bukkit/towny/object/TownyWorld.java
@@ -2,7 +2,6 @@ package com.palmergames.bukkit.towny.object;
 
 import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.TownyUniverse;
-import com.palmergames.bukkit.towny.event.BedExplodeEvent;
 import com.palmergames.bukkit.towny.exceptions.AlreadyRegisteredException;
 import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
@@ -24,23 +23,33 @@ import java.util.Map;
 public class TownyWorld extends TownyObject {
 
 	private HashMap<String, Town> towns = new HashMap<>();
-	private boolean isClaimable = true;
+
 	private boolean isUsingPlotManagementDelete = TownySettings.isUsingPlotManagementDelete();
-	private boolean isUsingPlotManagementMayorDelete = TownySettings.isUsingPlotManagementMayorDelete();
-	private boolean isUsingPlotManagementRevert = TownySettings.isUsingPlotManagementRevert();
-	private boolean isUsingPlotManagementWildRevert = TownySettings.isUsingPlotManagementWildRegen();
-	private long plotManagementWildRevertDelay = TownySettings.getPlotManagementWildRegenDelay();
-	private List<String> unclaimedZoneIgnoreBlockMaterials = null;
 	private List<String> plotManagementDeleteIds = null;
+	
+	private boolean isUsingPlotManagementMayorDelete = TownySettings.isUsingPlotManagementMayorDelete();
 	private List<String> plotManagementMayorDelete = null;
+	
+	private boolean isUsingPlotManagementRevert = TownySettings.isUsingPlotManagementRevert();
 	private List<String> plotManagementIgnoreIds = null;
-	private Boolean unclaimedZoneBuild = null, unclaimedZoneDestroy = null,
-			unclaimedZoneSwitch = null, unclaimedZoneItemUse = null;
-	private String unclaimedZoneName = null;
-	private List<Coord> warZones = new ArrayList<>();
+
+	private boolean isUsingPlotManagementWildRevert = TownySettings.isUsingPlotManagementWildRegen();	
+	private long plotManagementWildRevertDelay = TownySettings.getPlotManagementWildRegenDelay();
 	private List<String> entityExplosionProtection = null;
 	
+	private boolean isUsingPlotManagementWildBlockRevert = TownySettings.isUsingPlotManagementWildBlockRegen();
+	private long plotManagementWildBlockRevertDelay = TownySettings.getPlotManagementWildBlockRegenDelay();
+	private List<String> blockExplosionProtection = null;
+	
+	private List<String> unclaimedZoneIgnoreBlockMaterials = null;
+	private Boolean unclaimedZoneBuild = null, unclaimedZoneDestroy = null,
+			unclaimedZoneSwitch = null, unclaimedZoneItemUse = null;
+
+	private String unclaimedZoneName = null;
+	private List<Coord> warZones = new ArrayList<>();
+	
 	private boolean isUsingTowny = TownySettings.isUsingTowny();
+	private boolean isClaimable = true;
 	private boolean isWarAllowed = TownySettings.isWarAllowed();
 	private boolean isPVP = TownySettings.isPvP();
 	private boolean isForcePVP = TownySettings.isForcingPvP();
@@ -54,7 +63,7 @@ public class TownyWorld extends TownyObject {
 	
 	private boolean isDisablePlayerTrample = TownySettings.isPlayerTramplingCropsDisabled();
 	private boolean isDisableCreatureTrample = TownySettings.isCreatureTramplingCropsDisabled();
-	public Map<Location, BedExplodeEvent> bedMap = new HashMap<Location, BedExplodeEvent>();
+	public Map<Location, Material> bedMap = new HashMap<Location, Material>();
 
 	// TODO: private List<TownBlock> adminTownBlocks = new
 	// ArrayList<TownBlock>();
@@ -401,6 +410,14 @@ public class TownyWorld extends TownyObject {
 
 		return isUsingPlotManagementWildRevert;
 	}
+	
+	/**
+	 * @return the isUsingPlotManagementWildRevert
+	 */
+	public boolean isUsingPlotManagementWildBlockRevert() {
+
+		return isUsingPlotManagementWildBlockRevert;
+	}
 
 	/**
 	 * @param isUsingPlotManagementWildRevert the
@@ -409,6 +426,15 @@ public class TownyWorld extends TownyObject {
 	public void setUsingPlotManagementWildRevert(boolean isUsingPlotManagementWildRevert) {
 
 		this.isUsingPlotManagementWildRevert = isUsingPlotManagementWildRevert;
+	}
+	
+	/**
+	 * @param isUsingPlotManagementWildBlockRevert the
+	 *            isUsingPlotManagementWildBlockRevert to set
+	 */
+	public void setUsingPlotManagementWildBlockRevert(boolean isUsingPlotManagementWildBlockRevert) {
+
+		this.isUsingPlotManagementWildBlockRevert = isUsingPlotManagementWildBlockRevert;
 	}
 
 	/**
@@ -453,6 +479,50 @@ public class TownyWorld extends TownyObject {
 			setPlotManagementWildRevertEntities(TownySettings.getWildExplosionProtectionEntities());
 
 		return (entityExplosionProtection.contains(entity.getType().getEntityClass().getSimpleName().toLowerCase()));
+
+	}
+	
+	/**
+	 * @return the plotManagementWildRevertDelay
+	 */
+	public long getPlotManagementWildBlockRevertDelay() {
+
+		return plotManagementWildBlockRevertDelay;
+	}
+
+	/**
+	 * @param plotManagementWildRevertDelay the plotManagementWildRevertDelay to
+	 *            set
+	 */
+	public void setPlotManagementWildBlockRevertDelay(long plotManagementWildBlockRevertDelay) {
+
+		this.plotManagementWildBlockRevertDelay = plotManagementWildBlockRevertDelay;
+	}
+
+	public void setPlotManagementWildRevertMaterials(List<String> mats) {
+
+		blockExplosionProtection = new ArrayList<>();
+
+		for (String mat : mats)
+			if (!mat.equals(""))
+				blockExplosionProtection.add(mat);
+
+	}
+
+	public List<String> getPlotManagementWildRevertBlocks() {
+
+		if (blockExplosionProtection == null)
+			setPlotManagementWildRevertMaterials(TownySettings.getWildExplosionProtectionBlocks());
+
+		return entityExplosionProtection;
+	}
+
+	public boolean isProtectingExplosionBlock(Material material) {
+
+		if (blockExplosionProtection == null)
+			setPlotManagementWildRevertMaterials(TownySettings.getWildExplosionProtectionBlocks());
+
+		return (blockExplosionProtection.contains(material.toString()));
 
 	}
 
@@ -761,11 +831,15 @@ public class TownyWorld extends TownyObject {
 		return bedMap.containsKey(loc);
 	}
 	
-	public void addBedExplosionAtBlock(Location loc, BedExplodeEvent event) {
-		bedMap.put(loc, event);
-
-		System.out.println("bed added");
-		System.out.println("Event Block Location " + loc);
+	public void addBedExplosionAtBlock(Location loc, Material mat) {
+		bedMap.put(loc, mat);
+	}
+	
+	@Nullable
+	public Material getBedExplosionMaterial(Location loc) {
+		if (hasBedExplosionAtBlock(loc))
+			return bedMap.get(loc);
+		return null;
 	}
 	
 	public void removeBedExplosionAtBlock(Location loc) {

--- a/src/com/palmergames/bukkit/towny/object/TownyWorld.java
+++ b/src/com/palmergames/bukkit/towny/object/TownyWorld.java
@@ -496,7 +496,7 @@ public class TownyWorld extends TownyObject {
 		if (blockExplosionProtection == null)
 			setPlotManagementWildRevertMaterials(TownySettings.getWildExplosionProtectionBlocks());
 
-		return entityExplosionProtection;
+		return blockExplosionProtection;
 	}
 
 	public boolean isProtectingExplosionBlock(Material material) {

--- a/src/com/palmergames/bukkit/towny/object/TownyWorld.java
+++ b/src/com/palmergames/bukkit/towny/object/TownyWorld.java
@@ -2,12 +2,15 @@ package com.palmergames.bukkit.towny.object;
 
 import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.TownyUniverse;
+import com.palmergames.bukkit.towny.event.BedExplodeEvent;
 import com.palmergames.bukkit.towny.exceptions.AlreadyRegisteredException;
 import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.TownyPermission.ActionType;
 import com.palmergames.bukkit.towny.object.metadata.CustomDataField;
 import com.palmergames.util.MathUtil;
+
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.Nullable;
@@ -16,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class TownyWorld extends TownyObject {
 
@@ -50,6 +54,7 @@ public class TownyWorld extends TownyObject {
 	
 	private boolean isDisablePlayerTrample = TownySettings.isPlayerTramplingCropsDisabled();
 	private boolean isDisableCreatureTrample = TownySettings.isCreatureTramplingCropsDisabled();
+	public Map<Location, BedExplodeEvent> bedMap = new HashMap<Location, BedExplodeEvent>();
 
 	// TODO: private List<TownBlock> adminTownBlocks = new
 	// ArrayList<TownBlock>();
@@ -751,4 +756,23 @@ public class TownyWorld extends TownyObject {
 
 		TownyUniverse.getInstance().getDataSource().saveWorld(this);
 	}
+	
+	public boolean hasBedExplosionAtBlock(Location loc) {
+		return bedMap.containsKey(loc);
+	}
+	
+	public void addBedExplosionAtBlock(Location loc, BedExplodeEvent event) {
+		bedMap.put(loc, event);
+
+		System.out.println("bed added");
+		System.out.println("Event Block Location " + loc);
+	}
+	
+	public void removeBedExplosionAtBlock(Location loc) {
+		if (hasBedExplosionAtBlock(loc)) {
+			bedMap.remove(loc);
+			System.out.println("bedremoved");
+		}
+	}
+	
 }


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This PR will create a new setting per-world allowing for admins to turn off the explosion reverting caused by blocks (beds and respawn anchors as of modern minecraft,) independently from explosions caused by entities.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->

  - New Config Option: new_world_settings.plot_management.wild_revert_on_block_explosion.enabled
    - default: true
    - Enabling this will slowly regenerate holes created in the wilderness by exploding blocks like beds.
    - Is a default setting for new worlds only.
  - New Config Option: new_world_settings.plot_management.wild_revert_on_block_explosion.blocks
    - default: WHITE_BED,ORANGE_BED,MAGENTA_BED,LIGHT_BLUE_BED,YELLOW_BED,LIME_BED,PINK_BED,GRAY_BED,LIGHT_GRAY_BED,CYAN_BED,PURPLE_BED,BLUE_BED,BROWN_BED,GREEN_BED,RED_BED,BLACK_BED
    - The list of blocks whose explosions should be reverted.
    - Is a default settings applied to new worlds only.
  - Removed Command: /tw toggle revertexpl
  - New Command: /tw toggle revertentityexpl
    - Toggles explosions caused by entities reverting on and off.
  - New Command: /tw toggle revertblockexpl
    - Toggles explosions caused by blocks reverting on and off.
  - Adds a BedExplosionEvent, fired from TownyPlayerListener.
    - The BukkitAPI does not return a bed when it explodes, rather a block air.
    - This is patched by using a bedMap in the TownyWorld object to track exploded beds and the explosions they cause.

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
#4300 

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
