### PR TITLE
Hotfix: Prevent admins from Soft-Locking Towny by force-joining outlaws.

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -2855,9 +2855,6 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 				invited.remove(newMember);
 				TownyMessaging.sendErrorMsg(sender, e.getMessage());
 			}
-			if (town.hasOutlaw(newMember)) {
-				town.removeOutlaw(newMember);
-			}
 		}
 
 		if (invited.size() > 0) {
@@ -2876,6 +2873,9 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 	}
 
 	public static void townAddResident(Town town, Resident resident) throws AlreadyRegisteredException {
+		// If player is outlawed in target town, remove them from outlaw list.
+		if (town.hasOutlaw(resident))
+			town.removeOutlaw(resident);
 
 		resident.setTown(town);
 		plugin.deleteCache(resident.getName());

--- a/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -924,11 +924,6 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 					TownyMessaging.sendMessage(sender, Translation.of("msg_error_no_player_with_that_name", split[2]));
 					return;
 				}
-				
-				// If player is outlawed in target town, remove them from outlaw list.
-				if (town.hasOutlaw(resident))
-					town.removeOutlaw(resident);
-				
 				TownCommand.townAddResident(town, resident);
 				TownyMessaging.sendPrefixedTownMessage(town, Translation.of("msg_join_town", resident.getName()));
 				TownyMessaging.sendMessage(sender, Translation.of("msg_join_town", resident.getName()));

--- a/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -924,6 +924,11 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 					TownyMessaging.sendMessage(sender, Translation.of("msg_error_no_player_with_that_name", split[2]));
 					return;
 				}
+				
+				// If player is outlawed in target town, remove them from outlaw list.
+				if (town.hasOutlaw(resident))
+					town.removeOutlaw(resident);
+				
 				TownCommand.townAddResident(town, resident);
 				TownyMessaging.sendPrefixedTownMessage(town, Translation.of("msg_join_town", resident.getName()));
 				TownyMessaging.sendMessage(sender, Translation.of("msg_join_town", resident.getName()));


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Attempts to address the following issue.

> found out you can lock towny in safe mode by joining a town you're outlawed in using townyadmin, which will cause towny to startup in safe mode next restart - @GNosii 
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
