### PR TITLE
More explosions protections.

### DIFF
--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1008,7 +1008,10 @@ public enum ConfigNodes {
 			"# These are blocks in the world that will be protected by a town/resident/plot's switch setting.",
 			"# Switches are blocks, that are in the world, which get right-clicked.",
 			"# Towny will tell you the proper name to use in this list if you hit the block while holding a clay brick item in your hand.",
-			"# Group names you can use in this list: BOATS,MINECARTS,WOOD_DOORS,PRESSURE_PLATES,FENCE_GATES,TRAPDOORS,SHULKER_BOXES,BUTTONS",
+			"# Group names you can use in this list: BOATS,MINECARTS,WOOD_DOORS,PRESSURE_PLATES,FENCE_GATES,TRAPDOORS,SHULKER_BOXES,BUTTONS.",
+			"# Note: Vehicles like MINECARTS and BOATS can be added here. If you want to treat other rideable mobs like switches add SADDLE",
+			"#       to protect HORSES, DONKEYS, MULES, PIGS, STRIDERS (This is not recommended, unless you want players to not be able to",
+			"#       re-mount their animals in towns they cannot switch in.)",
 			"# A full list of proper names can be found here https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Material.html "),
 	PROT_FIRE_SPREAD_BYPASS(
 			"protection.fire_spread_bypass_materials",

--- a/src/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
@@ -140,6 +140,11 @@ public class TownyCustomListener implements Listener {
 		
 	}
 	
+	/**
+	 * Runs when a bed or respawn anchor explodes that we can track them in the BlockExplodeEvent,
+	 * which always returns AIR for that event's getBlock().
+	 * @param event
+	 */
 	@EventHandler(priority = EventPriority.NORMAL) 
 	public void onBedExplodeEvent(BedExplodeEvent event) {
 		TownyWorld world = null;
@@ -148,7 +153,8 @@ public class TownyCustomListener implements Listener {
 		} catch (NotRegisteredException ignored) {}
 		
 		world.addBedExplosionAtBlock(event.getLocation(), event.getMaterial());
-		world.addBedExplosionAtBlock(event.getLocation2(), event.getMaterial());
+		if (event.getLocation2() != null);
+			world.addBedExplosionAtBlock(event.getLocation2(), event.getMaterial());
 		final TownyWorld finalWorld = world;
 		Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, new Runnable() {
             @Override

--- a/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
@@ -26,13 +26,9 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
-import org.bukkit.entity.Animals;
-import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Creature;
-import org.bukkit.entity.EnderCrystal;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
-import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Monster;
 import org.bukkit.entity.Player;
@@ -47,6 +43,8 @@ import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.entity.EntityCombustByEntityEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.entity.EntityInteractEvent;
@@ -82,9 +80,6 @@ public class TownyEntityListener implements Listener {
 
 	/**
 	 * Prevent PvP and PvM damage dependent upon PvP settings and location.
-	 * 
-	 * EntityDamageByEntity events involving 0 player interaction has
-	 * already been handled in the {@link #nonPlayerEntityDamageByEntity(EntityDamageByEntityEvent)} method.
 	 * 
 	 * @param event - EntityDamageByEntityEvent
 	 */
@@ -263,15 +258,12 @@ public class TownyEntityListener implements Listener {
 	}
 	
 	/**
-	 * Non-player involved cases of entity damage.
-	 * 
-	 * Prevent explosions from hurting non-living entities in towns.
-	 * Includes: Armorstands, itemframes, animals, endercrystals, minecarts
-	 * 
-	 * @param event - EntityDamageByEntityEvent
+	 * Prevent explosions from hurting non-player entities.
+	 *  
+	 * @param event - EntityDamageEvent
 	 */
 	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-	public void nonPlayerEntityDamageByEntity(EntityDamageByEntityEvent event) {
+	public void onNonPlayerEntityTakesExplosionDamage(EntityDamageEvent event) {
 		if (plugin.isError()) {
 				return;
 		}
@@ -279,65 +271,19 @@ public class TownyEntityListener implements Listener {
 		if (!TownyAPI.getInstance().isTownyWorld(event.getEntity().getWorld()))
 			return;
 
-		/*
-		 * Bail out if a player is involved in the damage.
-		 */
-		if ((event.getDamager() instanceof Player) ||
-			(event.getEntity() instanceof Player) ||
-			((event.getDamager() instanceof Projectile) && ((Projectile)event.getDamager()) instanceof Player)
-			) return;
-		System.out.println("nonplayerdamage");
-			
-		TownyUniverse townyUniverse = TownyUniverse.getInstance();
+		if (event.getEntity() instanceof Player)
+			return;
+
 		TownyWorld townyWorld = null;
-		
-		Entity entity = event.getEntity();
-		Entity damager= event.getDamager();
-		
 		try {
-			townyWorld = townyUniverse.getDataSource().getWorld(entity.getWorld().getName());
+			townyWorld = TownyUniverse.getInstance().getDataSource().getWorld(event.getEntity().getWorld().getName());
 		} catch (NotRegisteredException e) {
 			e.printStackTrace();
 		}
 
-		/*
-		 * Entities requiring special protection.
-		 * 
-		 * Whether because they are fragile or because they are specifically in protected lists.
-		 */
-		if (entity instanceof ArmorStand || entity instanceof ItemFrame || entity instanceof EnderCrystal 
-				|| (TownySettings.getEntityTypes().contains("Animals") && entity instanceof Animals) // Only protect these entities if servers specifically add them to the protections.
-				|| (TownySettings.getEntityTypes().contains("Villager") && entity instanceof Villager) // Only protect these entities if servers specifically add them to the protections.
-				){
-			
-			// Handle exploding causes of damage.
-		    if (EntityTypeUtil.isExplosive(damager.getType()) && !locationCanExplode(townyWorld, entity.getLocation())) {
-				event.setCancelled(true);
-				return;
-			}
-		    
-		    if (damager.getType() == EntityType.LIGHTNING) {
-		    	// Other than natural causes, as of the introduction of Tridents with the Channeling enchantment,
-		    	// lightning can be summoned by anyone at anything. Until we can discern the cause of the lightning
-		    	// we will block all damage to the above entities requiring special protection.
-		    	// TODO: use the LightningStrikeEvent for this very thing.
-				if (!locationCanExplode(townyWorld, entity.getLocation())) {
-					event.setDamage(0);
-					event.setCancelled(true);
-				}
-				return;
-		    }
+		if ((event.getCause() == DamageCause.BLOCK_EXPLOSION || event.getCause() == DamageCause.ENTITY_EXPLOSION || event.getCause() == DamageCause.LIGHTNING) && !locationCanExplode(townyWorld, event.getEntity().getLocation()))
+			event.setCancelled(true);
 
-		    /*
-		     * Prevents projectiles fired by non-players harming the above entities.
-		     * Could be a monster or it could be a dispenser.
-		     */
-			if (event.getDamager() instanceof Projectile) {
-				event.setCancelled(true);	
-			}
-
-		}
-			
 	}
 
 	/**
@@ -917,7 +863,10 @@ public class TownyEntityListener implements Listener {
 			}
 		}
 
-		
+
+		/*
+		 * It's a player or an entity (probably an explosion)
+		 */
 		if (event instanceof HangingBreakByEntityEvent) {
 			HangingBreakByEntityEvent evt = (HangingBreakByEntityEvent) event;
 			Object remover = evt.getRemover();
@@ -944,24 +893,31 @@ public class TownyEntityListener implements Listener {
 
 				//Make decision on whether this is allowed using the PlayerCache and then a cancellable event.
 				event.setCancelled(!TownyActionEventExecutor.canDestroy(player, hanging.getLocation(), mat));
-
-			} else {
+			} else if (remover instanceof Monster) {
+				/*
+				 * Probably a skeleton, cancel the break if it is in a town.
+				 */
+				if (!TownyAPI.getInstance().isWilderness(hanging.getLocation()))
+					event.setCancelled(true);
+			}
+		
+			if (event.getCause() == RemoveCause.EXPLOSION) {
 				// Explosions are blocked in this plot
 				if (!locationCanExplode(townyWorld, hanging.getLocation())) {
 					event.setCancelled(true);
 				// Explosions are enabled, must check if in the wilderness and if we have explrevert in that world
 				} else {
 					TownBlock tb = TownyAPI.getInstance().getTownBlock(hanging.getLocation());
-					if (tb == null) {
-					    // We're in the wilderness because the townblock is null;
-						if (townyWorld.isExpl())
-							if (townyWorld.isUsingPlotManagementWildEntityRevert() && (remover != null))
-								if (townyWorld.isProtectingExplosionEntity((Entity)remover))
-									event.setCancelled(true);
-					}
+					// We're in the wilderness because the townblock is null and we have a remover.
+					if (tb == null && remover != null)
+					    if (townyWorld.isExpl() && townyWorld.isUsingPlotManagementWildEntityRevert() && townyWorld.isProtectingExplosionEntity((Entity)remover))
+							event.setCancelled(true);
 				}
-		}
+			}
 
+		/*
+		 * Probably a case of a block explosion/created explosion with no Entity.
+		 */
 		} else {
 
 			switch (event.getCause()) {

--- a/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -486,6 +486,7 @@ public class TownyPlayerListener implements Listener {
 				case LEASH_HITCH:
 				case MINECART_COMMAND:
 				case MINECART_TNT:
+				case MINECART_MOB_SPAWNER:
 					mat = EntityTypeUtil.parseEntityToMaterial(event.getRightClicked().getType());
 					break;
 				/*
@@ -503,12 +504,9 @@ public class TownyPlayerListener implements Listener {
 				/*
 				 * Afterwards they will remain as Switch perm checks.
 				 */
-				case MINECART:
-				case MINECART_MOB_SPAWNER:
 				case MINECART_CHEST:
 				case MINECART_FURNACE:				
 				case MINECART_HOPPER:
-				case BOAT:
 					mat = EntityTypeUtil.parseEntityToMaterial(event.getRightClicked().getType());
 					actionType = ActionType.SWITCH;
 					break;

--- a/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -356,7 +356,7 @@ public class TownyPlayerListener implements Listener {
 >>>>>>> edeaa1f More explosions protections.
 	 * @param event PlayerInteractEvent
 	 */
-	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
 	public void onPlayerBlowsUpBedOrRespawnAnchor(PlayerInteractEvent event) {
 
 		if (plugin.isError()) {
@@ -508,6 +508,7 @@ public class TownyPlayerListener implements Listener {
 				case MINECART_CHEST:
 				case MINECART_FURNACE:				
 				case MINECART_HOPPER:
+				case BOAT:
 					mat = EntityTypeUtil.parseEntityToMaterial(event.getRightClicked().getType());
 					actionType = ActionType.SWITCH;
 					break;

--- a/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -343,16 +343,21 @@ public class TownyPlayerListener implements Listener {
 	}
 
 	/**
+<<<<<<< Upstream, based on origin/master
 	 * Handles clicking on beds in the nether, sending blocks to a map so we can track when explosions occur from beds.
 	 * Spigot API's BlockExplodeEvent#getBlock() always returns AIR for beds exploding, which is why this is necessary.
 	 * 
 	 * Also denies the use of beds in plots the player doesn't own and plots which are not inn plots.
 	 *   - Also denies enemies and outlaws using inn plots.
 	 *   
+=======
+	 * Handles clicking on beds in the nether/respawn anchors in the overworld sending blocks to a map so we can track when explosions occur from beds.
+	 * Spigot API's BlockExplodeEvent#getBlock() always returns AIR for beds/anchors exploding, which is why this is necessary.
+>>>>>>> edeaa1f More explosions protections.
 	 * @param event PlayerInteractEvent
 	 */
 	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-	public void onPlayerInteractWithBed(PlayerInteractEvent event) {
+	public void onPlayerBlowsUpBedOrRespawnAnchor(PlayerInteractEvent event) {
 
 		if (plugin.isError()) {
 			event.setCancelled(true);
@@ -364,12 +369,29 @@ public class TownyPlayerListener implements Listener {
 
 		Block block = event.getClickedBlock();
 		if (event.hasBlock()) {
+			/*
+			 * Catches respawn anchors blowing up and allows us to track their explosions.
+			 */
+			if (block.getType() == Material.RESPAWN_ANCHOR) {
+				org.bukkit.block.data.type.RespawnAnchor anchor = ((org.bukkit.block.data.type.RespawnAnchor) block.getBlockData());
+				if (anchor.getCharges() == 4)
+					BukkitTools.getPluginManager().callEvent(new BedExplodeEvent(event.getPlayer(), block.getLocation(), null, block.getType()));
+				return;
+			}
+			
+			/*
+			 * Catches beds blowing up and allows us to track their explosions.
+			 */
 			if (Tag.BEDS.isTagged(block.getType()) && event.getPlayer().getWorld().getEnvironment().equals(Environment.NETHER)) {
 				org.bukkit.block.data.type.Bed bed = ((org.bukkit.block.data.type.Bed) block.getBlockData());
 				BukkitTools.getPluginManager().callEvent(new BedExplodeEvent(event.getPlayer(), block.getLocation(), block.getRelative(bed.getFacing()).getLocation(), block.getType()));
 				return;
 			}
 			
+			/*
+			 * Prevents setting the spawn point of the player using beds, 
+			 * except in allowed plots (personally-owned and Inns)
+			 */
 			if (Tag.BEDS.isTagged(block.getType())) {
 				if (!TownySettings.getBedUse())
 					return;
@@ -392,6 +414,7 @@ public class TownyPlayerListener implements Listener {
 					isOwner = townblock.isOwner(resident);
 					isInnPlot = townblock.getType() == TownBlockType.INN;
 					
+					//Prevent enemies and outlaws using the Inn plots.
 					if (CombatUtil.isEnemyTownBlock(event.getPlayer(), townblock.getWorldCoord()) || town.hasOutlaw(resident)) {
 						event.setCancelled(true);
 						TownyMessaging.sendErrorMsg(event.getPlayer(), Translation.of("msg_err_no_sleep_in_enemy_inn"));
@@ -406,7 +429,6 @@ public class TownyPlayerListener implements Listener {
 				}
 			}
 		}
-		
 	}
 
 	

--- a/src/com/palmergames/bukkit/towny/listeners/TownyVehicleListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyVehicleListener.java
@@ -5,10 +5,12 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.vehicle.VehicleDestroyEvent;
+import org.bukkit.event.vehicle.VehicleDamageEvent;
+import org.bukkit.event.vehicle.VehicleEnterEvent;
 
 import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.TownyAPI;
+import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.event.executors.TownyActionEventExecutor;
 import com.palmergames.bukkit.towny.utils.EntityTypeUtil;
 import com.palmergames.bukkit.towny.utils.ExplosionUtil;
@@ -28,9 +30,14 @@ public class TownyVehicleListener implements Listener {
 		plugin = instance;
 	}
 	
+	/**
+	 * Cancelling the damage will also prevent the boats/minecarts from being moved around.
+	 * 
+	 * @param event VehicleDamageEvent.
+	 */
 	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
-	public void onVehicleDestroy(VehicleDestroyEvent event) {
-
+	public void onVehicleDamage(VehicleDamageEvent event) {
+		
 		if (plugin.isError()) {
 			event.setCancelled(true);
 			return;
@@ -39,13 +46,13 @@ public class TownyVehicleListener implements Listener {
 		if (!TownyAPI.getInstance().isTownyWorld(event.getVehicle().getWorld()))
 			return;
 
-		if (event.getAttacker() == null) {  // Probably a respawn anchor or a TNT minecart.
+		if (event.getAttacker() == null) {  // Probably a respawn anchor or a TNT minecart or TNT lit by redstone.
 			event.setCancelled(!ExplosionUtil.locationCanExplode(event.getVehicle().getLocation()));
 			return;
 		}
 		
 		/*
-		 * Note: TNT and Fireballs are considered Players by the API in this instance.
+		 * Note: Player-lit-TNT and Fireballs are considered Players by the API in this instance.
 		 */
 		if (event.getAttacker() instanceof Player) {
 			
@@ -79,6 +86,52 @@ public class TownyVehicleListener implements Listener {
 			if (EntityTypeUtil.isExplosive(event.getAttacker().getType()) && !ExplosionUtil.locationCanExplode(event.getVehicle().getLocation()))
 				event.setCancelled(true);
 		}
+	}
+
+	/**
+	 * Handles switch use (entering into vehicles.)
+	 * 
+	 * @param event VehicleEnterEvent.
+	 */
+	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+	public void onVehicleEnter(VehicleEnterEvent event) {
+
+		if (plugin.isError()) {
+			event.setCancelled(true);
+			return;
+		}
+
+		if (!TownyAPI.getInstance().isTownyWorld(event.getVehicle().getWorld()))
+			return;
+
+		if (event.getEntered() instanceof Player) {
 			
+			Player player = (Player) event.getEntered();
+			Material vehicle = null;
+
+			/*
+			 * Substitute a Material for the Entity so we can run a switch test against it.
+			 * Any entity not in the switch statement will leave vehicle null and no test will occur.
+			 */
+			switch (event.getVehicle().getType()) {
+				case MINECART:
+				case BOAT:
+					vehicle = EntityTypeUtil.parseEntityToMaterial(event.getVehicle().getType());
+					break;
+				case HORSE:
+				case STRIDER:
+				case PIG:
+				case DONKEY:
+				case MULE:
+					vehicle = Material.SADDLE;
+					break;
+			}
+
+			if (vehicle != null) {
+				//Make decision on whether this is allowed using the PlayerCache and then a cancellable event.
+				if (TownySettings.isSwitchMaterial(vehicle.name()))
+					event.setCancelled(!TownyActionEventExecutor.canSwitch(player, event.getVehicle().getLocation(), vehicle));
+			}
+		}	
 	}
 }

--- a/src/com/palmergames/bukkit/towny/utils/CombatUtil.java
+++ b/src/com/palmergames/bukkit/towny/utils/CombatUtil.java
@@ -248,9 +248,15 @@ public class CombatUtil {
 			/*
 			 * DefendingEntity is not a player.
 			 * This is now non-player vs non-player damage.
-			 * This should be unreachable as we are already parsing out
-			 * non-player involved combat at TownyEntityListener#nonPlayerEntityDamageByEntity.
 			 */
+			} else {
+			    /*
+			     * Prevents projectiles fired by non-players harming non-player entities.
+			     * Could be a monster or it could be a dispenser.
+			     */
+				if (attackingEntity instanceof Projectile) {
+					return true;	
+				}
 			}
 		}
 		return false;

--- a/src/com/palmergames/bukkit/towny/utils/EntityTypeUtil.java
+++ b/src/com/palmergames/bukkit/towny/utils/EntityTypeUtil.java
@@ -111,6 +111,10 @@ public class EntityTypeUtil {
 		case MINECART_TNT:
 			material = Material.TNT_MINECART;
 			break;
+		
+		case BOAT:
+			material = Material.OAK_BOAT;
+			break;
 		}
 					
 		return material;

--- a/src/com/palmergames/bukkit/towny/utils/EntityTypeUtil.java
+++ b/src/com/palmergames/bukkit/towny/utils/EntityTypeUtil.java
@@ -22,7 +22,8 @@ public class EntityTypeUtil {
 			EntityType.MINECART_TNT, 
 			EntityType.PRIMED_TNT, 
 			EntityType.WITHER, 
-			EntityType.WITHER_SKULL));
+			EntityType.WITHER_SKULL,
+			EntityType.ENDER_CRYSTAL));
 
 	public static boolean isInstanceOfAny(List<Class<?>> classesOfWorldMobsToRemove2, Object obj) {
 

--- a/src/com/palmergames/bukkit/towny/utils/ExplosionUtil.java
+++ b/src/com/palmergames/bukkit/towny/utils/ExplosionUtil.java
@@ -1,0 +1,65 @@
+package com.palmergames.bukkit.towny.utils;
+
+import org.bukkit.Location;
+
+import com.palmergames.bukkit.towny.TownyAPI;
+import com.palmergames.bukkit.towny.object.Coord;
+import com.palmergames.bukkit.towny.object.Town;
+import com.palmergames.bukkit.towny.object.TownBlock;
+import com.palmergames.bukkit.towny.object.TownyWorld;
+import com.palmergames.bukkit.towny.war.common.WarZoneConfig;
+import com.palmergames.bukkit.towny.war.eventwar.War;
+
+public class ExplosionUtil {
+
+	public ExplosionUtil() {
+		
+	}
+	
+	/**
+	 * Test if this location has explosions enabled.
+	 * 
+	 * @param loc - Location to check
+	 * @return true if allowed.
+	 */
+	public static boolean locationCanExplode(Location loc) {
+		
+		TownyWorld world = TownyAPI.getInstance().getTownyWorld(loc.getWorld().getName());
+		if (world == null)
+			return false;
+		
+		/*
+		 * Handle occasions in the wilderness first.
+		 */
+		if (TownyAPI.getInstance().isWilderness(loc)) {
+			if (world.isForceExpl() || world.isExpl())
+				return true;
+			if (!world.isExpl())
+				return false;				
+		}
+
+		/*
+		 * Must be inside of a town.
+		 */
+		Coord coord = Coord.parseCoord(loc);
+
+		/*
+		 * Stops any type of exploding damage and block damage if wars are not allowing explosions.
+		 */
+		if (world.isWarZone(coord) && !WarZoneConfig.isAllowingExplosionsInWarZone()) {
+			return false;
+		}
+
+		TownBlock townBlock = TownyAPI.getInstance().getTownBlock(loc);
+		Town town = TownyAPI.getInstance().getTown(loc);
+
+		if (TownyAPI.getInstance().isWarTime() && WarZoneConfig.explosionsBreakBlocksInWarZone() && War.isWarZone(townBlock.getWorldCoord())){
+			return true;				
+		}
+		if ((!townBlock.getPermissions().explosion) || (TownyAPI.getInstance().isWarTime() && WarZoneConfig.isAllowingExplosionsInWarZone() && !town.hasNation() && !town.isBANG()))
+			return false;
+
+		
+		return true;
+	}
+}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
- Fixes item_frames getting blown up.
- Fixes non-player entities being harmed by blockexplosions,
entityexplosions and lightning all in one tiny method.
  - Fixes end crystals & respawn anchors blowing up armor stands.
- Moves one instance of non-player/non-player entity-on-entity damage
into the CombatUtil's preventDamage().
  - The scenario where a dispenser fires an arrow/projectile at a
non-player.

- Unifies the canLocationExplode methods into one ExplosionUtil method.
  - Rewrote the method to be more simple. It will change again when the
war parts are removed and turned into an event.
- Fixes vehicles being destroyed by null attackers (respawn anchor,
beds, tnt minecarts, probably others,) and adds Boats to the list of
protected things.

- Adds RespawnAnchors to the BedExplodeEvent system, since their
BlockExplodeEvents also register an AIR block where they explode.
- Made blocks and entities that explode actually blow up the blocks in
their block lists that are allowed to explode according to the
townblock/world setting.
  - Previous behaviour was to cancel the whole explosion if any block
could not be blown up.
- Made EntityDamageEvent that was looking at non-player explosion damage
only, also cancel damage on player's if they are in a location that
cannot explode.
- Removed unused canLocationExplode() in TownyBlockListener.

- Set priority to BedClickExplosion EventPriority to Monitor on an event
- Add boat to possible switch use.

- Move switch tests for vehicle entering to the Vehicle listener.
- Add the option to use SADDLE to protect the saddle-wearing vehicles in
the switch list.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

Closes #4409 #4266 
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
