### PR TITLE
Merges in the Ruined Town feature from Goosius' SiegeWar.

### DIFF
--- a/resources/english.yml
+++ b/resources/english.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.91
+version: 0.92
 language: english
 author: ElgarL
 website: 'http://townyadvanced.github.io/'
@@ -1195,6 +1195,7 @@ msg_universe_contributors: ' And contributors like you. '
 msg_universe_heart: '<3'
 townblock_plu: 'TownBlocks'
 
+#Added in 0.92
 #Town Ruins
 admin_panel_4: 'Run the new hour code'
 msg_newhour_success: 'newhour command executed successfully'
@@ -1205,3 +1206,5 @@ msg_err_cannot_reclaim_town_yet: '&cYou cannot reclaim your town for another %d 
 msg_town_reclaimed: '&b%s has reclaimed the town of %s.'
 msg_err_cannot_attack_ruined_town: '&6[War]&c You cannot attack a ruined town.'
 msg_err_cannot_use_command_because_town_ruined: "&cYou cannot use this command because your town is ruined. To resume normal command usage, either reclaim the town using ''/town reclaim'', or leave the town using ''/town leave''."
+msg_remaining_ruins_time: '&cRemaining ruins time: %s hours.'
+msg_warning_your_town_is_ruined_for_x_more_hours: '&cYour town lies in a ruined state for %d more hours. Use ''/town reclaim'' to save the town and become mayor.'

--- a/resources/english.yml
+++ b/resources/english.yml
@@ -1194,3 +1194,14 @@ msg_universe_attribution: 'Authors: '
 msg_universe_contributors: ' And contributors like you. '
 msg_universe_heart: '<3'
 townblock_plu: 'TownBlocks'
+
+#Town Ruins
+admin_panel_4: 'Run the new hour code'
+msg_newhour_success: 'newhour command executed successfully'
+town_help_12: 'Reclaim your town from a ruined state.'
+msg_warning_town_ruined_if_deleted: "WARNING!!!: If you delete your town it will enter a ruined state for %d hours. After this time full deletion will occur. In the ruined state, all perms are enabled, the town can be griefed, and the town can be reclaimed by any resident using '/t reclaim.'"
+msg_err_cannot_reclaim_town_unless_ruined: '&cYou cannot reclaim your town because it is not ruined.'
+msg_err_cannot_reclaim_town_yet: '&cYou cannot reclaim your town for another %d hours.'
+msg_town_reclaimed: '&b%s has reclaimed the town of %s.'
+msg_err_cannot_attack_ruined_town: '&6[War]&c You cannot attack a ruined town.'
+msg_err_cannot_use_command_because_town_ruined: "&cYou cannot use this command because your town is ruined. To resume normal command usage, either reclaim the town using ''/town reclaim'', or leave the town using ''/town leave''."

--- a/resources/english.yml
+++ b/resources/english.yml
@@ -1200,11 +1200,14 @@ townblock_plu: 'TownBlocks'
 admin_panel_4: 'Run the new hour code'
 msg_newhour_success: 'newhour command executed successfully'
 town_help_12: 'Reclaim your town from a ruined state.'
-msg_warning_town_ruined_if_deleted: "WARNING!!!: If you delete your town it will enter a ruined state for %d hours. After this time full deletion will occur. In the ruined state, all perms are enabled, the town can be griefed, and the town can be reclaimed by any resident using '/t reclaim.'"
+msg_warning_town_ruined_if_deleted: "WARNING!!!: If you delete your town it will enter a ruined state for %d hours. After this time full deletion will occur. In the ruined state, all perms are enabled and the town can be griefed."
+msg_warning_town_ruined_if_deleted2: "The town can be reclaimed by any town resident by using ''/t reclaim'' after %d hours."
 msg_err_cannot_reclaim_town_unless_ruined: '&cYou cannot reclaim your town because it is not ruined.'
 msg_err_cannot_reclaim_town_yet: '&cYou cannot reclaim your town for another %d hours.'
 msg_town_reclaimed: '&b%s has reclaimed the town of %s.'
 msg_err_cannot_attack_ruined_town: '&6[War]&c You cannot attack a ruined town.'
 msg_err_cannot_use_command_because_town_ruined: "&cYou cannot use this command because your town is ruined. To resume normal command usage, either reclaim the town using ''/town reclaim'', or leave the town using ''/town leave''."
-msg_remaining_ruins_time: '&cRemaining ruins time: %s hours.'
 msg_warning_your_town_is_ruined_for_x_more_hours: '&cYour town lies in a ruined state for %d more hours. Use ''/town reclaim'' to save the town and become mayor.'
+msg_time_remaining_before_full_removal: '&cTime remaining before full removal: &d hours.'
+msg_time_until_reclaim_available: '&cTime until reclaim available: &d hours.'
+msg_reclaim_available: '&aReclaim available.'

--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -314,6 +314,7 @@ permissions:
             towny.command.town.plots: true
             towny.command.town.rank.*: true
             towny.command.town.ranklist: true
