### PR TITLE
Add per-world FriendlyFire setting.

### DIFF
--- a/resources/ChangeLog.txt
+++ b/resources/ChangeLog.txt
@@ -5074,3 +5074,4 @@ v0.92.0.11:
       - NationRemoveAllyEvent
   - pt-br.yml updated to 0.86 by Plugner with PR #4348. (First-Time Contributor!)
   - New farmable nether blocks added to config by Momshroom with PR #4353. (First-Time Contributor!)
+  - Fix bankruptcy test stopping players from using /t claim.

--- a/resources/chinese.yml
+++ b/resources/chinese.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.86
+version: 0.87
 language: Chinese
 author: ElgarL
 website: 'http://townyadvanced.github.io/'
@@ -1163,3 +1163,12 @@ msg_your_town_payed_upkeep: '&bYour town paid the daily upkeep of %s.'
 msg_your_nation_payed_upkeep: '&bYour nation paid the daily upkeep of %s.'
 msg_your_town_couldnt_pay_upkeep: '&bYour town could not pay the daily upkeep of %s and has disbanded.'
 msg_your_nation_couldnt_pay_upkeep: '&bYour nation could not pay the daily upkeep of %s and has disbanded.'
+
+#Added in 0.87
+msg_town_reached_debtcap_and_is_disbanded: '&b%s could not pay their upkeep, reached their debtcap, and has disbanded.'
+msg_town_reached_debtcap_and_is_disbanded_multiple: '&bThe following towns could not pay their upkeep, reached their debtcap, and have disbanded: '
+msg_unable_to_deposit_x: 'Unable to deposit %s into that town''s bank.'
+msg_unable_to_withdraw_x: 'Unable to withdraw %s from that town''s bank.'
+status_debtcap: '&2Debt Cap: &a%s'
+status_world_explrevert_entity: '&2Entity Explosion Revert: '
+status_world_explrevert_block: '&2Block Explosion Revert: '

--- a/resources/es-mx.yml
+++ b/resources/es-mx.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.86
+version: 0.87
 language: español
 author: VreyaViress
 website: 'http://townyadvanced.github.io/'
@@ -1150,3 +1150,12 @@ msg_your_town_payed_upkeep: '&bYour town paid the daily upkeep of %s.'
 msg_your_nation_payed_upkeep: '&bYour nation paid the daily upkeep of %s.'
 msg_your_town_couldnt_pay_upkeep: '&bYour town could not pay the daily upkeep of %s and has disbanded.'
 msg_your_nation_couldnt_pay_upkeep: '&bYour nation could not pay the daily upkeep of %s and has disbanded.'
+
+#Added in 0.87
+msg_town_reached_debtcap_and_is_disbanded: '&b%s could not pay their upkeep, reached their debtcap, and has disbanded.'
+msg_town_reached_debtcap_and_is_disbanded_multiple: '&bThe following towns could not pay their upkeep, reached their debtcap, and have disbanded: '
+msg_unable_to_deposit_x: 'Unable to deposit %s into that town''s bank.'
+msg_unable_to_withdraw_x: 'Unable to withdraw %s from that town''s bank.'
+status_debtcap: '&2Debt Cap: &a%s'
+status_world_explrevert_entity: '&2Entity Explosion Revert: '
+status_world_explrevert_block: '&2Block Explosion Revert: '

--- a/resources/french.yml
+++ b/resources/french.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.86
+version: 0.87
 language: french
 author: Noiknez,TheCalypso,Cidalex,Mitsu,ARNPIK
 website: 'http://townyadvanced.github.io/'
@@ -1163,3 +1163,12 @@ msg_your_town_payed_upkeep: '&bYour town paid the daily upkeep of %s.'
 msg_your_nation_payed_upkeep: '&bYour nation paid the daily upkeep of %s.'
 msg_your_town_couldnt_pay_upkeep: '&bYour town could not pay the daily upkeep of %s and has disbanded.'
 msg_your_nation_couldnt_pay_upkeep: '&bYour nation could not pay the daily upkeep of %s and has disbanded.'
