### PR TITLE
Fix Config Migrator & Add debtCapModifier

### DIFF
--- a/resources/config-migration.json
+++ b/resources/config-migration.json
@@ -70,7 +70,7 @@
       },
       {
         "type": "TOWN_LEVEL_ADD",
-        "path": "debtCapModifier",
+        "key": "debtCapModifier",
         "value": "1.0"
       }
     ]

--- a/resources/config-migration.json
+++ b/resources/config-migration.json
@@ -67,6 +67,11 @@
         "path": "new_world_settings.plot_management.revert_on_unclaim.block_ignore",
         "value": "FURNACE,BLAST_FURNACE,SMOKER,BREWING_STAND,TNT,AIR,FIRE,NETHER_QUARTZ_ORE",
         "worldAction": "UPDATE_WORLD_BLOCK_IGNORE"
+      },
+      {
+        "type": "TOWN_LEVEL_ADD",
+        "path": "debtCapModifier",
+        "value": "1.0"
       }
     ]
   }

--- a/resources/config-migration.json
+++ b/resources/config-migration.json
@@ -67,7 +67,12 @@
         "path": "new_world_settings.plot_management.revert_on_unclaim.block_ignore",
         "value": "FURNACE,BLAST_FURNACE,SMOKER,BREWING_STAND,TNT,AIR,FIRE,NETHER_QUARTZ_ORE",
         "worldAction": "UPDATE_WORLD_BLOCK_IGNORE"