+            towny.command.town.reclaim: true
             towny.command.town.reslist: true
             towny.command.town.say: true
             towny.command.town.set.*: true

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1617,7 +1617,7 @@ public enum ConfigNodes {
 			"# How much it costs to start a town."),
 	ECO_PRICE_RECLAIM_RUINED_TOWN(
 			"economy.new_expand.price_reclaim_ruined_town",
-			"200.0",
+			"500.0",
 			"# How much it costs to reclaim a ruined town.",
 			"# This is only applicable if the town-ruins & town-reclaim features are enabled."),
 	ECO_PRICE_OUTPOST(
@@ -2004,7 +2004,42 @@ public enum ConfigNodes {
 			"false",
 			"",
 			"# If true players will only be able to use /t deposit, /t withdraw, /n deposit & /n withdraw while inside bank plots belonging to the town or nation capital respectively.",
-			"# Home plots will also allow deposit and withdraw commands."),			
+			"# Home plots will also allow deposit and withdraw commands."),
+	
+	TOWN_RUINING_HEADER("town_ruining", "", "", "",
+			"  ############################################################",
+			"  # +------------------------------------------------------+ #",
+			"  # |               Town Ruining Settings                  | #",
+			"  # +------------------------------------------------------+ #",
+			"  ############################################################",
+			""),
+	TOWN_RUINING_TOWN_RUINS_ENABLED(
+			"town_ruining.town_ruins.enabled", 
+			"false",
+			"",
+			"# If this is true, then if a town falls, it remains in a 'ruined' state for a time.",
+			"# In this state, the town cannot be claimed, but can be looted.",
+			"# The feature prevents mayors from escaping attack/occupation, ",
+			"# by deleting then quickly recreating their town."),
+	TOWN_RUINING_TOWN_RUINS_MAX_DURATION_HOURS(
+			"town_ruining.town_ruins.max_duration_hours", 
+			"72",
+			"",
+			"# This value determines the maximum duration in which a town can lie in ruins",
+			"# After this time is reached, the town will be completely deleted.",
+			"# Does not accept values greater than 1000."),
+	TOWN_RUINING_TOWN_RUINS_MIN_DURATION_HOURS(
+			"town_ruining.town_ruins.min_duration_hours", 
+			"4",
+			"",
+			"# This value determines the minimum duration in which a town must lie in ruins,",
+			"# before it can be reclaimed by a resident."),
+	TOWN_RUINING_TOWN_RUINS_RECLAIM_ENABLED(
+			"town_ruining.town_ruins.reclaim_enabled", 
+			"true",
+			"",
+			"# If this is true, then after a town has been ruined for the minimum configured time,",
+			"# it can then be reclaimed by any resident who runs /t reclaim, and pays the required price. (price is configured in the eco section)"),
 	WAR(
 			"war",
 			"",
@@ -2324,49 +2359,7 @@ public enum ConfigNodes {
 			"",
 			"# A list of blocks that will not be exploded, mostly because they won't regenerate properly.",
 			"# These blocks will also protect the block below them, so that blocks like doors do not dupe themselves.",
-			"# Only under affect when explosions_break_blocks is true."),
-
-	WAR_COMMON("war.common", "", "", "",
-			"############################################################",
-			"# +------------------------------------------------------+ #",
-			"# |                 Common War settings                  | #",
-			"# |                                                      | #",
-			"# |  These configs are common to multiple war systems.   | #",
-			"# |                                                      | #",
-			"# |  Note: The town ruins settings are here,             | #",
-			"# |  because town ruin is critical to many war systems   | #",
-			"# |  												      | #",
-			"# +------------------------------------------------------+ #",
-			"############################################################",
-			""),
-	// Town Ruins
-	WAR_COMMON_TOWN_RUINS_ENABLED(
-			"war.common.town_ruins.enabled", 
-			"true",
-			"",
-			"# If this is true, then if a town falls, it remains in a 'ruined' state for a time.",
-			"# In this state, the town cannot be claimed, but can be looted.",
-			"# The feature prevents mayors from escaping attack/occupation, ",
-			"# by deleting then quickly recreating their town."),
-	WAR_COMMON_TOWN_RUINS_MAX_DURATION_HOURS(
-			"war.common.town_ruins.max_duration_hours", 
-			"72",
-			"",
-			"# This value determines the maximum duration in which a town can lie in ruins",
-			"# After this time is reached, the town will be completely deleted.",
-			"# Does not accept values greater than 1000."),
-	WAR_COMMON_TOWN_RUINS_MIN_DURATION_HOURS(
-			"war.common.town_ruins.min_duration_hours", 
-			"24",
-			"",
-			"# This value determines the minimum duration in which a town must lie in ruins,",
-			"# before it can be reclaimed by a resident."),
-	WAR_COMMON_TOWN_RUINS_RECLAIM_ENABLED(
-			"war.common.town_ruins.reclaim_enabled", 
-			"true",
-			"",
-			"# If this is true, then after a town has been ruined for the minimum configured time,",
-			"# it can then be reclaimed by any resident who runs /t reclaim, and pays the required price. (price is configured in the eco section)");
+			"# Only under affect when explosions_break_blocks is true.");
 
 	private final String Root;
 	private final String Default;

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -2337,8 +2337,8 @@ public enum ConfigNodes {
 			"# |  because town ruin is critical to many war systems   | #",
 			"# |  												      | #",
 			"# +------------------------------------------------------+ #",
-			"############################################################", ""),
-
+			"############################################################",
+			""),
 	// Town Ruins
 	WAR_COMMON_TOWN_RUINS_ENABLED(
 			"war.common.town_ruins.enabled", 

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1615,6 +1615,11 @@ public enum ConfigNodes {
 			"250.0",
 			"",
 			"# How much it costs to start a town."),
+	ECO_PRICE_RECLAIM_RUINED_TOWN(
+			"economy.new_expand.price_reclaim_ruined_town",
+			"200.0",
+			"# How much it costs to reclaim a ruined town.",
+			"# This is only applicable if the town-ruins & town-reclaim features are enabled."),
 	ECO_PRICE_OUTPOST(
 			"economy.new_expand.price_outpost",
 			"500.0",
@@ -2319,8 +2324,48 @@ public enum ConfigNodes {
 			"",
 			"# A list of blocks that will not be exploded, mostly because they won't regenerate properly.",
 			"# These blocks will also protect the block below them, so that blocks like doors do not dupe themselves.",
-			"# Only under affect when explosions_break_blocks is true.");
+			"# Only under affect when explosions_break_blocks is true."),
 
+	WAR_COMMON("war.common", "", "", "",
+			"############################################################",
+			"# +------------------------------------------------------+ #",
+			"# |                 Common War settings                  | #",
+			"# |                                                      | #",
+			"# |  These configs are common to multiple war systems.   | #",
+			"# |                                                      | #",
+			"# |  Note: The town ruins settings are here,             | #",
+			"# |  because town ruin is critical to many war systems   | #",
+			"# |  												      | #",
+			"# +------------------------------------------------------+ #",
+			"############################################################", ""),
+
+	// Town Ruins
+	WAR_COMMON_TOWN_RUINS_ENABLED(
+			"war.common.town_ruins.enabled", 
+			"true",
+			"",
+			"# If this is true, then if a town falls, it remains in a 'ruined' state for a time.",
+			"# In this state, the town cannot be claimed, but can be looted.",
+			"# The feature prevents mayors from escaping attack/occupation, ",
+			"# by deleting then quickly recreating their town."),
+	WAR_COMMON_TOWN_RUINS_MAX_DURATION_HOURS(
+			"war.common.town_ruins.max_duration_hours", 
+			"72",
+			"",
+			"# This value determines the maximum duration in which a town can lie in ruins",
+			"# After this time is reached, the town will be completely deleted."),
+	WAR_COMMON_TOWN_RUINS_MIN_DURATION_HOURS(
+			"war.common.town_ruins.min_duration_hours", 
+			"24",
+			"",
+			"# This value determines the minimum duration in which a town must lie in ruins,",
+			"# before it can be reclaimed by a resident."),
+	WAR_COMMON_TOWN_RUINS_RECLAIM_ENABLED(
+			"war.common.town_ruins.reclaim_enabled", 
+			"true",
+			"",
+			"# If this is true, then after a town has been ruined for the minimum configured time,",
+			"# it can then be reclaimed by any resident who runs /t reclaim, and pays the required price. (price is configured in the eco section)");
 
 	private final String Root;
 	private final String Default;

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -2353,7 +2353,8 @@ public enum ConfigNodes {
 			"72",
 			"",
 			"# This value determines the maximum duration in which a town can lie in ruins",
-			"# After this time is reached, the town will be completely deleted."),
+			"# After this time is reached, the town will be completely deleted.",
+			"# Does not accept values greater than 1000."),
 	WAR_COMMON_TOWN_RUINS_MIN_DURATION_HOURS(
 			"war.common.town_ruins.min_duration_hours", 
 			"24",

--- a/src/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/src/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -374,54 +374,62 @@ public class TownyFormatter {
 				Translation.of("firespread") + ((town.isFire() || world.isForceFire()) ? Translation.of("status_on"): Translation.of("status_off")) + 
 				Translation.of("mobspawns") + ((town.hasMobs() || world.isForceTownMobs()) ? Translation.of("status_on"): Translation.of("status_off")));
 
-	      //Only display the remaining fields if town is not ruined
-        if(!town.isRuined()) {
-        	// | Bank: 534 coins
-        	if (TownySettings.isUsingEconomy() && TownyEconomyHandler.isActive()) {
-        		String bankString = "";
-        
-        		bankString = Translation.of(town.isBankrupt() ? "status_bank_bankrupt" : "status_bank" , town.getAccount().getHoldingFormattedBalance());
-        		if (town.isBankrupt()) {
-        			if (town.getAccount().getDebtCap() == 0)
-        				town.getAccount().setDebtCap(MoneyUtil.getEstimatedValueOfTown(town));
-        			bankString += " " + Translation.of("status_debtcap", "-" + TownyEconomyHandler.getFormattedBalance(town.getAccount().getDebtCap()));
-        		}
-        		if (town.hasUpkeep())
-        			bankString += Translation.of("status_bank_town2", BigDecimal.valueOf(TownySettings.getTownUpkeepCost(town)).setScale(2, RoundingMode.HALF_UP).doubleValue());
-        		if (TownySettings.getUpkeepPenalty() > 0 && town.isOverClaimed())
-        			bankString += Translation.of("status_bank_town_penalty_upkeep", TownySettings.getTownPenaltyUpkeepCost(town));
-        		bankString += Translation.of("status_bank_town3", town.getTaxes()) + (town.isTaxPercentage() ? "%" : "");
-        
-        		out.add(bankString);
-        	}
-        
-        	// Mayor: MrSand | Bank: 534 coins
-        	out.add(Translation.of("rank_list_mayor", town.getMayor().getFormattedName()));
-        
-        	// Assistants [2]: Sammy, Ginger
-        	List<String> ranklist = new ArrayList<>();
-        	getRanks(town, ranklist);
-        
-        	out.addAll(ranklist);
-        
-        	// Nation: Azur Empire
-        	try {
-        		out.add(Translation.of("status_town_nation", town.getNation().getFormattedName()) + (town.isConquered() ? Translation.of("msg_conquered") : "" ));
-        	} catch (TownyException ignored) {}
-        
-        	// Residents [12]: James, Carry, Mason
-        
-        	String[] residents = getFormattedNames(town.getResidents().toArray(new Resident[0]));
-        	if (residents.length > 34) {
-        		String[] entire = residents;
-        		residents = new String[36];
-        		System.arraycopy(entire, 0, residents, 0, 35);
-        		residents[35] = Translation.of("status_town_reslist_overlength");
-        	}
-        	out.addAll(ChatTools.listArr(residents, Translation.of("status_town_reslist", town.getNumResidents())));		
+		// Only display the remaining fields if town is not ruined
+		if (!town.isRuined()) {
+			// | Bank: 534 coins
+			if (TownySettings.isUsingEconomy() && TownyEconomyHandler.isActive()) {
+				String bankString = "";
 
-        }
-        
+				bankString = Translation.of(town.isBankrupt() ? "status_bank_bankrupt" : "status_bank",
+						town.getAccount().getHoldingFormattedBalance());
+				if (town.isBankrupt()) {
+					if (town.getAccount().getDebtCap() == 0)
+						town.getAccount().setDebtCap(MoneyUtil.getEstimatedValueOfTown(town));
+					bankString += " " + Translation.of("status_debtcap",
+							"-" + TownyEconomyHandler.getFormattedBalance(town.getAccount().getDebtCap()));
+				}
+				if (town.hasUpkeep())
+					bankString += Translation.of("status_bank_town2",
+							BigDecimal.valueOf(TownySettings.getTownUpkeepCost(town)).setScale(2, RoundingMode.HALF_UP)
+									.doubleValue());
+				if (TownySettings.getUpkeepPenalty() > 0 && town.isOverClaimed())
+					bankString += Translation.of("status_bank_town_penalty_upkeep",
+							TownySettings.getTownPenaltyUpkeepCost(town));
+				bankString += Translation.of("status_bank_town3", town.getTaxes())
+						+ (town.isTaxPercentage() ? "%" : "");
+
+				out.add(bankString);
+			}
+
+			// Mayor: MrSand | Bank: 534 coins
+			out.add(Translation.of("rank_list_mayor", town.getMayor().getFormattedName()));
+
+			// Assistants [2]: Sammy, Ginger
+			List<String> ranklist = new ArrayList<>();
+			getRanks(town, ranklist);
+
+			out.addAll(ranklist);
+
+			// Nation: Azur Empire
+			try {
+				out.add(Translation.of("status_town_nation", town.getNation().getFormattedName())
+						+ (town.isConquered() ? Translation.of("msg_conquered") : ""));
+			} catch (TownyException ignored) {
+			}
+
+			// Residents [12]: James, Carry, Mason
+
+			String[] residents = getFormattedNames(town.getResidents().toArray(new Resident[0]));
+			if (residents.length > 34) {
+				String[] entire = residents;
+				residents = new String[36];
+				System.arraycopy(entire, 0, residents, 0, 35);
+				residents[35] = Translation.of("status_town_reslist_overlength");
+			}
+			out.addAll(ChatTools.listArr(residents, Translation.of("status_town_reslist", town.getNumResidents())));
+
+		}
+
 		out.addAll(getExtraFields(town));
 		
 		out = formatStatusScreens(out);

--- a/src/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/src/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -18,6 +18,8 @@ import com.palmergames.bukkit.towny.permissions.TownyPerms;
 import com.palmergames.bukkit.towny.utils.CombatUtil;
 import com.palmergames.bukkit.towny.utils.MoneyUtil;
 import com.palmergames.bukkit.towny.utils.ResidentUtil;
+import com.palmergames.bukkit.towny.war.common.townruin.TownRuinSettings;
+import com.palmergames.bukkit.towny.war.common.townruin.TownRuinUtil;
 import com.palmergames.bukkit.util.BukkitTools;
 import com.palmergames.bukkit.util.ChatTools;
 import com.palmergames.bukkit.util.Colors;
@@ -374,10 +376,14 @@ public class TownyFormatter {
 				Translation.of("firespread") + ((town.isFire() || world.isForceFire()) ? Translation.of("status_on"): Translation.of("status_off")) + 
 				Translation.of("mobspawns") + ((town.hasMobs() || world.isForceTownMobs()) ? Translation.of("status_on"): Translation.of("status_off")));
 
-		if (town.isRuined())
-			out.add(Translation.of("msg_remaining_ruins_time", town.getRuinDurationRemainingHours()));
+		if (town.isRuined()) {
+			out.add(Translation.of("msg_time_remaining_before_full_removal", TownRuinSettings.getTownRuinsMaxDurationHours() - TownRuinUtil.getTimeSinceRuining(town)));
+			if (TownRuinUtil.getTimeSinceRuining(town) < TownRuinSettings.getTownRuinsMinDurationHours())
+				out.add(Translation.of("msg_time_until_reclaim_available", TownRuinSettings.getTownRuinsMinDurationHours() - TownRuinUtil.getTimeSinceRuining(town)));
+			else 
+				out.add(Translation.of("msg_reclaim_available"));
 			// Only display the remaining fields if town is not ruined
-		else {
+		} else {
 			// | Bank: 534 coins
 			if (TownySettings.isUsingEconomy() && TownyEconomyHandler.isActive()) {
 				String bankString = "";

--- a/src/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/src/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -378,10 +378,12 @@ public class TownyFormatter {
 
 		if (town.isRuined()) {
 			out.add(Translation.of("msg_time_remaining_before_full_removal", TownRuinSettings.getTownRuinsMaxDurationHours() - TownRuinUtil.getTimeSinceRuining(town)));
-			if (TownRuinUtil.getTimeSinceRuining(town) < TownRuinSettings.getTownRuinsMinDurationHours())
-				out.add(Translation.of("msg_time_until_reclaim_available", TownRuinSettings.getTownRuinsMinDurationHours() - TownRuinUtil.getTimeSinceRuining(town)));
-			else 
-				out.add(Translation.of("msg_reclaim_available"));
+			if (TownRuinSettings.getTownRuinsReclaimEnabled()) {
+				if (TownRuinUtil.getTimeSinceRuining(town) < TownRuinSettings.getTownRuinsMinDurationHours())
+					out.add(Translation.of("msg_time_until_reclaim_available", TownRuinSettings.getTownRuinsMinDurationHours() - TownRuinUtil.getTimeSinceRuining(town)));
+				else 
+					out.add(Translation.of("msg_reclaim_available"));
+			}
 			// Only display the remaining fields if town is not ruined
 		} else {
 			// | Bank: 534 coins

--- a/src/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/src/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -374,50 +374,54 @@ public class TownyFormatter {
 				Translation.of("firespread") + ((town.isFire() || world.isForceFire()) ? Translation.of("status_on"): Translation.of("status_off")) + 
 				Translation.of("mobspawns") + ((town.hasMobs() || world.isForceTownMobs()) ? Translation.of("status_on"): Translation.of("status_off")));
 
-		// | Bank: 534 coins
-		if (TownySettings.isUsingEconomy() && TownyEconomyHandler.isActive()) {
-			String bankString = "";
+	      //Only display the remaining fields if town is not ruined
+        if(!town.isRuined()) {
+        	// | Bank: 534 coins
+        	if (TownySettings.isUsingEconomy() && TownyEconomyHandler.isActive()) {
+        		String bankString = "";
+        
+        		bankString = Translation.of(town.isBankrupt() ? "status_bank_bankrupt" : "status_bank" , town.getAccount().getHoldingFormattedBalance());
+        		if (town.isBankrupt()) {
+        			if (town.getAccount().getDebtCap() == 0)
+        				town.getAccount().setDebtCap(MoneyUtil.getEstimatedValueOfTown(town));
+        			bankString += " " + Translation.of("status_debtcap", "-" + TownyEconomyHandler.getFormattedBalance(town.getAccount().getDebtCap()));
+        		}
+        		if (town.hasUpkeep())
+        			bankString += Translation.of("status_bank_town2", BigDecimal.valueOf(TownySettings.getTownUpkeepCost(town)).setScale(2, RoundingMode.HALF_UP).doubleValue());
+        		if (TownySettings.getUpkeepPenalty() > 0 && town.isOverClaimed())
+        			bankString += Translation.of("status_bank_town_penalty_upkeep", TownySettings.getTownPenaltyUpkeepCost(town));
+        		bankString += Translation.of("status_bank_town3", town.getTaxes()) + (town.isTaxPercentage() ? "%" : "");
+        
+        		out.add(bankString);
+        	}
+        
+        	// Mayor: MrSand | Bank: 534 coins
+        	out.add(Translation.of("rank_list_mayor", town.getMayor().getFormattedName()));
+        
+        	// Assistants [2]: Sammy, Ginger
+        	List<String> ranklist = new ArrayList<>();
+        	getRanks(town, ranklist);
+        
+        	out.addAll(ranklist);
+        
+        	// Nation: Azur Empire
+        	try {
+        		out.add(Translation.of("status_town_nation", town.getNation().getFormattedName()) + (town.isConquered() ? Translation.of("msg_conquered") : "" ));
+        	} catch (TownyException ignored) {}
+        
+        	// Residents [12]: James, Carry, Mason
+        
+        	String[] residents = getFormattedNames(town.getResidents().toArray(new Resident[0]));
+        	if (residents.length > 34) {
+        		String[] entire = residents;
+        		residents = new String[36];
+        		System.arraycopy(entire, 0, residents, 0, 35);
+        		residents[35] = Translation.of("status_town_reslist_overlength");
+        	}
+        	out.addAll(ChatTools.listArr(residents, Translation.of("status_town_reslist", town.getNumResidents())));		
 
-			bankString = Translation.of(town.isBankrupt() ? "status_bank_bankrupt" : "status_bank" , town.getAccount().getHoldingFormattedBalance());
-			if (town.isBankrupt()) {
-				if (town.getAccount().getDebtCap() == 0)
-					town.getAccount().setDebtCap(MoneyUtil.getEstimatedValueOfTown(town));
-				bankString += " " + Translation.of("status_debtcap", "-" + TownyEconomyHandler.getFormattedBalance(town.getAccount().getDebtCap()));
-			}
-			if (town.hasUpkeep())
-				bankString += Translation.of("status_bank_town2", BigDecimal.valueOf(TownySettings.getTownUpkeepCost(town)).setScale(2, RoundingMode.HALF_UP).doubleValue());
-			if (TownySettings.getUpkeepPenalty() > 0 && town.isOverClaimed())
-				bankString += Translation.of("status_bank_town_penalty_upkeep", TownySettings.getTownPenaltyUpkeepCost(town));
-			bankString += Translation.of("status_bank_town3", town.getTaxes()) + (town.isTaxPercentage() ? "%" : "");
-
-			out.add(bankString);
-		}
-
-		// Mayor: MrSand | Bank: 534 coins
-		out.add(Translation.of("rank_list_mayor", town.getMayor().getFormattedName()));
-
-		// Assistants [2]: Sammy, Ginger
-		List<String> ranklist = new ArrayList<>();
-		getRanks(town, ranklist);
-
-		out.addAll(ranklist);
-
-		// Nation: Azur Empire
-		try {
-			out.add(Translation.of("status_town_nation", town.getNation().getFormattedName()) + (town.isConquered() ? Translation.of("msg_conquered") : "" ));
-		} catch (TownyException ignored) {}
-
-		// Residents [12]: James, Carry, Mason
-
-		String[] residents = getFormattedNames(town.getResidents().toArray(new Resident[0]));
-		if (residents.length > 34) {
-			String[] entire = residents;
-			residents = new String[36];
-			System.arraycopy(entire, 0, residents, 0, 35);
-			residents[35] = Translation.of("status_town_reslist_overlength");
-		}
-		out.addAll(ChatTools.listArr(residents, Translation.of("status_town_reslist", town.getNumResidents())));		
-
+        }
+        
 		out.addAll(getExtraFields(town));
 		
 		out = formatStatusScreens(out);

--- a/src/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/src/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -374,8 +374,10 @@ public class TownyFormatter {
 				Translation.of("firespread") + ((town.isFire() || world.isForceFire()) ? Translation.of("status_on"): Translation.of("status_off")) + 
 				Translation.of("mobspawns") + ((town.hasMobs() || world.isForceTownMobs()) ? Translation.of("status_on"): Translation.of("status_off")));
 
-		// Only display the remaining fields if town is not ruined
-		if (!town.isRuined()) {
+		if (town.isRuined())
+			out.add(Translation.of("msg_remaining_ruins_time", town.getRuinDurationRemainingHours()));
+			// Only display the remaining fields if town is not ruined
+		else {
 			// | Bank: 534 coins
 			if (TownySettings.isUsingEconomy() && TownyEconomyHandler.isActive()) {
 				String bankString = "";

--- a/src/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/src/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -385,18 +385,13 @@ public class TownyFormatter {
 				if (town.isBankrupt()) {
 					if (town.getAccount().getDebtCap() == 0)
 						town.getAccount().setDebtCap(MoneyUtil.getEstimatedValueOfTown(town));
-					bankString += " " + Translation.of("status_debtcap",
-							"-" + TownyEconomyHandler.getFormattedBalance(town.getAccount().getDebtCap()));
+					bankString += " " + Translation.of("status_debtcap", "-" + TownyEconomyHandler.getFormattedBalance(town.getAccount().getDebtCap()));
 				}
 				if (town.hasUpkeep())
-					bankString += Translation.of("status_bank_town2",
-							BigDecimal.valueOf(TownySettings.getTownUpkeepCost(town)).setScale(2, RoundingMode.HALF_UP)
-									.doubleValue());
+					bankString += Translation.of("status_bank_town2", BigDecimal.valueOf(TownySettings.getTownUpkeepCost(town)).setScale(2, RoundingMode.HALF_UP).doubleValue());
 				if (TownySettings.getUpkeepPenalty() > 0 && town.isOverClaimed())
-					bankString += Translation.of("status_bank_town_penalty_upkeep",
-							TownySettings.getTownPenaltyUpkeepCost(town));
-				bankString += Translation.of("status_bank_town3", town.getTaxes())
-						+ (town.isTaxPercentage() ? "%" : "");
+					bankString += Translation.of("status_bank_town_penalty_upkeep", TownySettings.getTownPenaltyUpkeepCost(town));
+				bankString += Translation.of("status_bank_town3", town.getTaxes()) + (town.isTaxPercentage() ? "%" : "");
 
 				out.add(bankString);
 			}
@@ -412,8 +407,7 @@ public class TownyFormatter {
 
 			// Nation: Azur Empire
 			try {
-				out.add(Translation.of("status_town_nation", town.getNation().getFormattedName())
-						+ (town.isConquered() ? Translation.of("msg_conquered") : ""));
+				out.add(Translation.of("status_town_nation", town.getNation().getFormattedName()) + (town.isConquered() ? Translation.of("msg_conquered") : ""));
 			} catch (TownyException ignored) {
 			}
 

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -215,6 +215,8 @@ public class TownySettings {
 //
 //		if (level != null) return level;
 //		return 0;
+		if(town.isRuined())
+			return 0;
 		int n = town.getNumResidents();
 		for (Integer level : configTownLevel.keySet())
 			if (n >= level)
@@ -234,8 +236,8 @@ public class TownySettings {
 	 * @return id
 	 */
 	public static int calcTownLevelId(Town town) {
-//		if(town.isRuined())  TODO: Potentially merge in Ruined Towns feature.
-//			return 0;
+		if(town.isRuined())
+			return 0;
 
 		int townLevelId = -1;
 		int numResidents = town.getNumResidents();
@@ -2812,7 +2814,7 @@ public class TownySettings {
 		Map<String,String> nationColorsMap = new HashMap<>();
 		String[] keyValuePair;
 		for(String nationColor: nationColorsList) {
-			keyValuePair = nationColor.split(":");
+			keyValuePair = nationColor.trim().split(":");
 			nationColorsMap.put(keyValuePair[0], keyValuePair[1]);
 		}
 		return nationColorsMap;

--- a/src/com/palmergames/bukkit/towny/command/PlotCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/PlotCommand.java
@@ -37,6 +37,7 @@ import com.palmergames.bukkit.towny.utils.AreaSelectionUtil;
 import com.palmergames.bukkit.towny.utils.CombatUtil;
 import com.palmergames.bukkit.towny.utils.NameUtil;
 import com.palmergames.bukkit.towny.utils.OutpostUtil;
+import com.palmergames.bukkit.towny.war.common.townruin.TownRuinUtil;
 import com.palmergames.bukkit.util.BukkitTools;
 import com.palmergames.bukkit.util.ChatTools;
 import com.palmergames.bukkit.util.Colors;
@@ -235,6 +236,10 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 			}
 
 			try {
+				if (TownRuinUtil.isPlayersTownRuined(player)) {
+					throw new TownyException(Translation.of("msg_err_cannot_use_command_because_town_ruined"));
+				}
+
 				if (split[0].equalsIgnoreCase("claim")) {
 
 					if (!townyUniverse.getPermissionSource().testPermission(player, PermissionNodes.TOWNY_COMMAND_PLOT_CLAIM.getNode()))

--- a/src/com/palmergames/bukkit/towny/command/PlotCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/PlotCommand.java
@@ -37,7 +37,6 @@ import com.palmergames.bukkit.towny.utils.AreaSelectionUtil;
 import com.palmergames.bukkit.towny.utils.CombatUtil;
 import com.palmergames.bukkit.towny.utils.NameUtil;
 import com.palmergames.bukkit.towny.utils.OutpostUtil;
-import com.palmergames.bukkit.towny.war.common.townruin.TownRuinUtil;
 import com.palmergames.bukkit.util.BukkitTools;
 import com.palmergames.bukkit.util.ChatTools;
 import com.palmergames.bukkit.util.Colors;
@@ -236,9 +235,8 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 			}
 
 			try {
-				if (TownRuinUtil.isPlayersTownRuined(player)) {
+				if (!TownyAPI.getInstance().isWilderness(player.getLocation()) && TownyAPI.getInstance().getTownBlock(player.getLocation()).getTown().isRuined())
 					throw new TownyException(Translation.of("msg_err_cannot_use_command_because_town_ruined"));
-				}
 
 				if (split[0].equalsIgnoreCase("claim")) {
 

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -2782,7 +2782,6 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 
 				town = resident.getTown();
 				Confirmation.runOnAccept(() -> {
-					TownyMessaging.sendGlobalMessage(Translation.of("MSG_DEL_TOWN", town.getName()));
 					TownyUniverse.getInstance().getDataSource().removeTown(town);
 				})
 					.sendTo(player);

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -486,11 +486,9 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 				if (!TownySettings.isUsingEconomy())
 					throw new TownyException(Translation.of("msg_err_no_economy"));
 
-				// TODO: use transaction event.
-				if (TownRuinUtil.isPlayersTownRuined(player)) {
+				if (TownRuinUtil.isPlayersTownRuined(player))
 					throw new TownyException(Translation.of("msg_err_cannot_use_command_because_town_ruined"));
-				}
-
+				
 				if (!townyUniverse.getPermissionSource().testPermission(player, PermissionNodes.TOWNY_COMMAND_TOWN_WITHDRAW.getNode()))
 					throw new TownyException(Translation.of("msg_err_command_disable"));
 				
@@ -572,9 +570,8 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 					throw new TownyException(Translation.of("msg_must_specify_amnt", "/town deposit"));
 			} else if (split[0].equalsIgnoreCase("plots")) {
 
-				if (TownRuinUtil.isPlayersTownRuined(player)) {
+				if (TownRuinUtil.isPlayersTownRuined(player))
 					throw new TownyException(Translation.of("msg_err_cannot_use_command_because_town_ruined"));
-				}
 
 				if (!townyUniverse.getPermissionSource().testPermission(player, PermissionNodes.TOWNY_COMMAND_TOWN_PLOTS.getNode()))
 					throw new TownyException(Translation.of("msg_err_command_disable"));
@@ -598,9 +595,8 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 				townPlots(player, town);
 
 			} else {
-				if (TownRuinUtil.isPlayersTownRuined(player)) {
+				if (TownRuinUtil.isPlayersTownRuined(player))
 					throw new TownyException(Translation.of("msg_err_cannot_use_command_because_town_ruined"));
-				}
 
 				String[] newSplit = StringMgmt.remFirstArg(split);
 
@@ -2781,11 +2777,10 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 			try {
 				Resident resident = townyUniverse.getDataSource().getResident(player.getName());
 
-				if(TownRuinSettings.getWarCommonTownRuinsEnabled()) {
+				if (TownRuinSettings.getWarCommonTownRuinsEnabled()) {
 					int durationHours = TownRuinSettings.getWarCommonTownRuinsMaxDurationHours();
-					TownyMessaging.sendErrorMsg(player, String.format(
-						Translation.of("msg_warning_town_ruined_if_deleted"),
-						durationHours));
+					TownyMessaging.sendErrorMsg(player,
+							String.format(Translation.of("msg_warning_town_ruined_if_deleted"), durationHours));
 				}
 
 				town = resident.getTown();

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -471,7 +471,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 				if (!townyUniverse.getPermissionSource().testPermission(player, PermissionNodes.TOWNY_COMMAND_TOWN_RECLAIM.getNode()))
 					throw new TownyException(Translation.of("msg_err_command_disable"));
 				
-				if(!TownRuinSettings.getWarCommonTownRuinsReclaimEnabled())
+				if(!TownRuinSettings.getTownRuinsReclaimEnabled())
 					throw new TownyException(Translation.of("msg_err_command_disable"));
 				
 				TownRuinUtil.processRuinedTownReclaimRequest(player, plugin);
@@ -2777,9 +2777,11 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 			try {
 				Resident resident = townyUniverse.getDataSource().getResident(player.getName());
 
-				if (TownRuinSettings.getWarCommonTownRuinsEnabled())
-					TownyMessaging.sendErrorMsg(player, Translation.of("msg_warning_town_ruined_if_deleted", TownRuinSettings.getWarCommonTownRuinsMaxDurationHours()));
-
+				if (TownRuinSettings.getTownRuinsEnabled()) {
+					TownyMessaging.sendErrorMsg(player, Translation.of("msg_warning_town_ruined_if_deleted", TownRuinSettings.getTownRuinsMaxDurationHours()));
+					if (TownRuinSettings.getTownRuinsReclaimEnabled())
+						TownyMessaging.sendErrorMsg(player, Translation.of("msg_warning_town_ruined_if_deleted2", TownRuinSettings.getTownRuinsMinDurationHours()));
+				}
 				town = resident.getTown();
 				Confirmation.runOnAccept(() -> {
 					TownyUniverse.getInstance().getDataSource().removeTown(town);

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -468,11 +468,13 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 
 			} else if (split[0].equalsIgnoreCase("reclaim")) {
 
-				if(TownRuinSettings.getWarCommonTownRuinsReclaimEnabled()) {
-					TownRuinUtil.processRuinedTownReclaimRequest(player, plugin);
-				} else {
+				if (!townyUniverse.getPermissionSource().testPermission(player, PermissionNodes.TOWNY_COMMAND_TOWN_RECLAIM.getNode()))
 					throw new TownyException(Translation.of("msg_err_command_disable"));
-				}
+				
+				if(!TownRuinSettings.getWarCommonTownRuinsReclaimEnabled())
+					throw new TownyException(Translation.of("msg_err_command_disable"));
+				
+				TownRuinUtil.processRuinedTownReclaimRequest(player, plugin);
 
 			} else if (split[0].equalsIgnoreCase("leave")) {
 
@@ -488,7 +490,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 
 				if (TownRuinUtil.isPlayersTownRuined(player))
 					throw new TownyException(Translation.of("msg_err_cannot_use_command_because_town_ruined"));
-				
+
 				if (!townyUniverse.getPermissionSource().testPermission(player, PermissionNodes.TOWNY_COMMAND_TOWN_WITHDRAW.getNode()))
 					throw new TownyException(Translation.of("msg_err_command_disable"));
 				
@@ -525,14 +527,12 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 
 			} else if (split[0].equalsIgnoreCase("deposit")) {
 
-				// TODO: use transaction event.
-				if (TownRuinUtil.isPlayersTownRuined(player)) {
-					throw new TownyException(Translation.of("msg_err_cannot_use_command_because_town_ruined"));
-				}
-
 				if (!TownySettings.isUsingEconomy())
 					throw new TownyException(Translation.of("msg_err_no_economy"));
-				
+
+				if (TownRuinUtil.isPlayersTownRuined(player)) 
+					throw new TownyException(Translation.of("msg_err_cannot_use_command_because_town_ruined"));
+
 				if (!townyUniverse.getPermissionSource().testPermission(player, PermissionNodes.TOWNY_COMMAND_TOWN_DEPOSIT.getNode()))
 					throw new TownyException(Translation.of("msg_err_command_disable"));
 				
@@ -2777,11 +2777,8 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 			try {
 				Resident resident = townyUniverse.getDataSource().getResident(player.getName());
 
-				if (TownRuinSettings.getWarCommonTownRuinsEnabled()) {
-					int durationHours = TownRuinSettings.getWarCommonTownRuinsMaxDurationHours();
-					TownyMessaging.sendErrorMsg(player,
-							String.format(Translation.of("msg_warning_town_ruined_if_deleted"), durationHours));
-				}
+				if (TownRuinSettings.getWarCommonTownRuinsEnabled())
+					TownyMessaging.sendErrorMsg(player, Translation.of("msg_warning_town_ruined_if_deleted", TownRuinSettings.getWarCommonTownRuinsMaxDurationHours()));
 
 				town = resident.getTown();
 				Confirmation.runOnAccept(() -> {

--- a/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -92,6 +92,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		"backup",
 		"checkperm",
 		"newday",
+		"newhour",
 		"unclaim",
 		"purge",
 		"mysqldump",
@@ -530,6 +531,11 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			} else if (split[0].equalsIgnoreCase("newday")) {
 
 				TownyTimerHandler.newDay();
+
+			} else if (split[0].equalsIgnoreCase("newhour")) {
+
+				TownyTimerHandler.newHour();
+				TownyMessaging.sendMsg(getSender(), Translation.of("msg_newhour_success"));
 
 			} else if (split[0].equalsIgnoreCase("purge")) {
 

--- a/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -941,11 +941,9 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			} else if (split[1].equalsIgnoreCase("delete")) {
 				if (!isConsole) {
 					TownyMessaging.sendMessage(sender, Translation.of("town_deleted_by_admin", town.getName()));
-					TownyMessaging.sendGlobalMessage(Translation.of("msg_del_town", town.getName()));
 					townyUniverse.getDataSource().removeTown(town);
 				} else { //isConsole
 					Confirmation.runOnAccept(() -> {
-						TownyMessaging.sendGlobalMessage(Translation.of("MSG_DEL_TOWN", town.getName()));
 						TownyUniverse.getInstance().getDataSource().removeTown(town);
 					})
 						.sendTo(sender);

--- a/src/com/palmergames/bukkit/towny/command/TownyCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyCommand.java
@@ -24,6 +24,7 @@ import com.palmergames.bukkit.towny.object.Translation;
 import com.palmergames.bukkit.towny.permissions.PermissionNodes;
 import com.palmergames.bukkit.towny.utils.NameUtil;
 import com.palmergames.bukkit.towny.utils.ResidentUtil;
+import com.palmergames.bukkit.towny.war.common.townruin.TownRuinSettings;
 import com.palmergames.bukkit.towny.war.eventwar.War;
 import com.palmergames.bukkit.util.ChatTools;
 import com.palmergames.bukkit.util.Colors;
@@ -503,6 +504,7 @@ public class TownyCommand extends BaseCommand implements CommandExecutor {
 
 		output.add(ChatTools.formatTitle("Prices"));
 		output.add(Colors.Yellow + "[New] " + Colors.Green + "Town: " + Colors.LightGreen + TownyEconomyHandler.getFormattedBalance(TownySettings.getNewTownPrice()) + Colors.Gray + " | " + Colors.Green + "Nation: " + Colors.LightGreen + TownyEconomyHandler.getFormattedBalance(TownySettings.getNewNationPrice()));
+		output.add(Colors.Yellow + "[Reclaim] " + Colors.Green + "Town: " + Colors.LightGreen + TownyEconomyHandler.getFormattedBalance(TownRuinSettings.getEcoPriceReclaimTown()));
 		if (town != null) {
 			output.add(Colors.Yellow + "[Upkeep] " + Colors.Green + "Town: " + Colors.LightGreen + TownyEconomyHandler.getFormattedBalance(TownySettings.getTownUpkeepCost(town)) + Colors.Gray + " | " + Colors.Green + "Nation: " + Colors.LightGreen + TownyEconomyHandler.getFormattedBalance(TownySettings.getNationUpkeepCost(nation)));
 			if (town.isOverClaimed() && TownySettings.getUpkeepPenalty() > 0)

--- a/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
+++ b/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
@@ -152,6 +152,8 @@ public class SQL_Schema {
 		columns.add("`metadata` text DEFAULT NULL");
 		columns.add("`conqueredDays` mediumint");
 		columns.add("`conquered` bool NOT NULL DEFAULT '0'");
+		columns.add("`ruined` bool NOT NULL DEFAULT '0'");
+		columns.add("`ruinDurationRemainingHours` BIGINT");
 		return columns;
 	}
 

--- a/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
+++ b/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
@@ -153,7 +153,7 @@ public class SQL_Schema {
 		columns.add("`conqueredDays` mediumint");
 		columns.add("`conquered` bool NOT NULL DEFAULT '0'");
 		columns.add("`ruined` bool NOT NULL DEFAULT '0'");
-		columns.add("`ruinDurationRemainingHours` int(11) DEFAULT 0");
+		columns.add("`ruinedTime` BIGINT DEFAULT '0'");
 		return columns;
 	}
 

--- a/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
+++ b/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
@@ -153,7 +153,7 @@ public class SQL_Schema {
 		columns.add("`conqueredDays` mediumint");
 		columns.add("`conquered` bool NOT NULL DEFAULT '0'");
 		columns.add("`ruined` bool NOT NULL DEFAULT '0'");
-		columns.add("`ruinDurationRemainingHours` BIGINT");
+		columns.add("`ruinDurationRemainingHours` int(11) DEFAULT 0");
 		return columns;
 	}
 

--- a/src/com/palmergames/bukkit/towny/db/TownyDataSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyDataSource.java
@@ -336,6 +336,8 @@ public abstract class TownyDataSource {
 
 	abstract public void removeTown(Town town);
 
+	abstract public void removeTown(Town town, boolean delayFullRemoval);
+
 	abstract public void removeWorld(TownyWorld world) throws UnsupportedOperationException;
 
 	/**

--- a/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
@@ -30,6 +30,7 @@ import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.TownyPermission;
 import com.palmergames.bukkit.towny.object.TownyWorld;
+import com.palmergames.bukkit.towny.object.Translation;
 import com.palmergames.bukkit.towny.object.WorldCoord;
 import com.palmergames.bukkit.towny.regen.PlotBlockData;
 import com.palmergames.bukkit.towny.regen.TownyRegenAPI;
@@ -687,6 +688,8 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 
 	@Override
 	public void removeTown(Town town, boolean delayFullRemoval) {
+		
+		TownyMessaging.sendGlobalMessage(Translation.of("msg_del_town", town.getName()));
 		
 		if (delayFullRemoval) {
 			/*

--- a/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
@@ -34,6 +34,8 @@ import com.palmergames.bukkit.towny.object.WorldCoord;
 import com.palmergames.bukkit.towny.regen.PlotBlockData;
 import com.palmergames.bukkit.towny.regen.TownyRegenAPI;
 import com.palmergames.bukkit.towny.tasks.DeleteFileTask;
+import com.palmergames.bukkit.towny.war.common.townruin.TownRuinSettings;
+import com.palmergames.bukkit.towny.war.common.townruin.TownRuinUtil;
 import com.palmergames.bukkit.towny.war.eventwar.WarSpoils;
 import com.palmergames.bukkit.util.BukkitTools;
 import com.palmergames.bukkit.util.NameValidation;
@@ -676,6 +678,17 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 	@Override
 	public void removeTown(Town town) {
 		
+		boolean delayFullRemoval = TownRuinSettings.getWarCommonTownRuinsEnabled();
+		removeTown(town, delayFullRemoval);
+	}
+
+	@Override
+	public void removeTown(Town town, boolean delayFullRemoval) {
+		if (delayFullRemoval) {
+			TownRuinUtil.putTownIntoRuinedState(town, plugin);
+			return;
+		}
+
 		PreDeleteTownEvent preEvent = new PreDeleteTownEvent(town);
 		BukkitTools.getPluginManager().callEvent(preEvent);
 		

--- a/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
@@ -678,13 +678,20 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 	@Override
 	public void removeTown(Town town) {
 		
-		boolean delayFullRemoval = TownRuinSettings.getWarCommonTownRuinsEnabled();
-		removeTown(town, delayFullRemoval);
+		/*
+		 * If Town Ruining is enabled set the town into a ruined state
+		 * rather than deleting.
+		 */
+		removeTown(town, TownRuinSettings.getWarCommonTownRuinsEnabled());
 	}
 
 	@Override
 	public void removeTown(Town town, boolean delayFullRemoval) {
+		
 		if (delayFullRemoval) {
+			/*
+			 * When Town ruining is active, send the Town into a ruined state, prior to real removal.
+			 */
 			TownRuinUtil.putTownIntoRuinedState(town, plugin);
 			return;
 		}

--- a/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
@@ -683,7 +683,7 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 		 * If Town Ruining is enabled set the town into a ruined state
 		 * rather than deleting.
 		 */
-		removeTown(town, TownRuinSettings.getWarCommonTownRuinsEnabled());
+		removeTown(town, TownRuinSettings.getTownRuinsEnabled());
 	}
 
 	@Override

--- a/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -811,14 +811,13 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 						town.setRuined(false);
 					}
 				
-				line = keys.get("ruinDurationRemainingHours");
-				if (line != null) {
+				line = keys.get("ruinedTime");
+				if (line != null)
 					try {
-						town.setRuinDurationRemainingHours(Integer.parseInt(line));
-					} catch (Exception e) {
-						town.setRuinDurationRemainingHours(0);
+						town.setRuinedTime(Long.valueOf(line));
+					} catch (Exception ee) {
+						town.setRuinedTime(0);
 					}
-				}
 
 			} catch (Exception e) {
 				TownyMessaging.sendErrorMsg("Loading Error: Exception while reading town file " + town.getName() + " at line: " + line + ", in towny\\data\\towns\\" + town.getName() + ".txt");
@@ -1689,7 +1688,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 		list.add("metadata=" + serializeMetadata(town));
 		
 		list.add("ruined=" + town.isRuined());
-		list.add("ruinDurationRemainingHours=" + town.getRuinDurationRemainingHours());
+		list.add("ruinedTime=" + town.getRuinedTime());
 
 		/*
 		 *  Make sure we only save in async

--- a/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -803,6 +803,22 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 						town.setNation(nation);
 				}
 					
+				line = keys.get("ruined");
+				if (line != null)
+					try {
+						town.setRuined(Boolean.parseBoolean(line));
+					} catch (Exception e) {
+						town.setRuined(false);
+					}
+				
+				line = keys.get("ruinDurationRemainingHours");
+				if (line != null) {
+					try {
+						town.setRuinDurationRemainingHours(Integer.parseInt(line));
+					} catch (Exception e) {
+						town.setRuinDurationRemainingHours(0);
+					}
+				}
 
 			} catch (Exception e) {
 				TownyMessaging.sendErrorMsg("Loading Error: Exception while reading town file " + town.getName() + " at line: " + line + ", in towny\\data\\towns\\" + town.getName() + ".txt");
@@ -1672,6 +1688,9 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 		// Metadata
 		list.add("metadata=" + serializeMetadata(town));
 		
+		list.add("ruined=" + town.isRuined());
+		list.add("ruinDurationRemainingHours=" + town.getRuinDurationRemainingHours());
+
 		/*
 		 *  Make sure we only save in async
 		 */

--- a/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -1885,7 +1885,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			twn_hm.put("registered", town.getRegistered());
 
 			twn_hm.put("ruined", town.isRuined());
-			twn_hm.put("ruinDurationRemainingHours", Long.toString(town.getRuinDurationRemainingHours()));
+			twn_hm.put("ruinDurationRemainingHours", town.getRuinDurationRemainingHours());
 			
 			UpdateDB("TOWNS", twn_hm, Collections.singletonList("name"));
 			return true;

--- a/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -1077,7 +1077,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			}
 
 			town.setRuined(rs.getBoolean("ruined"));
-			town.setRuinDurationRemainingHours(rs.getInt("ruinDurationRemainingHours"));
+			town.setRuinedTime(rs.getLong("ruinedTime"));
 
 			return true;
 		} catch (SQLException e) {
@@ -1885,7 +1885,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			twn_hm.put("registered", town.getRegistered());
 
 			twn_hm.put("ruined", town.isRuined());
-			twn_hm.put("ruinDurationRemainingHours", town.getRuinDurationRemainingHours());
+			twn_hm.put("ruinedTime", town.getRuinedTime());
 			
 			UpdateDB("TOWNS", twn_hm, Collections.singletonList("name"));
 			return true;

--- a/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -1076,6 +1076,9 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			} catch (SQLException ignored) {
 			}
 
+			town.setRuined(rs.getBoolean("ruined"));
+			town.setRuinDurationRemainingHours(rs.getInt("ruinDurationRemainingHours"));
+
 			return true;
 		} catch (SQLException e) {
 			TownyMessaging.sendErrorMsg("SQL: Load Town " + name + " sql Error - " + e.getMessage());
@@ -1881,6 +1884,9 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			}
 			twn_hm.put("registered", town.getRegistered());
 
+			twn_hm.put("ruined", town.isRuined());
+			twn_hm.put("ruinDurationRemainingHours", Long.toString(town.getRuinDurationRemainingHours()));
+			
 			UpdateDB("TOWNS", twn_hm, Collections.singletonList("name"));
 			return true;
 

--- a/src/com/palmergames/bukkit/towny/event/town/TownReclaimedEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/town/TownReclaimedEvent.java
@@ -1,5 +1,6 @@
 package com.palmergames.bukkit.towny.event.town;
 
+import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
@@ -13,6 +14,7 @@ public class TownReclaimedEvent extends Event {
 	private final Resident resident;
 	
 	public TownReclaimedEvent(Town town, Resident resident) {
+		super(!Bukkit.getServer().isPrimaryThread());
 		this.town = town;
 		this.resident = resident;
 	}

--- a/src/com/palmergames/bukkit/towny/event/town/TownReclaimedEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/town/TownReclaimedEvent.java
@@ -1,0 +1,48 @@
+package com.palmergames.bukkit.towny.event.town;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+import com.palmergames.bukkit.towny.object.Resident;
+import com.palmergames.bukkit.towny.object.Town;
+
+public class TownReclaimedEvent extends Event {
+
+	private static final HandlerList handlers = new HandlerList();
+	private final Town town;
+	private final Resident resident;
+	
+	public TownReclaimedEvent(Town town, Resident resident) {
+		this.town = town;
+		this.resident = resident;
+	}
+
+	@Override
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+
+	public HandlerList getHandlerList() {
+		return handlers;
+	}
+
+	/**
+	 * The ruined town which has been reclaimed.
+	 * 
+	 * @return town which is being reclaimed.
+	 */
+	public Town getTown() {
+		return town;
+	}
+
+	/**
+	 * The resident who is reclaiming the town, and will become the new mayor.
+	 * 
+	 * @return resident who will be mayor.
+	 */
+	public Resident getResident() {
+		return resident;
+	}
+
+	
+}

--- a/src/com/palmergames/bukkit/towny/event/town/TownRuinedEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/town/TownRuinedEvent.java
@@ -1,0 +1,36 @@
+package com.palmergames.bukkit.towny.event.town;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+import com.palmergames.bukkit.towny.object.Town;
+
+public class TownRuinedEvent extends Event {
+
+	private static final HandlerList handlers = new HandlerList();
+	private final Town town;
+	
+	public TownRuinedEvent(Town town) {
+		this.town = town;
+	}
+
+	@Override
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+
+	public HandlerList getHandlerList() {
+		return handlers;
+	}
+
+	/**
+	 * The town which is falling into ruin.
+	 * 
+	 * @return town which is falling into ruin.
+	 */
+	public Town getTown() {
+		return town;
+	}
+
+	
+}

--- a/src/com/palmergames/bukkit/towny/event/town/TownRuinedEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/town/TownRuinedEvent.java
@@ -1,5 +1,6 @@
 package com.palmergames.bukkit.towny.event.town;
 
+import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
@@ -11,6 +12,7 @@ public class TownRuinedEvent extends Event {
 	private final Town town;
 	
 	public TownRuinedEvent(Town town) {
+		super(!Bukkit.getServer().isPrimaryThread());
 		this.town = town;
 	}
 

--- a/src/com/palmergames/bukkit/towny/object/Town.java
+++ b/src/com/palmergames/bukkit/towny/object/Town.java
@@ -62,7 +62,7 @@ public class Town extends Government implements TownBlockOwner {
 	private final ConcurrentHashMap<WorldCoord, TownBlock> townBlocks = new ConcurrentHashMap<>();
 	private final TownyPermission permissions = new TownyPermission();
 	private boolean ruined = false;
-	private int ruinDurationRemainingHours = 0;
+	private long ruinedTime;
 
 	public Town(String name) {
 		super(name);
@@ -1329,19 +1329,15 @@ public class Town extends Government implements TownBlockOwner {
 	public void setRuined(boolean b) {
 		ruined = b;
 	}
-
-	public int getRuinDurationRemainingHours() {
-		return ruinDurationRemainingHours;
-	}
-
-	public void decrementRemainingRuinTimeHours() {
-		ruinDurationRemainingHours--;
-	}
-
-	public void setRuinDurationRemainingHours(int i) {
-		ruinDurationRemainingHours = i;
+	
+	public void setRuinedTime(long time) {
+		this.ruinedTime = time;
 	}
 	
+	public long getRuinedTime() {
+		return ruinedTime;
+	}
+
 	/**
 	 * @deprecated As of 0.97.0.0+ please use {@link EconomyAccount#getWorld()} instead.
 	 * 

--- a/src/com/palmergames/bukkit/towny/object/Town.java
+++ b/src/com/palmergames/bukkit/towny/object/Town.java
@@ -61,10 +61,14 @@ public class Town extends Government implements TownBlockOwner {
 	private int conqueredDays;
 	private final ConcurrentHashMap<WorldCoord, TownBlock> townBlocks = new ConcurrentHashMap<>();
 	private final TownyPermission permissions = new TownyPermission();
+	private boolean ruined;
+	private int ruinDurationRemainingHours;
 
 	public Town(String name) {
 		super(name);
 		permissions.loadDefault(this);
+		ruined = false;
+		ruinDurationRemainingHours = 0;
 		
 		// Set defaults.
 		setTaxes(TownySettings.getTownDefaultTax());
@@ -1317,6 +1321,30 @@ public class Town extends Government implements TownBlockOwner {
 		return false;
 	}
 
+
+	public boolean isRuined() {
+		if(!ruined && residents.size() == 0) {
+			ruined = true;  //If all residents have been deleted, flag town as ruined.
+		}
+		return ruined;
+	}
+	
+	public void setRuined(boolean b) {
+		ruined = b;
+	}
+
+	public int getRuinDurationRemainingHours() {
+		return ruinDurationRemainingHours;
+	}
+
+	public void decrementRemainingRuinTimeHours() {
+		ruinDurationRemainingHours--;
+	}
+
+	public void setRuinDurationRemainingHours(int i) {
+		ruinDurationRemainingHours = i;
+	}
+	
 	/**
 	 * @deprecated As of 0.97.0.0+ please use {@link EconomyAccount#getWorld()} instead.
 	 * 

--- a/src/com/palmergames/bukkit/towny/object/Town.java
+++ b/src/com/palmergames/bukkit/towny/object/Town.java
@@ -61,14 +61,12 @@ public class Town extends Government implements TownBlockOwner {
 	private int conqueredDays;
 	private final ConcurrentHashMap<WorldCoord, TownBlock> townBlocks = new ConcurrentHashMap<>();
 	private final TownyPermission permissions = new TownyPermission();
-	private boolean ruined;
-	private int ruinDurationRemainingHours;
+	private boolean ruined = false;
+	private int ruinDurationRemainingHours = 0;
 
 	public Town(String name) {
 		super(name);
 		permissions.loadDefault(this);
-		ruined = false;
-		ruinDurationRemainingHours = 0;
 		
 		// Set defaults.
 		setTaxes(TownySettings.getTownDefaultTax());
@@ -1320,7 +1318,6 @@ public class Town extends Government implements TownBlockOwner {
 
 		return false;
 	}
-
 
 	public boolean isRuined() {
 		if(!ruined && residents.size() == 0) {

--- a/src/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
+++ b/src/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
@@ -101,6 +101,7 @@ public enum PermissionNodes {
 		TOWNY_COMMAND_TOWN_OUTPOST_LIST("towny.command.town.outpost.list"),
 		TOWNY_COMMAND_TOWN_NEW("towny.command.town.new"),
 		TOWNY_COMMAND_TOWN_LEAVE("towny.command.town.leave"),
+		TOWNY_COMMAND_TOWN_RECLAIM("towny.command.town.reclaim"),
 		TOWNY_COMMAND_TOWN_WITHDRAW("towny.command.town.withdraw"),
 		TOWNY_COMMAND_TOWN_DEPOSIT("towny.command.town.deposit"),
 		TOWNY_COMMAND_TOWN_PLOTS("towny.command.town.plots"),

--- a/src/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
@@ -211,7 +211,7 @@ public class DailyTimerTask extends TownyTimerTask {
 				 * We are running in an Async thread so MUST verify all objects.
 				 */
 				if (universe.getDataSource().hasTown(town.getName())) {
-					if (town.isCapital() || !town.hasUpkeep() || town.isRuined())
+					if (town.isCapital() || !town.hasUpkeep())
 						continue;
 					if (town.getAccount().canPayFromHoldings(taxAmount)) {
 					// Town is able to pay the nation's tax.
@@ -450,7 +450,7 @@ public class DailyTimerTask extends TownyTimerTask {
 			 */
 			if (universe.getDataSource().hasTown(town.getName())) {
 
-				if (town.hasUpkeep() && !town.isRuined()) {
+				if (town.hasUpkeep()) {
 					double upkeep = TownySettings.getTownUpkeepCost(town);
 					double upkeepPenalty = TownySettings.getTownPenaltyUpkeepCost(town);
 					if (upkeepPenalty > 0 && upkeep > 0)

--- a/src/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
@@ -211,7 +211,7 @@ public class DailyTimerTask extends TownyTimerTask {
 				 * We are running in an Async thread so MUST verify all objects.
 				 */
 				if (universe.getDataSource().hasTown(town.getName())) {
-					if (town.isCapital() || !town.hasUpkeep())
+					if (town.isCapital() || !town.hasUpkeep() || town.isRuined())
 						continue;
 					if (town.getAccount().canPayFromHoldings(taxAmount)) {
 					// Town is able to pay the nation's tax.
@@ -295,7 +295,7 @@ public class DailyTimerTask extends TownyTimerTask {
 			 * exists.
 			 * We are running in an Async thread so MUST verify all objects.
 			 */
-			if (universe.getDataSource().hasTown(town.getName()))
+			if (universe.getDataSource().hasTown(town.getName()) && !town.isRuined())
 				collectTownTaxes(town);
 		}
 	}
@@ -450,7 +450,7 @@ public class DailyTimerTask extends TownyTimerTask {
 			 */
 			if (universe.getDataSource().hasTown(town.getName())) {
 
-				if (town.hasUpkeep()) {
+				if (town.hasUpkeep() && !town.isRuined()) {
 					double upkeep = TownySettings.getTownUpkeepCost(town);
 					double upkeepPenalty = TownySettings.getTownPenaltyUpkeepCost(town);
 					if (upkeepPenalty > 0 && upkeep > 0)

--- a/src/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
@@ -211,7 +211,7 @@ public class DailyTimerTask extends TownyTimerTask {
 				 * We are running in an Async thread so MUST verify all objects.
 				 */
 				if (universe.getDataSource().hasTown(town.getName())) {
-					if (town.isCapital() || !town.hasUpkeep())
+					if (town.isCapital() || !town.hasUpkeep() || town.isRuined())
 						continue;
 					if (town.getAccount().canPayFromHoldings(taxAmount)) {
 					// Town is able to pay the nation's tax.
@@ -450,7 +450,7 @@ public class DailyTimerTask extends TownyTimerTask {
 			 */
 			if (universe.getDataSource().hasTown(town.getName())) {
 
-				if (town.hasUpkeep()) {
+				if (town.hasUpkeep() && !town.isRuined()) {
 					double upkeep = TownySettings.getTownUpkeepCost(town);
 					double upkeepPenalty = TownySettings.getTownPenaltyUpkeepCost(town);
 					if (upkeepPenalty > 0 && upkeep > 0)

--- a/src/com/palmergames/bukkit/towny/tasks/HourlyTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/HourlyTimerTask.java
@@ -19,7 +19,7 @@ public class HourlyTimerTask extends TownyTimerTask {
 
 	@Override
 	public void run() {
-		if (TownRuinSettings.getWarCommonTownRuinsEnabled()) {
+		if (TownRuinSettings.getTownRuinsEnabled()) {
 			TownRuinUtil.evaluateRuinedTownRemovals();
 		}
 	}

--- a/src/com/palmergames/bukkit/towny/tasks/HourlyTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/HourlyTimerTask.java
@@ -1,6 +1,8 @@
 package com.palmergames.bukkit.towny.tasks;
 
 import com.palmergames.bukkit.towny.Towny;
+import com.palmergames.bukkit.towny.war.common.townruin.TownRuinSettings;
+import com.palmergames.bukkit.towny.war.common.townruin.TownRuinUtil;
 
 /**
  * This class represents the hourly timer task
@@ -17,5 +19,8 @@ public class HourlyTimerTask extends TownyTimerTask {
 
 	@Override
 	public void run() {
+		if (TownRuinSettings.getWarCommonTownRuinsEnabled()) {
+			TownRuinUtil.evaluateRuinedTownRemovals();
+		}
 	}
 }

--- a/src/com/palmergames/bukkit/towny/tasks/OnPlayerLogin.java
+++ b/src/com/palmergames/bukkit/towny/tasks/OnPlayerLogin.java
@@ -16,6 +16,8 @@ import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.Translation;
 import com.palmergames.bukkit.towny.permissions.TownyPerms;
+import com.palmergames.bukkit.towny.war.common.townruin.TownRuinSettings;
+import com.palmergames.bukkit.towny.war.common.townruin.TownRuinUtil;
 import com.palmergames.bukkit.util.BukkitTools;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -197,8 +199,8 @@ public class OnPlayerLogin implements Runnable {
 		
 		try {
 			if (resident.hasTown() && resident.getTown().isRuined()) {
-				TownyMessaging.sendMsg(resident, Translation.of("msg_warning_your_town_is_ruined_for_x_more_hours", resident.getTown().getRuinDurationRemainingHours()));
+				TownyMessaging.sendMsg(resident, Translation.of("msg_warning_your_town_is_ruined_for_x_more_hours", TownRuinSettings.getTownRuinsMaxDurationHours() - TownRuinUtil.getTimeSinceRuining(resident.getTown())));
 			}
-		} catch (NotRegisteredException e) {}
+		} catch (NotRegisteredException ignored) {}
 	}
 }

--- a/src/com/palmergames/bukkit/towny/tasks/OnPlayerLogin.java
+++ b/src/com/palmergames/bukkit/towny/tasks/OnPlayerLogin.java
@@ -154,7 +154,7 @@ public class OnPlayerLogin implements Runnable {
 			if (resident.hasTown()) {
 				try {
 					Town town = resident.getTown();
-					if (town.hasUpkeep()) {
+					if (town.hasUpkeep() && !town.isRuined()) {
 						double upkeep = TownySettings.getTownUpkeepCost(town);
 						try {
 							if ((upkeep > 0) && (!town.getAccount().canPayFromHoldings(upkeep))) {
@@ -195,5 +195,10 @@ public class OnPlayerLogin implements Runnable {
 			}
 		}
 		
+		try {
+			if (resident.hasTown() && resident.getTown().isRuined()) {
+				TownyMessaging.sendMsg(resident, Translation.of("msg_warning_your_town_is_ruined_for_x_more_hours", resident.getTown().getRuinDurationRemainingHours()));
+			}
+		} catch (NotRegisteredException e) {}
 	}
 }

--- a/src/com/palmergames/bukkit/towny/utils/PlayerCacheUtil.java
+++ b/src/com/palmergames/bukkit/towny/utils/PlayerCacheUtil.java
@@ -5,7 +5,6 @@ import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.TownyUniverse;
-import com.palmergames.bukkit.towny.exceptions.EconomyException;
 import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Coord;
@@ -390,18 +389,18 @@ public class PlayerCacheUtil {
 		if (townyUniverse.getPermissionSource().isTownyAdmin(player))
 			return true;
 
-		//If town is bankrupt, nobody can build
+		//If town is bankrupt (but not ruined), nobody can build
 		TownBlock townBlock = null;
 		Town targetTown = null;
 		if(TownySettings.isTownBankruptcyEnabled() && action == ActionType.BUILD) {
 			try {
 				townBlock = pos.getTownBlock();
 				targetTown = townBlock.getTown();
-				if(targetTown.getAccount().isBankrupt())  {
+				if(targetTown.isBankrupt() && !targetTown.isRuined())  {
 					cacheBlockErrMsg(player, Translation.of("msg_err_bankrupt_town_cannot_build"));
 					return false;
 				}
-			} catch (NotRegisteredException | EconomyException ignored) {
+			} catch (NotRegisteredException ignored) {
 			}
 		}
 

--- a/src/com/palmergames/bukkit/towny/war/common/townruin/TownRuinSettings.java
+++ b/src/com/palmergames/bukkit/towny/war/common/townruin/TownRuinSettings.java
@@ -6,19 +6,19 @@ import com.palmergames.bukkit.towny.TownySettings;
 public class TownRuinSettings {
 
 	public static boolean getWarCommonTownRuinsEnabled() {
-		return TownySettings.getBoolean(ConfigNodes.WAR_COMMON_TOWN_RUINS_ENABLED);
+		return TownySettings.getBoolean(ConfigNodes.TOWN_RUINING_TOWN_RUINS_ENABLED);
 	}
 
 	public static int getWarCommonTownRuinsMaxDurationHours() {
-		return Math.min(TownySettings.getInt(ConfigNodes.WAR_COMMON_TOWN_RUINS_MAX_DURATION_HOURS), 1000);
+		return Math.min(TownySettings.getInt(ConfigNodes.TOWN_RUINING_TOWN_RUINS_MAX_DURATION_HOURS), 1000);
 	}
 
 	public static int getWarCommonTownRuinsMinDurationHours() {
-		return TownySettings.getInt(ConfigNodes.WAR_COMMON_TOWN_RUINS_MIN_DURATION_HOURS);
+		return TownySettings.getInt(ConfigNodes.TOWN_RUINING_TOWN_RUINS_MIN_DURATION_HOURS);
 	}
 
 	public static boolean getWarCommonTownRuinsReclaimEnabled() {
-		return TownySettings.getBoolean(ConfigNodes.WAR_COMMON_TOWN_RUINS_RECLAIM_ENABLED);
+		return TownySettings.getBoolean(ConfigNodes.TOWN_RUINING_TOWN_RUINS_RECLAIM_ENABLED);
 	}
 
 	public static double getEcoPriceReclaimTown() {

--- a/src/com/palmergames/bukkit/towny/war/common/townruin/TownRuinSettings.java
+++ b/src/com/palmergames/bukkit/towny/war/common/townruin/TownRuinSettings.java
@@ -25,5 +25,4 @@ public class TownRuinSettings {
 		return TownySettings.getDouble(ConfigNodes.ECO_PRICE_RECLAIM_RUINED_TOWN);
 	}
 
-
 }

--- a/src/com/palmergames/bukkit/towny/war/common/townruin/TownRuinSettings.java
+++ b/src/com/palmergames/bukkit/towny/war/common/townruin/TownRuinSettings.java
@@ -5,19 +5,19 @@ import com.palmergames.bukkit.towny.TownySettings;
 
 public class TownRuinSettings {
 
-	public static boolean getWarCommonTownRuinsEnabled() {
+	public static boolean getTownRuinsEnabled() {
 		return TownySettings.getBoolean(ConfigNodes.TOWN_RUINING_TOWN_RUINS_ENABLED);
 	}
 
-	public static int getWarCommonTownRuinsMaxDurationHours() {
+	public static int getTownRuinsMaxDurationHours() {
 		return Math.min(TownySettings.getInt(ConfigNodes.TOWN_RUINING_TOWN_RUINS_MAX_DURATION_HOURS), 1000);
 	}
 
-	public static int getWarCommonTownRuinsMinDurationHours() {
+	public static int getTownRuinsMinDurationHours() {
 		return TownySettings.getInt(ConfigNodes.TOWN_RUINING_TOWN_RUINS_MIN_DURATION_HOURS);
 	}
 
-	public static boolean getWarCommonTownRuinsReclaimEnabled() {
+	public static boolean getTownRuinsReclaimEnabled() {
 		return TownySettings.getBoolean(ConfigNodes.TOWN_RUINING_TOWN_RUINS_RECLAIM_ENABLED);
 	}
 

--- a/src/com/palmergames/bukkit/towny/war/common/townruin/TownRuinSettings.java
+++ b/src/com/palmergames/bukkit/towny/war/common/townruin/TownRuinSettings.java
@@ -1,0 +1,29 @@
+package com.palmergames.bukkit.towny.war.common.townruin;
+
+import com.palmergames.bukkit.config.ConfigNodes;
+import com.palmergames.bukkit.towny.TownySettings;
+
+public class TownRuinSettings {
+
+	public static boolean getWarCommonTownRuinsEnabled() {
+		return TownySettings.getBoolean(ConfigNodes.WAR_COMMON_TOWN_RUINS_ENABLED);
+	}
+
+	public static int getWarCommonTownRuinsMaxDurationHours() {
+		return TownySettings.getInt(ConfigNodes.WAR_COMMON_TOWN_RUINS_MAX_DURATION_HOURS);
+	}
+
+	public static int getWarCommonTownRuinsMinDurationHours() {
+		return TownySettings.getInt(ConfigNodes.WAR_COMMON_TOWN_RUINS_MIN_DURATION_HOURS);
+	}
+
+	public static boolean getWarCommonTownRuinsReclaimEnabled() {
+		return TownySettings.getBoolean(ConfigNodes.WAR_COMMON_TOWN_RUINS_RECLAIM_ENABLED);
+	}
+
+	public static double getEcoPriceReclaimTown() {
+		return TownySettings.getDouble(ConfigNodes.ECO_PRICE_RECLAIM_RUINED_TOWN);
+	}
+
+
+}

--- a/src/com/palmergames/bukkit/towny/war/common/townruin/TownRuinSettings.java
+++ b/src/com/palmergames/bukkit/towny/war/common/townruin/TownRuinSettings.java
@@ -10,7 +10,7 @@ public class TownRuinSettings {
 	}
 
 	public static int getWarCommonTownRuinsMaxDurationHours() {
-		return TownySettings.getInt(ConfigNodes.WAR_COMMON_TOWN_RUINS_MAX_DURATION_HOURS);
+		return Math.min(TownySettings.getInt(ConfigNodes.WAR_COMMON_TOWN_RUINS_MAX_DURATION_HOURS), 1000);
 	}
 
 	public static int getWarCommonTownRuinsMinDurationHours() {

--- a/src/com/palmergames/bukkit/towny/war/common/townruin/TownRuinUtil.java
+++ b/src/com/palmergames/bukkit/towny/war/common/townruin/TownRuinUtil.java
@@ -80,7 +80,7 @@ public class TownRuinUtil {
 		// Call the TownRuinEvent.
 		TownRuinedEvent event = new TownRuinedEvent(town);
 		Bukkit.getPluginManager().callEvent(event);
-
+		
 		// Set Town settings.
 		town.setRuined(true);
 		town.setRuinDurationRemainingHours(TownRuinSettings.getWarCommonTownRuinsMaxDurationHours());

--- a/src/com/palmergames/bukkit/towny/war/common/townruin/TownRuinUtil.java
+++ b/src/com/palmergames/bukkit/towny/war/common/townruin/TownRuinUtil.java
@@ -1,0 +1,241 @@
+package com.palmergames.bukkit.towny.war.common.townruin;
+
+
+import com.palmergames.bukkit.towny.Towny;
+import com.palmergames.bukkit.towny.TownyMessaging;
+import com.palmergames.bukkit.towny.TownySettings;
+import com.palmergames.bukkit.towny.TownyUniverse;
+import com.palmergames.bukkit.towny.command.TownyAdminCommand;
+import com.palmergames.bukkit.towny.exceptions.EconomyException;
+import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
+import com.palmergames.bukkit.towny.exceptions.TownyException;
+import com.palmergames.bukkit.towny.object.Resident;
+
+import com.palmergames.bukkit.towny.object.Town;
+import com.palmergames.bukkit.towny.object.TownBlock;
+import com.palmergames.bukkit.towny.object.Translation;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ListIterator;
+
+
+/**
+ * This class contains utility functions related to ruins
+ *
+ * @author Goosius
+ */
+public class TownRuinUtil {
+
+	/**
+	 * This method returns true if the given player's town is ruined
+	 * 
+	 * @param player the player
+	 * @return true if ruined, false if not
+	 */
+	public static boolean isPlayersTownRuined(Player player) {
+		try {
+			TownyUniverse townyUniverse = TownyUniverse.getInstance();
+			Resident resident = townyUniverse.getDataSource().getResident(player.getName());
+
+			if(resident.hasTown()) {
+				return resident.getTown().isRuined();
+			} else {
+				return false;
+			}
+		} catch (NotRegisteredException x) {
+			return false;
+		}
+	}
+
+	/**
+	 * Put town into ruined state:
+	 * 1. Remove town from nation
+	 * 2. Set mayor to NPC
+	 * 3. Enable all perms
+	 * 4. Now, the residents cannot run /plot commands, and some /t commands
+	 * 5. Town will later be deleted full, unless it is reclaimed
+	 */
+	public static void putTownIntoRuinedState(Town town, Towny plugin) {
+		TownyUniverse townyUniverse = TownyUniverse.getInstance();
+
+		if (town.isRuined())
+			return; //Town already ruined. Do not run code as it would reset ruin status to 888 (ie phase 1)
+
+		//Remove town from nation, otherwise after we change the mayor to NPC and if the nation falls, the npc would receive nation refund.
+		if (town.hasNation())
+			town.removeNation();
+
+		//Set NPC mayor, otherwise mayor of ruined town cannot leave until full deletion
+		try {
+			TownyAdminCommand adminCommand = new TownyAdminCommand(plugin);
+			adminCommand.adminSet(new String[]{"mayor", town.getName(), "npc"});
+		} catch (TownyException e) {
+			e.printStackTrace();
+		}
+
+		/*
+		 * TODO: Create a newlyRuined event so plugins can react to Towns going to ruin.
+		 */
+//		//Remove siege if any
+//		if (town.hasSiege())
+//			townyUniverse.getDataSource().removeSiege(town.getSiege(), SiegeSide.ATTACKERS);
+
+		town.setRuined(true);
+		town.setRuinDurationRemainingHours(TownRuinSettings.getWarCommonTownRuinsMaxDurationHours());
+		town.setPublic(false);
+		town.setOpen(false);
+
+		//Return town blocks to the basic, unowned, type
+		for(TownBlock townBlock: town.getTownBlocks()) {
+			townBlock.setType(0);
+			townBlock.setPlotPrice(-1);
+			townBlock.setResident(null);
+			townBlock.removePlotObjectGroup();
+			townyUniverse.getDataSource().saveTownBlock(townBlock);
+		}
+
+		//Set town level perms
+		try {
+			for (String element : new String[]{"residentBuild",
+				"residentDestroy", "residentSwitch",
+				"residentItemUse", "outsiderBuild",
+				"outsiderDestroy", "outsiderSwitch",
+				"outsiderItemUse", "allyBuild", "allyDestroy",
+				"allySwitch", "allyItemUse", "nationBuild", "nationDestroy",
+				"nationSwitch", "nationItemUse",
+				"pvp", "fire", "explosion", "mobs"}) {
+				town.getPermissions().set(element, true);
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+
+		//Propogate perm changes to individual plots
+		try {
+			TownyAdminCommand adminCommand = new TownyAdminCommand(plugin);
+			adminCommand.parseAdminTownCommand(new String[]{town.getName(),"set", "perm", "reset"});
+		} catch (Exception e) {
+			System.out.println("Problem propogating perm changes to individual plots");
+			e.printStackTrace();
+		}
+
+		townyUniverse.getDataSource().saveTown(town);
+		plugin.resetCache();
+	}
+
+	/**
+	 * Processes a player request to reclaim a ruined town
+	 *
+	 * @param player the player
+	 */
+	public static void processRuinedTownReclaimRequest(Player player, Towny plugin) {
+		Town town;
+		try {
+			TownyUniverse townyUniverse = TownyUniverse.getInstance();
+			Resident resident = townyUniverse.getDataSource().getResident(player.getName());
+
+			if (!resident.hasTown())
+				throw new TownyException(Translation.of("msg_err_dont_belong_town"));
+
+			//Ensure town is ruined
+			town = resident.getTown();
+			if (!town.isRuined())
+				throw new TownyException(Translation.of("msg_err_cannot_reclaim_town_unless_ruined"));
+
+			//Validate if player can pay
+			double townReclaimCost = TownRuinSettings.getEcoPriceReclaimTown();
+			if (TownySettings.isUsingEconomy() && !resident.getAccount().canPayFromHoldings(townReclaimCost))
+				throw new TownyException(Translation.of("msg_err_no_money"));
+
+			//Validate if player can remove at this time
+			int currentRuinDurationHours = TownRuinSettings.getWarCommonTownRuinsMaxDurationHours() - town.getRuinDurationRemainingHours();
+			if (currentRuinDurationHours < TownRuinSettings.getWarCommonTownRuinsMinDurationHours()) {
+				int timeUntilReclaimAllowedHours =  TownRuinSettings.getWarCommonTownRuinsMinDurationHours() - currentRuinDurationHours;
+				throw new TownyException(Translation.of("msg_err_cannot_reclaim_town_yet", timeUntilReclaimAllowedHours));
+			}
+
+			//Recover Town now
+			resident.getAccount().withdraw(townReclaimCost, "Cost of town reclaim.");
+			town.setRuined(false);
+			town.setRuinDurationRemainingHours(0);
+
+			//Set player as mayor (and remove npc)
+			//Set NPC mayor, otherwise mayor of ruined town cannot leave until full deletion
+			try {
+				TownyAdminCommand adminCommand = new TownyAdminCommand(plugin);
+				adminCommand.adminSet(new String[]{"mayor", town.getName(), resident.getName()});
+			} catch (TownyException e) {
+				e.printStackTrace();
+			}
+
+			//Set town level perms
+			try {
+				for (String element : new String[]{"residentBuild",
+					"residentDestroy", "residentSwitch",
+					"residentItemUse", "outsiderBuild",
+					"outsiderDestroy", "outsiderSwitch",
+					"outsiderItemUse", "allyBuild", "allyDestroy",
+					"allySwitch", "allyItemUse", "nationBuild", "nationDestroy",
+					"nationSwitch", "nationItemUse",
+					"pvp", "fire", "explosion", "mobs"}) {
+					town.getPermissions().set(element, false);
+				}
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+
+			//Propogate perm changes to individual plots
+			try {
+				TownyAdminCommand adminCommand = new TownyAdminCommand(plugin);
+				adminCommand.parseAdminTownCommand(new String[]{town.getName(),"set", "perm", "reset"});
+			} catch (TownyException e) {
+				e.printStackTrace();
+			}
+
+			townyUniverse.getDataSource().saveTown(town);
+			plugin.resetCache();
+
+			TownyMessaging.sendGlobalMessage(Translation.of("msg_town_reclaimed", resident.getName(), town.getName()));
+		} catch (TownyException e) {
+			TownyMessaging.sendErrorMsg(player,e.getMessage());
+		} catch (EconomyException ex) {
+			TownyMessaging.sendErrorMsg(player,ex.getMessage());
+		}
+	}
+
+	/**
+	 * This method cycles through all towns
+	 * If a town is in ruins, its remaining_ruin_time_hours counter is decreased
+	 * If a counter hits 0, the town is deleted
+	 */
+    public static void evaluateRuinedTownRemovals() {
+		TownyUniverse townyUniverse = TownyUniverse.getInstance();
+		List<Town> towns = new ArrayList<>(townyUniverse.getDataSource().getTowns());
+		ListIterator<Town> townItr = towns.listIterator();
+		Town town;
+
+		while (townItr.hasNext()) {
+			town = townItr.next();
+			/*
+			 * Only delete ruined town if it really still
+			 * exists.
+			 * We are running in an Async thread so MUST verify all objects.
+			 */
+			if (townyUniverse.getDataSource().hasTown(town.getName())) {
+
+				if (town.isRuined()) {
+					town.decrementRemainingRuinTimeHours();
+
+					if(town.getRuinDurationRemainingHours() < 1) {
+						//Ruin found & recently ruined end time reached. Delete town now.
+						townyUniverse.getDataSource().removeTown(town, false);
+					} else {
+						townyUniverse.getDataSource().saveTown(town);
+					}
+				}
+			} 
+		}
+    }
+}

--- a/src/com/palmergames/util/TimeTools.java
+++ b/src/com/palmergames/util/TimeTools.java
@@ -69,4 +69,8 @@ public class TimeTools {
 
 		return t * 20;
 	}
+	
+	public static int getHours(long milliSeconds) {
+		return (int) ((milliSeconds /1000) / 60) /60;
+	}
 }


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
- Probably caught a 2nd bug with the mysql implementation of ruins' hours.
- Adds a permission node to /town reclaim.
- Adds TownReclaimedEvent & TownRuinedEvent.
- Cleans up TownRuinUtil to use the API in places it did not.
- Changes PlotCommand test to check the townblock's town and not the player running the command.
- Maxes out the RemainingHours at 1000.
- Remove unnecessary isRuined() tests in DailyTimerTask.
  - the town.hasUpkeep() is false for all NPC mayor'd towns.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
New Command:
  - /town reclaim - Reclaims a town from ruin status, must be run by a town resident (but not the mayor.)

New Permission Node: 
  - towny.command.town.reclaim
    - childnode of towny.command.town.*

New Config Options:
  - economy.new_expand.price_reclaim_ruined_town
    - default: 500.0
    - How much it costs to reclaim a ruined town.
    - This is only applicable if the town-ruins & town-reclaim features are enabled.
  - town_ruining.town_ruins.enabled", 
    - default: false
    - If this is true, then if a town falls, it remains in a 'ruined' state for a time.
    - In this state, the town cannot be claimed, but can be looted.
    - The feature prevents mayors from escaping attack/occupation, by deleting then quickly recreating their town.
  - town_ruining.town_ruins.max_duration_hours
    - default: 72
    - This value determines the maximum duration in which a town can lie in ruins.
    - After this time is reached, the town will be completely deleted.
    - Does not accept values greater than 1000.
  - town_ruining.town_ruins.min_duration_hours
    - default: 4
    - This value determines the minimum duration in which a town must lie in ruins, before it can be reclaimed by a resident.
  - town_ruining.town_ruins.reclaim_enabled
    - default: true
    - If this is true, then after a town has been ruined for the minimum configured time,",
    - it can then be reclaimed by any resident who runs /t reclaim, and pays the required price. (price is configured in the eco section)


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
