### PR TITLE
Fix nation neutral messages

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -2608,13 +2608,16 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 				}
 
 				nation.toggleNeutral(value);
-
-				// send message depending on if using an economy and charging
-				// for peaceful
-				if (TownySettings.isUsingEconomy() && cost > 0)
-					TownyMessaging.sendMsg(player, Translation.of("msg_you_paid", TownyEconomyHandler.getFormattedBalance(cost)));
-				else
-					TownyMessaging.sendMsg(player, Translation.of("msg_nation_set_peaceful"));
+				
+				// Only send status message if switching nation to peaceful.
+				if (value) {
+					// send message depending on if using an economy and charging
+					// for peaceful
+					if (TownySettings.isUsingEconomy() && cost > 0)
+						TownyMessaging.sendMsg(player, Translation.of("msg_you_paid", TownyEconomyHandler.getFormattedBalance(cost)));
+					else
+						TownyMessaging.sendMsg(player, Translation.of("msg_nation_set_peace"));
+				}
 
 				TownyMessaging.sendPrefixedNationMessage(nation, Translation.of("msg_nation_peaceful") + (nation.isNeutral
 						() ? Colors.Green : Colors.Red + " not") + " peaceful.");

--- a/src/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -2590,34 +2590,34 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 
 				if (!townyUniverse.getPermissionSource().testPermission(player, PermissionNodes.TOWNY_COMMAND_NATION_TOGGLE_NEUTRAL.getNode()))
 					throw new TownyException(Translation.of("msg_err_command_disable"));
+				
+				boolean value = choice.orElse(!nation.isNeutral());
+				double cost = TownySettings.getNationNeutralityCost();
+				
+				if (nation.isNeutral() && value) throw new TownyException(Translation.of("msg_nation_already_peaceful"));
+				else if (!nation.isNeutral() && !value) throw new TownyException(Translation.of("msg_nation_already_not_peaceful"));
 
 				try {
-					boolean value = choice.orElse(!nation.isNeutral());
-					double cost = TownySettings.getNationNeutralityCost();
-					
-					if (nation.isNeutral() && value) throw new TownyException(Translation.of("msg_nation_already_peaceful"));
-					else if (!nation.isNeutral() && !value) throw new TownyException(Translation.of("msg_nation_already_not_peaceful"));
-
 					if (value && TownySettings.isUsingEconomy() && !nation.getAccount().withdraw(cost, "Peaceful Nation Cost"))
 						throw new TownyException(Translation.of("msg_nation_cant_peaceful"));
-
-					nation.toggleNeutral(value);
-
-					// send message depending on if using an economy and charging
-					// for peaceful
-					if (TownySettings.isUsingEconomy() && cost > 0)
-						TownyMessaging.sendMsg(player, Translation.of("msg_you_paid", TownyEconomyHandler.getFormattedBalance(cost)));
-					else
-						TownyMessaging.sendMsg(player, Translation.of("msg_nation_set_peaceful"));
-
-					TownyMessaging.sendPrefixedNationMessage(nation, Translation.of("msg_nation_peaceful") + (nation.isNeutral
-							() ? Colors.Green : Colors.Red + " not") + " peaceful.");
-				} catch (TownyException e) {
-					nation.setNeutral(false);
+				} catch (EconomyException e) {
+					// This can literally never happen. But if it does, print to console, and send message to player.
+					e.printStackTrace();
 					TownyMessaging.sendErrorMsg(player, e.getMessage());
-				} catch (Exception e) {
-					TownyMessaging.sendErrorMsg(player, e.getMessage());
+					return;
 				}
+
+				nation.toggleNeutral(value);
+
+				// send message depending on if using an economy and charging
+				// for peaceful
+				if (TownySettings.isUsingEconomy() && cost > 0)
+					TownyMessaging.sendMsg(player, Translation.of("msg_you_paid", TownyEconomyHandler.getFormattedBalance(cost)));
+				else
+					TownyMessaging.sendMsg(player, Translation.of("msg_nation_set_peaceful"));
+
+				TownyMessaging.sendPrefixedNationMessage(nation, Translation.of("msg_nation_peaceful") + (nation.isNeutral
+						() ? Colors.Green : Colors.Red + " not") + " peaceful.");
 			} else if(split[0].equalsIgnoreCase("public")){
                 if (!townyUniverse.getPermissionSource().testPermission(player, PermissionNodes.TOWNY_COMMAND_NATION_TOGGLE_PUBLIC.getNode()))
                     throw new TownyException(Translation.of("msg_err_command_disable"));


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
There were several things in the neutral toggling code that were being mishandled.
First, several towny exceptions being thrown were preemptively caught. The handler of those exceptions then immediately set nation peaceful to off. This was fixed by removing the try-catch entirely and just letting the method executors handle the exceptions. 

Second, switching from peaceful to non-peaceful never charged a nation, however we were sending a falsely sending a "Nation has paid ..." message when nations switched to non-peaceful. This is fixed by just sending the message when toggling to peaceful.
____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Should fix #4467 (did not intentionally put closes since I don't know if this is the cause).
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