+
+#Added in 0.87
+msg_town_reached_debtcap_and_is_disbanded: '&b%s could not pay their upkeep, reached their debtcap, and has disbanded.'
+msg_town_reached_debtcap_and_is_disbanded_multiple: '&bThe following towns could not pay their upkeep, reached their debtcap, and have disbanded: '
+msg_unable_to_deposit_x: 'Unable to deposit %s into that town''s bank.'
+msg_unable_to_withdraw_x: 'Unable to withdraw %s from that town''s bank.'
+status_debtcap: '&2Debt Cap: &a%s'
+status_world_explrevert_entity: '&2Entity Explosion Revert: '
+status_world_explrevert_block: '&2Block Explosion Revert: '

--- a/resources/german.yml
+++ b/resources/german.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.86
+version: 0.87
 language: german
 author: 'ElgarL, translated by Articdive, Wolf2323, BlocK, Yasu-San and enterih'
 website: 'http://townyadvanced.github.io/'
@@ -1165,3 +1165,12 @@ msg_your_town_payed_upkeep: '&bYour town paid the daily upkeep of %s.'
 msg_your_nation_payed_upkeep: '&bYour nation paid the daily upkeep of %s.'
 msg_your_town_couldnt_pay_upkeep: '&bYour town could not pay the daily upkeep of %s and has disbanded.'
 msg_your_nation_couldnt_pay_upkeep: '&bYour nation could not pay the daily upkeep of %s and has disbanded.'
+
+#Added in 0.87
+msg_town_reached_debtcap_and_is_disbanded: '&b%s could not pay their upkeep, reached their debtcap, and has disbanded.'
+msg_town_reached_debtcap_and_is_disbanded_multiple: '&bThe following towns could not pay their upkeep, reached their debtcap, and have disbanded: '
+msg_unable_to_deposit_x: 'Unable to deposit %s into that town''s bank.'
+msg_unable_to_withdraw_x: 'Unable to withdraw %s from that town''s bank.'
+status_debtcap: '&2Debt Cap: &a%s'
+status_world_explrevert_entity: '&2Entity Explosion Revert: '
+status_world_explrevert_block: '&2Block Explosion Revert: '

--- a/resources/italian.yml
+++ b/resources/italian.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.86
+version: 0.87
 language: italian
 author: Leomixer17
 website: 'http://townyadvanced.github.io/'
@@ -1164,3 +1164,12 @@ msg_your_town_payed_upkeep: '&bYour town paid the daily upkeep of %s.'
 msg_your_nation_payed_upkeep: '&bYour nation paid the daily upkeep of %s.'
 msg_your_town_couldnt_pay_upkeep: '&bYour town could not pay the daily upkeep of %s and has disbanded.'
 msg_your_nation_couldnt_pay_upkeep: '&bYour nation could not pay the daily upkeep of %s and has disbanded.'
+
+#Added in 0.87
+msg_town_reached_debtcap_and_is_disbanded: '&b%s could not pay their upkeep, reached their debtcap, and has disbanded.'
+msg_town_reached_debtcap_and_is_disbanded_multiple: '&bThe following towns could not pay their upkeep, reached their debtcap, and have disbanded: '
+msg_unable_to_deposit_x: 'Unable to deposit %s into that town''s bank.'
+msg_unable_to_withdraw_x: 'Unable to withdraw %s from that town''s bank.'
+status_debtcap: '&2Debt Cap: &a%s'
+status_world_explrevert_entity: '&2Entity Explosion Revert: '
+status_world_explrevert_block: '&2Block Explosion Revert: '

--- a/resources/korean.yml
+++ b/resources/korean.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.86
+version: 0.87
 language: 한국어
 author: 'Daybreak 새벽'
 website: 'http://townyadvanced.github.io/'
@@ -1075,3 +1075,12 @@ msg_your_town_payed_upkeep: '&bYour town paid the daily upkeep of %s.'
 msg_your_nation_payed_upkeep: '&bYour nation paid the daily upkeep of %s.'
 msg_your_town_couldnt_pay_upkeep: '&bYour town could not pay the daily upkeep of %s and has disbanded.'
 msg_your_nation_couldnt_pay_upkeep: '&bYour nation could not pay the daily upkeep of %s and has disbanded.'