-      },
+      }
+    ]
+  },
+  {
+    "version": "0.96.2.22",
+    "changes": [
       {
         "type": "TOWN_LEVEL_ADD",
         "key": "debtCapModifier",

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1788,6 +1788,13 @@ public enum ConfigNodes {
 			"",
 			"# When set to greater than 0.0, this setting will override all other debt calculations and maximums,",
 			"# making all towns have the same debt cap."),
+	ECO_BANKRUPTCY_DEBT_CAP_USES_TOWN_LEVELS(
+			"economy.bankruptcy.debt_cap.debt_cap_uses_town_levels",
+			"false",
+			"",
+			"# When true the debt_cap.override price will be multiplied by the debtCapModifier in the town_level",
+			"# section of the config. (Ex: debtCapModifier of 3.0 and debt_cap.override of 1000.0 would set ",
+			"# a debtcap of 3.0 x 1000 = 3000."),
 	ECO_BANKRUPTCY_UPKEEP(
 			"economy.bankruptcy.upkeep",
 			"",

--- a/src/com/palmergames/bukkit/config/migration/ConfigMigrator.java
+++ b/src/com/palmergames/bukkit/config/migration/ConfigMigrator.java
@@ -66,10 +66,10 @@ public class ConfigMigrator {
 				config.set(change.path, base + change.value);
 				break;
 			case TOWN_LEVEL_ADD:
-				addTownLevelProperty(change.path, change.value);
+				addTownLevelProperty(change.key, change.value);
 				break;
 			case NATION_LEVEL_ADD:
-				addNationLevelProperty(change.path, change.value);
+				addNationLevelProperty(change.key, change.value);
 				break;
 			default:
 				throw new UnsupportedOperationException("Unsupported Change type: " + change);

--- a/src/com/palmergames/bukkit/config/migration/ConfigMigrator.java
+++ b/src/com/palmergames/bukkit/config/migration/ConfigMigrator.java
@@ -66,10 +66,10 @@ public class ConfigMigrator {
 				config.set(change.path, base + change.value);
 				break;
 			case TOWN_LEVEL_ADD:
-				addTownLevelProperty(change.key, change.value);
+				addTownLevelProperty(change.path, change.value);
 				break;
 			case NATION_LEVEL_ADD:
-				addNationLevelProperty(change.key, change.value);
+				addNationLevelProperty(change.path, change.value);
 				break;
 			default:
 				throw new UnsupportedOperationException("Unsupported Change type: " + change);

--- a/src/com/palmergames/bukkit/towny/ChunkNotification.java
+++ b/src/com/palmergames/bukkit/towny/ChunkNotification.java
@@ -46,7 +46,7 @@ public class ChunkNotification {
 
 	/**
 	 * Called on Config load.
-	 * Specifically: TownySettings.loadCachedLangStrings()
+	 * Specifically: TownySettings.loadConfig()
 	 */
 	public static void loadFormatStrings() {
 

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -233,6 +233,9 @@ public class TownySettings {
 			setDefaults(version, file);
 
 			config.save();
+			
+			loadWarMaterialsLists(); // TODO: move this to be with the other war stuff.
+			ChunkNotification.loadFormatStrings();
 		}
 	}
 	
@@ -243,27 +246,24 @@ public class TownySettings {
 			playermap = new CommentedConfiguration(file);
 			if (!playermap.load()) {
 				System.out.println("Failed to load playermap!");
-				
-				
 			}
 		}
 	}
-
-	public static void loadCachedObjects() throws IOException {
-
+	
+	private static void loadWarMaterialsLists() {
 		// Cell War material types.
 		FlagWarConfig.setFlagBaseMaterial(Material.matchMaterial(getString(ConfigNodes.WAR_ENEMY_FLAG_BASE_BLOCK)));
 		FlagWarConfig.setFlagLightMaterial(Material.matchMaterial(getString(ConfigNodes.WAR_ENEMY_FLAG_LIGHT_BLOCK)));
 		FlagWarConfig.setBeaconWireFrameMaterial(Material.matchMaterial(getString(ConfigNodes.WAR_ENEMY_BEACON_WIREFRAME_BLOCK)));
 
+		// Load allowed blocks in warzone.
+		WarZoneConfig.setEditableMaterialsInWarZone(getAllowedMaterials(ConfigNodes.WAR_WARZONE_EDITABLE_MATERIALS));
+	}
+
+	public static void loadTownAndNationLevels() throws IOException {
 		// Load Nation & Town level data into maps.
 		loadTownLevelConfig();
 		loadNationLevelConfig();
-
-		// Load allowed blocks in warzone.
-		WarZoneConfig.setEditableMaterialsInWarZone(getAllowedMaterials(ConfigNodes.WAR_WARZONE_EDITABLE_MATERIALS));
-
-		ChunkNotification.loadFormatStrings();
 	}
 
 	public static void sendError(String msg) {

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -46,7 +46,7 @@ public class TownySettings {
 
 	// Town Level
 	public enum TownLevel {
-		NAME_PREFIX, NAME_POSTFIX, MAYOR_PREFIX, MAYOR_POSTFIX, TOWN_BLOCK_LIMIT, UPKEEP_MULTIPLIER, OUTPOST_LIMIT, TOWN_BLOCK_BUY_BONUS_LIMIT
+		NAME_PREFIX, NAME_POSTFIX, MAYOR_PREFIX, MAYOR_POSTFIX, TOWN_BLOCK_LIMIT, UPKEEP_MULTIPLIER, OUTPOST_LIMIT, TOWN_BLOCK_BUY_BONUS_LIMIT, DEBT_CAP_MODIFIER
 	}
 
 	// Nation Level
@@ -61,7 +61,7 @@ public class TownySettings {
 	private static final SortedMap<Integer, Map<TownySettings.TownLevel, Object>> configTownLevel = Collections.synchronizedSortedMap(new TreeMap<Integer, Map<TownySettings.TownLevel, Object>>(Collections.reverseOrder()));
 	private static final SortedMap<Integer, Map<TownySettings.NationLevel, Object>> configNationLevel = Collections.synchronizedSortedMap(new TreeMap<Integer, Map<TownySettings.NationLevel, Object>>(Collections.reverseOrder()));
 	
-	public static void newTownLevel(int numResidents, String namePrefix, String namePostfix, String mayorPrefix, String mayorPostfix, int townBlockLimit, double townUpkeepMultiplier, int townOutpostLimit, int townBlockBuyBonusLimit) {
+	public static void newTownLevel(int numResidents, String namePrefix, String namePostfix, String mayorPrefix, String mayorPostfix, int townBlockLimit, double townUpkeepMultiplier, int townOutpostLimit, int townBlockBuyBonusLimit, double debtCapModifier) {
 
 		ConcurrentHashMap<TownySettings.TownLevel, Object> m = new ConcurrentHashMap<TownySettings.TownLevel, Object>();
 		m.put(TownySettings.TownLevel.NAME_PREFIX, namePrefix);
@@ -72,6 +72,7 @@ public class TownySettings {
 		m.put(TownySettings.TownLevel.UPKEEP_MULTIPLIER, townUpkeepMultiplier);
 		m.put(TownySettings.TownLevel.OUTPOST_LIMIT, townOutpostLimit);
 		m.put(TownySettings.TownLevel.TOWN_BLOCK_BUY_BONUS_LIMIT, townBlockBuyBonusLimit);
+		m.put(TownySettings.TownLevel.DEBT_CAP_MODIFIER, debtCapModifier);
 		configTownLevel.put(numResidents, m);
 	}
 
@@ -110,15 +111,16 @@ public class TownySettings {
 
 			try {
 				newTownLevel(
-						(Integer) level.get("numResidents"),
-						(String) level.get("namePrefix"),
-						(String) level.get("namePostfix"),
-						(String) level.get("mayorPrefix"),
-						(String) level.get("mayorPostfix"),
-						(Integer) level.get("townBlockLimit"),
-						(Double) level.get("upkeepModifier"),
-						(Integer) level.get("townOutpostLimit"),
-						(Integer) level.get("townBlockBuyBonusLimit")
+						Integer.parseInt(level.get("numResidents").toString()),
+						String.valueOf(level.get("namePrefix")),
+						String.valueOf(level.get("namePostfix")),
+						String.valueOf(level.get("mayorPrefix")),
+						String.valueOf(level.get("mayorPostfix")),
+						Integer.parseInt(level.get("townBlockLimit").toString()),
+						Double.parseDouble(level.get("upkeepModifier").toString()),
+						Integer.parseInt(level.get("townOutpostLimit").toString()),
+						Integer.parseInt(level.get("townBlockBuyBonusLimit").toString()),
+						Double.parseDouble(level.get("debtCapModifier").toString())
 						);
 			} catch (NullPointerException e) {
 				System.out.println("Your Towny config.yml's town_level section is out of date.");
@@ -146,18 +148,18 @@ public class TownySettings {
 
 			try {
 				newNationLevel(
-						(Integer) level.get("numResidents"),
-						(String) level.get("namePrefix"),
-						(String) level.get("namePostfix"),
-						(String) level.get("capitalPrefix"),
-						(String) level.get("capitalPostfix"),
-						(String) level.get("kingPrefix"),
-						(String) level.get("kingPostfix"),
-						(level.containsKey("townBlockLimitBonus") ? (Integer) level.get("townBlockLimitBonus") : 0),
-						(Double) level.get("upkeepModifier"),
-						(level.containsKey("nationTownUpkeepModifier") ? (Double) level.get("nationTownUpkeepModifier") : 1.0),
-						(Integer) level.get("nationZonesSize"),
-						(Integer) level.get("nationBonusOutpostLimit")
+						Integer.parseInt(level.get("numResidents").toString()),
+						String.valueOf(level.get("namePrefix")),
+						String.valueOf(level.get("namePostfix")),
+						String.valueOf(level.get("capitalPrefix")),
+						String.valueOf(level.get("capitalPostfix")),
+						String.valueOf(level.get("kingPrefix")),
+						String.valueOf(level.get("kingPostfix")),
+						Integer.parseInt(level.get("townBlockLimitBonus").toString()),
+						Double.parseDouble(level.get("upkeepModifier").toString()),
+						Double.parseDouble(level.get("nationTownUpkeepModifier").toString()),
+						Integer.parseInt(level.get("nationZonesSize").toString()),
+						Integer.parseInt(level.get("nationBonusOutpostLimit").toString())
 						);
 			} catch (Exception e) {
 				System.out.println("Your Towny config.yml's nation_level section is out of date.");
@@ -231,8 +233,6 @@ public class TownySettings {
 			setDefaults(version, file);
 
 			config.save();
-
-			loadCachedObjects();
 		}
 	}
 	
@@ -533,6 +533,7 @@ public class TownySettings {
 			level.put("upkeepModifier", 1.0);
 			level.put("townOutpostLimit", 0);
 			level.put("townBlockBuyBonusLimit", 0);
+			level.put("debtCapModifier", 1.0);
 			levels.add(new HashMap<>(level));
 			level.clear();
 			level.put("numResidents", 1);
@@ -544,6 +545,7 @@ public class TownySettings {
 			level.put("upkeepModifier", 1.0);
 			level.put("townOutpostLimit", 0);
 			level.put("townBlockBuyBonusLimit", 0);
+			level.put("debtCapModifier", 1.0);
 			levels.add(new HashMap<>(level));
 			level.clear();
 			level.put("numResidents", 2);
@@ -555,6 +557,7 @@ public class TownySettings {
 			level.put("upkeepModifier", 1.0);
 			level.put("townOutpostLimit", 1);
 			level.put("townBlockBuyBonusLimit", 0);
+			level.put("debtCapModifier", 1.0);
 			levels.add(new HashMap<>(level));
 			level.clear();
 			level.put("numResidents", 6);
@@ -566,6 +569,7 @@ public class TownySettings {
 			level.put("upkeepModifier", 1.0);
 			level.put("townOutpostLimit", 1);
 			level.put("townBlockBuyBonusLimit", 0);
+			level.put("debtCapModifier", 1.0);
 			levels.add(new HashMap<>(level));
 			level.clear();
 			level.put("numResidents", 10);
@@ -577,6 +581,7 @@ public class TownySettings {
 			level.put("upkeepModifier", 1.0);
 			level.put("townOutpostLimit", 2);
 			level.put("townBlockBuyBonusLimit", 0);
+			level.put("debtCapModifier", 1.0);
 			levels.add(new HashMap<>(level));
 			level.clear();
 			level.put("numResidents", 14);
@@ -588,6 +593,7 @@ public class TownySettings {
 			level.put("upkeepModifier", 1.0);
 			level.put("townOutpostLimit", 2);
 			level.put("townBlockBuyBonusLimit", 0);
+			level.put("debtCapModifier", 1.0);
 			levels.add(new HashMap<>(level));
 			level.clear();
 			level.put("numResidents", 20);
@@ -599,6 +605,7 @@ public class TownySettings {
 			level.put("upkeepModifier", 1.0);
 			level.put("townOutpostLimit", 3);
 			level.put("townBlockBuyBonusLimit", 0);
+			level.put("debtCapModifier", 1.0);
 			levels.add(new HashMap<>(level));
 			level.clear();
 			level.put("numResidents", 24);
@@ -610,6 +617,7 @@ public class TownySettings {
 			level.put("upkeepModifier", 1.0);
 			level.put("townOutpostLimit", 3);
 			level.put("townBlockBuyBonusLimit", 0);
+			level.put("debtCapModifier", 1.0);
 			levels.add(new HashMap<>(level));
 			level.clear();
 			level.put("numResidents", 28);
@@ -621,6 +629,7 @@ public class TownySettings {
 			level.put("upkeepModifier", 1.0);
 			level.put("townOutpostLimit", 4);
 			level.put("townBlockBuyBonusLimit", 0);
+			level.put("debtCapModifier", 1.0);
 			levels.add(new HashMap<>(level));
 			level.clear();
 			newConfig.set(ConfigNodes.LEVELS_TOWN_LEVEL.getRoot(), levels);
@@ -2823,6 +2832,10 @@ public class TownySettings {
 	
 	public static double getDebtCapOverride() {
 		return getDouble(ConfigNodes.ECO_BANKRUPTCY_DEBT_CAP_OVERRIDE);
+	}
+	
+	public static boolean isDebtCapDeterminedByTownLevel() {
+		return getBoolean(ConfigNodes.ECO_BANKRUPTCY_DEBT_CAP_USES_TOWN_LEVELS);
 	}
 	
 	public static boolean isUpkeepDeletingTownsThatReachDebtCap() {

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -110,6 +110,12 @@ public class TownySettings {
 		for (Map<?, ?> level : levels) {
 
 			try {
+				/*
+				 * We parse everything as if it were a string because of the config-migrator, 
+				 * which will always write any double or integer as a string (ex: debtCaptModifier: '2.0')
+				 * Until the migrator is revamped to handle different types of primitives, or,
+				 * the nation/town levels are changed this might be least painful alternative.
+				 */
 				newTownLevel(
 						Integer.parseInt(level.get("numResidents").toString()),
 						String.valueOf(level.get("namePrefix")),
@@ -147,8 +153,14 @@ public class TownySettings {
 		for (Map<?, ?> level : levels) {
 
 			try {
-				newNationLevel(
-						Integer.parseInt(level.get("numResidents").toString()),
+				/*
+				 * We parse everything as if it were a string because of the config-migrator, 
+				 * which will always write any double or integer as a string (ex: debtCaptModifier: '2.0')
+				 * Until the migrator is revamped to handle different types of primitives, or,
+				 * the nation/town levels are changed this might be least painful alternative.
+				 */
+				newNationLevel( 
+						Integer.parseInt(level.get("numResidents").toString()), 
 						String.valueOf(level.get("namePrefix")),
 						String.valueOf(level.get("namePostfix")),
 						String.valueOf(level.get("capitalPrefix")),

--- a/src/com/palmergames/bukkit/towny/TownyUniverse.java
+++ b/src/com/palmergames/bukkit/towny/TownyUniverse.java
@@ -151,6 +151,13 @@ public class TownyUniverse {
 			migrator.migrate();
 		}
         
+        try {
+			TownySettings.loadCachedObjects();
+		} catch (IOException e) {
+			e.printStackTrace();
+			return false;
+		}
+        
         File f = new File(rootFolder, "outpostschecked.txt");
         if (!(f.exists())) {
             for (Town town : dataSource.getTowns()) {

--- a/src/com/palmergames/bukkit/towny/TownyUniverse.java
+++ b/src/com/palmergames/bukkit/towny/TownyUniverse.java
@@ -151,8 +151,9 @@ public class TownyUniverse {
 			migrator.migrate();
 		}
         
+        // Loads Town and Nation Levels.
         try {
-			TownySettings.loadCachedObjects();
+			TownySettings.loadTownAndNationLevels();
 		} catch (IOException e) {
 			e.printStackTrace();
 			return false;

--- a/src/com/palmergames/bukkit/towny/object/economy/BankAccount.java
+++ b/src/com/palmergames/bukkit/towny/object/economy/BankAccount.java
@@ -2,8 +2,12 @@ package com.palmergames.bukkit.towny.object.economy;
 
 import com.palmergames.bukkit.towny.TownyEconomyHandler;
 import com.palmergames.bukkit.towny.TownySettings;
+import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.exceptions.EconomyException;
+import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
 import com.palmergames.bukkit.towny.object.EconomyAccount;
+import com.palmergames.bukkit.towny.object.Town;
+
 import org.bukkit.World;
 
 /**
@@ -28,7 +32,7 @@ public class BankAccount extends Account {
 
 		public DebtAccount(Account account) {
 			// TNE doesn't play nice with "town-" on debt accounts.
-			super(DEBT_PREFIX + account.getName().replace("town-",""), account.getBukkitWorld());
+			super(DEBT_PREFIX + account.getName().replace(TownySettings.getTownAccountPrefix(),""), account.getBukkitWorld());
 			
 			// Check if the account already exists, if not make sure the balance is set to 0
 			// as some eco configurations put a default amount in every new account.
@@ -79,6 +83,16 @@ public class BankAccount extends Account {
 	 * @return The max amount of debt for this account.
 	 */
 	public double getDebtCap() {
+		if (TownySettings.isDebtCapDeterminedByTownLevel()) { // town_level debtCapModifier * debt_cap.override.
+			Town town = null;
+			try {
+				town = TownyUniverse.getInstance().getDataSource().getTown(this.getName().replace(TownySettings.getTownAccountPrefix(), ""));
+			} catch (NotRegisteredException e) {
+				e.printStackTrace();
+			}
+			return Double.parseDouble(TownySettings.getTownLevel(town).get(TownySettings.TownLevel.DEBT_CAP_MODIFIER).toString()) * TownySettings.getDebtCapOverride();
+		}
+		
 		if (TownySettings.getDebtCapOverride() != 0.0)
 			return TownySettings.getDebtCapOverride();
 		


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
  - Fixes config migrator not working on town and nation level changes.
    - Town and Nation levels were loading too early before migration and
throwing an exception for being incomplete.

  - Fixes debt accounts not using custom town-account-prefixes.
    - Was hardcoded to use "town-".

  - Adds debtCapModifier to town levels.
    - Uses debtCapModifier * debt_cap.override value.
  
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
  - New Config Option: economy.bankruptcy.debt_cap.debt_cap_uses_town_levels
    - default: false
    - When true the debt_cap.override price will be multiplied by the debtCapModifier in the town_level section of the config. (Ex: debtCapModifier of 3.0 and debt_cap.override of 1000.0 would set a debtcap of 3.0 x 1000 = 3000.)

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
  - Closes #4374.
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