+
+#Added in 0.87
+msg_town_reached_debtcap_and_is_disbanded: '&b%s could not pay their upkeep, reached their debtcap, and has disbanded.'
+msg_town_reached_debtcap_and_is_disbanded_multiple: '&bThe following towns could not pay their upkeep, reached their debtcap, and have disbanded: '
+msg_unable_to_deposit_x: 'Unable to deposit %s into that town''s bank.'
+msg_unable_to_withdraw_x: 'Unable to withdraw %s from that town''s bank.'
+status_debtcap: '&2Debt Cap: &a%s'
+status_world_explrevert_entity: '&2Entity Explosion Revert: '
+status_world_explrevert_block: '&2Block Explosion Revert: '

--- a/resources/norwegian.yml
+++ b/resources/norwegian.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.86
+version: 0.87
 language: norwegian
 author: Nectuz, Walbern
 website: 'http://townyadvanced.github.io/'
@@ -1162,3 +1162,12 @@ msg_your_town_payed_upkeep: '&bYour town paid the daily upkeep of %s.'
 msg_your_nation_payed_upkeep: '&bYour nation paid the daily upkeep of %s.'
 msg_your_town_couldnt_pay_upkeep: '&bYour town could not pay the daily upkeep of %s and has disbanded.'
 msg_your_nation_couldnt_pay_upkeep: '&bYour nation could not pay the daily upkeep of %s and has disbanded.'
+
+#Added in 0.87
+msg_town_reached_debtcap_and_is_disbanded: '&b%s could not pay their upkeep, reached their debtcap, and has disbanded.'
+msg_town_reached_debtcap_and_is_disbanded_multiple: '&bThe following towns could not pay their upkeep, reached their debtcap, and have disbanded: '
+msg_unable_to_deposit_x: 'Unable to deposit %s into that town''s bank.'
+msg_unable_to_withdraw_x: 'Unable to withdraw %s from that town''s bank.'
+status_debtcap: '&2Debt Cap: &a%s'
+status_world_explrevert_entity: '&2Entity Explosion Revert: '
+status_world_explrevert_block: '&2Block Explosion Revert: '

--- a/resources/polish.yml
+++ b/resources/polish.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.86
+version: 0.87
 language: polish
 author: Martinez
 website: 'http://townyadvanced.github.io/'
@@ -1162,3 +1162,12 @@ msg_your_town_payed_upkeep: '&bYour town paid the daily upkeep of %s.'
 msg_your_nation_payed_upkeep: '&bYour nation paid the daily upkeep of %s.'
 msg_your_town_couldnt_pay_upkeep: '&bYour town could not pay the daily upkeep of %s and has disbanded.'
 msg_your_nation_couldnt_pay_upkeep: '&bYour nation could not pay the daily upkeep of %s and has disbanded.'
+
+#Added in 0.87
+msg_town_reached_debtcap_and_is_disbanded: '&b%s could not pay their upkeep, reached their debtcap, and has disbanded.'
+msg_town_reached_debtcap_and_is_disbanded_multiple: '&bThe following towns could not pay their upkeep, reached their debtcap, and have disbanded: '
+msg_unable_to_deposit_x: 'Unable to deposit %s into that town''s bank.'
+msg_unable_to_withdraw_x: 'Unable to withdraw %s from that town''s bank.'
+status_debtcap: '&2Debt Cap: &a%s'
+status_world_explrevert_entity: '&2Entity Explosion Revert: '
+status_world_explrevert_block: '&2Block Explosion Revert: '

--- a/resources/pt-br.yml
+++ b/resources/pt-br.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.86
+version: 0.87
 language: português (Brasil)
 author: BannerGames, Plugner
 website: 'http://townyadvanced.github.io/'
@@ -1166,3 +1166,12 @@ msg_your_town_payed_upkeep: '&bSua cidade pagou a manutenção diária de %s.'
 msg_your_nation_payed_upkeep: '&bSua nação pagou a manutenção diária de %s.'
 msg_your_town_couldnt_pay_upkeep: '&bSua cidade não podia pagar a manutenção diária de %s e foi dissolvida.'
 msg_your_nation_couldnt_pay_upkeep: '&bSua nação não podia pagar a manutenção diária de %s e foi dissolvida.'
+
+#Added in 0.87
+msg_town_reached_debtcap_and_is_disbanded: '&b%s could not pay their upkeep, reached their debtcap, and has disbanded.'
+msg_town_reached_debtcap_and_is_disbanded_multiple: '&bThe following towns could not pay their upkeep, reached their debtcap, and have disbanded: '
+msg_unable_to_deposit_x: 'Unable to deposit %s into that town''s bank.'
+msg_unable_to_withdraw_x: 'Unable to withdraw %s from that town''s bank.'
+status_debtcap: '&2Debt Cap: &a%s'
+status_world_explrevert_entity: '&2Entity Explosion Revert: '
+status_world_explrevert_block: '&2Block Explosion Revert: '

--- a/resources/russian.yml
+++ b/resources/russian.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.86
+version: 0.87
 language: russian
 author: ElgarL (Plugin developer), Communar, Egor33345 (Russian Translation)
 website: 'http://townyadvanced.github.io/'
@@ -1162,3 +1162,12 @@ msg_your_town_payed_upkeep: '&bYour town paid the daily upkeep of %s.'
 msg_your_nation_payed_upkeep: '&bYour nation paid the daily upkeep of %s.'
 msg_your_town_couldnt_pay_upkeep: '&bYour town could not pay the daily upkeep of %s and has disbanded.'
 msg_your_nation_couldnt_pay_upkeep: '&bYour nation could not pay the daily upkeep of %s and has disbanded.'
+
+#Added in 0.87
+msg_town_reached_debtcap_and_is_disbanded: '&b%s could not pay their upkeep, reached their debtcap, and has disbanded.'
+msg_town_reached_debtcap_and_is_disbanded_multiple: '&bThe following towns could not pay their upkeep, reached their debtcap, and have disbanded: '
+msg_unable_to_deposit_x: 'Unable to deposit %s into that town''s bank.'
+msg_unable_to_withdraw_x: 'Unable to withdraw %s from that town''s bank.'
+status_debtcap: '&2Debt Cap: &a%s'
+status_world_explrevert_entity: '&2Entity Explosion Revert: '
+status_world_explrevert_block: '&2Block Explosion Revert: '

--- a/resources/spanish.yml
+++ b/resources/spanish.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.86
+version: 0.87
 language: spanish
 author: Seruhio, Alvarote1998, Beelzebu
 website: 'http://townyadvanced.github.io/'
@@ -1162,3 +1162,12 @@ msg_your_town_payed_upkeep: '&bYour town paid the daily upkeep of %s.'
 msg_your_nation_payed_upkeep: '&bYour nation paid the daily upkeep of %s.'
 msg_your_town_couldnt_pay_upkeep: '&bYour town could not pay the daily upkeep of %s and has disbanded.'
 msg_your_nation_couldnt_pay_upkeep: '&bYour nation could not pay the daily upkeep of %s and has disbanded.'
+
+#Added in 0.87
+msg_town_reached_debtcap_and_is_disbanded: '&b%s could not pay their upkeep, reached their debtcap, and has disbanded.'
+msg_town_reached_debtcap_and_is_disbanded_multiple: '&bThe following towns could not pay their upkeep, reached their debtcap, and have disbanded: '
+msg_unable_to_deposit_x: 'Unable to deposit %s into that town''s bank.'
+msg_unable_to_withdraw_x: 'Unable to withdraw %s from that town''s bank.'
+status_debtcap: '&2Debt Cap: &a%s'
+status_world_explrevert_entity: '&2Entity Explosion Revert: '
+status_world_explrevert_block: '&2Block Explosion Revert: '

--- a/resources/zh-TW.yml
+++ b/resources/zh-TW.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.86
+version: 0.87
 language: zh-TW
 author: ElgarL
 website: 'http://townyadvanced.github.io/'
@@ -1161,3 +1161,12 @@ msg_your_town_payed_upkeep: '&bYour town paid the daily upkeep of %s.'
 msg_your_nation_payed_upkeep: '&bYour nation paid the daily upkeep of %s.'
 msg_your_town_couldnt_pay_upkeep: '&bYour town could not pay the daily upkeep of %s and has disbanded.'
 msg_your_nation_couldnt_pay_upkeep: '&bYour nation could not pay the daily upkeep of %s and has disbanded.'
+
+#Added in 0.87
+msg_town_reached_debtcap_and_is_disbanded: '&b%s could not pay their upkeep, reached their debtcap, and has disbanded.'
+msg_town_reached_debtcap_and_is_disbanded_multiple: '&bThe following towns could not pay their upkeep, reached their debtcap, and have disbanded: '
+msg_unable_to_deposit_x: 'Unable to deposit %s into that town''s bank.'
+msg_unable_to_withdraw_x: 'Unable to withdraw %s from that town''s bank.'
+status_debtcap: '&2Debt Cap: &a%s'
+status_world_explrevert_entity: '&2Entity Explosion Revert: '
+status_world_explrevert_block: '&2Block Explosion Revert: '

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -237,6 +237,13 @@ public enum ConfigNodes {
 			"",
 			"# Do new worlds have pvp forced on by default?",
 			"# This setting overrides a towns' setting."),
+	NWS_FRIENDLY_FIRE_ENABLED(
+			"new_world_settings.pvp.friendly_fire_enabled",
+			"false",
+			"",
+			"# Do new world have friendly fire enabled by default?",
+			"# Does not affect Arena Plots which have FF enabled all the time.",
+			"# When true players on the same town or nation will harm each other."),	
 	NWS_WAR_ALLOWED(
 			"new_world_settings.pvp.war_allowed",
 			"true",
@@ -404,11 +411,6 @@ public enum ConfigNodes {
 			"  # +------------------------------------------------------+ #",
 			"  ############################################################",
 			""),
-	GTOWN_SETTINGS_FRIENDLY_FIRE(
-			"global_town_settings.friendly_fire",
-			"true",
-			"",
-			"# can residents/Allies harm other residents when in an area with pvp enabled? Other than an Arena plot."),
 	GTOWN_SETTINGS_HEALTH_REGEN(
 			"global_town_settings.health_regen",
 			"",

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -955,11 +955,11 @@ public class TownySettings {
 		return getInt(ConfigNodes.TOWN_TOWN_BLOCK_SIZE);
 	}
 
-	public static boolean getFriendlyFire() {
+	public static boolean isFriendlyFireEnabled() {
 
-		return getBoolean(ConfigNodes.GTOWN_SETTINGS_FRIENDLY_FIRE);
+		return getBoolean(ConfigNodes.NWS_FRIENDLY_FIRE_ENABLED);
 	}
-
+	
 	public static boolean isUsingEconomy() {
 
 		return getBoolean(ConfigNodes.PLUGIN_USING_ECONOMY);

--- a/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
+++ b/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
@@ -33,6 +33,7 @@ public class SQL_Schema {
 		columns.add("`pvp` bool NOT NULL DEFAULT '0'");
 		columns.add("`forcepvp` bool NOT NULL DEFAULT '0'");
 		columns.add("`forcetownmobs` bool NOT NULL DEFAULT '0'");
+		columns.add("`friendlyFire` bool NOT NULL DEFAULT '0'");
 		columns.add("`worldmobs` bool NOT NULL DEFAULT '0'");
 		columns.add("`firespread` bool NOT NULL DEFAULT '0'");
 		columns.add("`forcefirespread` bool NOT NULL DEFAULT '0'");

--- a/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -1193,6 +1193,13 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 					} catch (Exception ignored) {
 					}
 				
+				line = keys.get("friendlyFire");
+				if (line != null)
+					try {
+						world.setFriendlyFire(Boolean.parseBoolean(line));
+					} catch (Exception ignored) {
+					}
+				
 				line = keys.get("forcetownmobs");
 				if (line != null)
 					try {
@@ -1928,6 +1935,8 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 		list.add("pvp=" + world.isPVP());
 		// Force PvP
 		list.add("forcepvp=" + world.isForcePVP());
+		// FriendlyFire 
+		list.add("friendlyFire=" + world.isFriendlyFireEnabled());		
 		// Claimable
 		list.add("# Can players found towns and claim plots in this world?");
 		list.add("claimable=" + world.isClaimable());

--- a/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -1369,6 +1369,12 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 				world.setForcePVP(result);
 			} catch (Exception ignored) {
 			}
+			
+			result = rs.getBoolean("friendlyFire");
+			try {
+				world.setFriendlyFire(result);
+			} catch (Exception ignored) {
+			}
 
 			result = rs.getBoolean("forcetownmobs");
 			try {
@@ -1943,6 +1949,8 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			nat_hm.put("pvp", world.isPVP());
 			// Force PvP
 			nat_hm.put("forcepvp", world.isForcePVP());
+			// Friendly Fire
+			nat_hm.put("friendlyFire", world.isFriendlyFireEnabled());
 			// Claimable
 			nat_hm.put("claimable", world.isClaimable());
 			// has monster spawns

--- a/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
@@ -150,6 +150,7 @@ public class TownyEntityListener implements Listener {
 					return;
 				}
 				TownyUniverse universe = TownyUniverse.getInstance();
+				TownyWorld world = universe.getDataSource().getTownWorld(attacker.getLocation().getWorld().toString());
 				//Cancel because one of two players has no town and should not be interfering during war.
 				if (!universe.getDataSource().getResident(attacker.getName()).hasTown() || !universe.getDataSource().getResident(defender.getName()).hasTown()){
 					TownyMessaging.sendMessage(attacker, Translation.of("msg_war_a_player_has_no_town"));
@@ -182,7 +183,7 @@ public class TownyEntityListener implements Listener {
 					}
 					
 					//Cancel because one of the two players considers the other an ally.
-					if ( ((attackerTown.getNation().hasAlly(defenderTown.getNation())) || (defenderTown.getNation().hasAlly(attackerTown.getNation()))) && !TownySettings.getFriendlyFire()){
+					if ( ((attackerTown.getNation().hasAlly(defenderTown.getNation())) || (defenderTown.getNation().hasAlly(attackerTown.getNation()))) && !world.isFriendlyFireEnabled()){
 						TownyMessaging.sendMessage(attacker, Translation.of("msg_war_a_player_is_an_ally"));
 						event.setCancelled(true);
 						return;
@@ -190,7 +191,7 @@ public class TownyEntityListener implements Listener {
 				} catch (NotRegisteredException e) {
 					//One of the players has no nation.
 				}
-				if (CombatUtil.preventFriendlyFire((Player) attacker, (Player) defender)) {
+				if (CombatUtil.preventFriendlyFire((Player) attacker, (Player) defender, world)) {
 					// Remove the projectile here so no
 					// other events can fire to cause damage
 					if (attacker instanceof Projectile)

--- a/src/com/palmergames/bukkit/towny/object/Town.java
+++ b/src/com/palmergames/bukkit/towny/object/Town.java
@@ -1300,7 +1300,7 @@ public class Town extends Government implements TownBlockOwner {
 	 */
 	public boolean isBankrupt() { 
 		try {
-			return getAccount().isBankrupt();
+			return TownySettings.isUsingEconomy() && getAccount().isBankrupt();
 		} catch (EconomyException ignored) {}
 
 		return false;

--- a/src/com/palmergames/bukkit/towny/object/TownyWorld.java
+++ b/src/com/palmergames/bukkit/towny/object/TownyWorld.java
@@ -52,6 +52,7 @@ public class TownyWorld extends TownyObject {
 	private boolean isWarAllowed = TownySettings.isWarAllowed();
 	private boolean isPVP = TownySettings.isPvP();
 	private boolean isForcePVP = TownySettings.isForcingPvP();
+	private boolean isFriendlyFire = TownySettings.isFriendlyFireEnabled();
 	private boolean isFire = TownySettings.isFire();
 	private boolean isForceFire = TownySettings.isForcingFire();
 	private boolean hasWorldMobs = TownySettings.isWorldMonstersOn();
@@ -837,6 +838,15 @@ public class TownyWorld extends TownyObject {
 	public void removeBedExplosionAtBlock(Location location) {
 		if (hasBedExplosionAtBlock(location))
 			bedMap.remove(location);
+	}
+
+	public void setFriendlyFire(boolean parseBoolean) {
+		isFriendlyFire = parseBoolean;
+		
+	}
+	
+	public boolean isFriendlyFireEnabled( ) {
+		return isFriendlyFire;
 	}
 	
 }

--- a/src/com/palmergames/bukkit/towny/utils/CombatUtil.java
+++ b/src/com/palmergames/bukkit/towny/utils/CombatUtil.java
@@ -133,7 +133,7 @@ public class CombatUtil {
 				/*
 				 * Defending player is in a warzone
 				 */
-				if (world.isWarZone(coord) && !preventFriendlyFire(attackingPlayer, defendingPlayer))
+				if (world.isWarZone(coord) && !preventFriendlyFire(attackingPlayer, defendingPlayer, world))
 					return false;
 
 				/*
@@ -149,7 +149,7 @@ public class CombatUtil {
 				 * Check the defenders TownBlock and it's Town for their PvP
 				 * status, else the world.
 				 */
-				if (preventFriendlyFire(attackingPlayer, defendingPlayer) || preventPvP(world, attackerTB) || preventPvP(world, defenderTB)) {
+				if (preventFriendlyFire(attackingPlayer, defendingPlayer, world) || preventPvP(world, attackerTB) || preventPvP(world, defenderTB)) {
 
 					DisallowedPVPEvent event = new DisallowedPVPEvent(attackingPlayer, defendingPlayer);
 					plugin.getServer().getPluginManager().callEvent(event);
@@ -331,11 +331,30 @@ public class CombatUtil {
 	/**
 	 * Should we be preventing friendly fire?
 	 * 
+	 * Deprecated as of 0.96.2.20 use {@link CombatUtil#preventFriendlyFire(Player, Player, TownyWorld) instead}
+	 * 
 	 * @param attacker - Attacking Player
 	 * @param defender - Defending Player (receiving damage)
 	 * @return true if we should cancel damage.
 	 */
+	@Deprecated
 	public static boolean preventFriendlyFire(Player attacker, Player defender) {
+		TownyWorld world = null;
+		try {
+			world = TownyUniverse.getInstance().getDataSource().getWorld(attacker.getLocation().getWorld().getName());
+		} catch (NotRegisteredException ignored) {}
+		return preventFriendlyFire(attacker, defender, world);
+	}
+	
+	/**
+	 * Should we be preventing friendly fire?
+	 * 
+	 * @param attacker - Attacking Player
+	 * @param defender - Defending Player (receiving damage)
+	 * @param world - TownyWorld being tested.
+	 * @return true if we should cancel damage.
+	 */
+	public static boolean preventFriendlyFire(Player attacker, Player defender, TownyWorld world) {
 
 		/*
 		 * Don't block potion use (self damaging) on ourselves.
@@ -344,7 +363,7 @@ public class CombatUtil {
 			return false;
 
 		if ((attacker != null) && (defender != null))
-			if (!TownySettings.getFriendlyFire() && CombatUtil.isAlly(attacker.getName(), defender.getName())) {
+			if (!world.isFriendlyFireEnabled() && CombatUtil.isAlly(attacker.getName(), defender.getName())) {
 				try {
 					TownBlock townBlock = new WorldCoord(defender.getWorld().getName(), Coord.parseCoord(defender)).getTownBlock();
 					if (!townBlock.getType().equals(TownBlockType.ARENA))


### PR DESCRIPTION




<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
  - Added CombatUtil.preventFriendlyFire(attacker, defender, world).
  - Deprecated CombatUtil.preventFriendlyFire(attacker, defender).

  - Adds friendlyFire setting to database as a world setting.


____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->

  - New Config Option: new_world_settings.pvp.friendly_fire_enabled
    - Default: false.
    - Do new world have friendly fire enabled by default?
    - Does not affect Arena Plots which have FF enabled all the time.
    - When true players on the same town or nation will harm each other.
  - Removed Config Option: global_town_settings.friendly_fire

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

  - Closes #1242.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
