### PR TITLE
Move neutral setting to Government, allowing Towns to become neutral.

### DIFF
--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -410,6 +410,7 @@ permissions:
             towny.command.town.toggle.fire: true
             towny.command.town.toggle.jail: true
             towny.command.town.toggle.mobs: true
+            towny.command.town.toggle.neutral: true
             towny.command.town.toggle.open: true
             towny.command.town.toggle.public: true
             towny.command.town.toggle.pvp: true

--- a/src/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -2618,8 +2618,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 						nation.getAccount().withdraw(cost, "Peaceful Nation Cost");
 				} catch (EconomyException ignored) {}
 
-				// Set the toggle setting.
-				nation.toggleNeutral(value);
+				nation.setNeutral(value);
 				
 				// If they setting neutral status on send a message confirming they paid something, if they did.
 				if (value && TownySettings.isUsingEconomy() && cost > 0)

--- a/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
+++ b/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
@@ -154,6 +154,7 @@ public class SQL_Schema {
 		columns.add("`conquered` bool NOT NULL DEFAULT '0'");
 		columns.add("`ruined` bool NOT NULL DEFAULT '0'");
 		columns.add("`ruinedTime` BIGINT DEFAULT '0'");
+		columns.add("`neutral` bool NOT NULL DEFAULT '0'");
 		return columns;
 	}
 

--- a/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -818,6 +818,14 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 					} catch (Exception ee) {
 						town.setRuinedTime(0);
 					}
+				
+				line = keys.get("neutral");
+				if (line != null)
+					try {
+						town.setNeutral(Boolean.parseBoolean(line));
+					} catch (Exception ignored) {
+					}
+
 
 			} catch (Exception e) {
 				TownyMessaging.sendErrorMsg("Loading Error: Exception while reading town file " + town.getName() + " at line: " + line + ", in towny\\data\\towns\\" + town.getName() + ".txt");
@@ -1689,6 +1697,8 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 		
 		list.add("ruined=" + town.isRuined());
 		list.add("ruinedTime=" + town.getRuinedTime());
+		// Peaceful
+		list.add("neutral=" + town.isNeutral());
 
 		/*
 		 *  Make sure we only save in async

--- a/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -821,11 +821,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 				
 				line = keys.get("neutral");
 				if (line != null)
-					try {
-						town.setNeutral(Boolean.parseBoolean(line));
-					} catch (Exception ignored) {
-					}
-
+					town.setNeutral(Boolean.parseBoolean(line));
 
 			} catch (Exception e) {
 				TownyMessaging.sendErrorMsg("Loading Error: Exception while reading town file " + town.getName() + " at line: " + line + ", in towny\\data\\towns\\" + town.getName() + ".txt");
@@ -935,10 +931,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 				
 				line = keys.get("neutral");
 				if (line != null)
-					try {
-						nation.setNeutral(Boolean.parseBoolean(line));
-					} catch (Exception ignored) {
-					}
+					nation.setNeutral(Boolean.parseBoolean(line));
 				
 				line = keys.get("uuid");
 				if (line != null) {

--- a/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -1079,6 +1079,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 
 			town.setRuined(rs.getBoolean("ruined"));
 			town.setRuinedTime(rs.getLong("ruinedTime"));
+			town.setNeutral(rs.getBoolean("neutral"));
 
 			return true;
 		} catch (SQLException e) {
@@ -1886,6 +1887,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 
 			twn_hm.put("ruined", town.isRuined());
 			twn_hm.put("ruinedTime", town.getRuinedTime());
+			twn_hm.put("neutral", town.isNeutral());
 			
 			UpdateDB("TOWNS", twn_hm, Collections.singletonList("name"));
 			return true;

--- a/src/com/palmergames/bukkit/towny/object/Government.java
+++ b/src/com/palmergames/bukkit/towny/object/Government.java
@@ -38,6 +38,7 @@ public abstract class Government extends TownyObject implements BankEconomyHandl
 	private final transient List<Invite> sentInvites = new ArrayList<>();
 	private boolean isPublic = false;
 	private boolean isOpen = false;
+	private boolean isNeutral = false;
 	private long registered;
 	private double spawnCost = TownySettings.getSpawnTravelCost();
 	protected double taxes;
@@ -142,7 +143,25 @@ public abstract class Government extends TownyObject implements BankEconomyHandl
 	public final boolean isOpen() { 
 		return isOpen; 
 	}
+	
+	/**
+	 * Sets the neutrality/peacefulness of the object. 
+	 * 
+	 * @param neutral whether the object will be neutral or peaceful.
+	 */
+	public final void setNeutral(boolean neutral) {
+		this.isNeutral = neutral;
+	}
 
+	/**
+	 * Is the object Neutral or Peaceful?
+	 * 
+	 * @return true if the object is Neutral or Peaceful.
+	 */
+	public final boolean isNeutral() {
+		return isNeutral;
+	}
+	
 	/**
 	 * Sets the date when this was registered.
 	 * 
@@ -293,4 +312,5 @@ public abstract class Government extends TownyObject implements BankEconomyHandl
 	public void setUUID(UUID uuid) {
 		this.uuid = uuid;
 	}
+
 }

--- a/src/com/palmergames/bukkit/towny/object/Government.java
+++ b/src/com/palmergames/bukkit/towny/object/Government.java
@@ -147,6 +147,7 @@ public abstract class Government extends TownyObject implements BankEconomyHandl
 	/**
 	 * Sets the neutrality/peacefulness of the object. 
 	 * 
+	 * @since 0.96.5.4
 	 * @param neutral whether the object will be neutral or peaceful.
 	 */
 	public final void setNeutral(boolean neutral) {
@@ -156,6 +157,7 @@ public abstract class Government extends TownyObject implements BankEconomyHandl
 	/**
 	 * Is the object Neutral or Peaceful?
 	 * 
+	 * @since 0.96.5.4
 	 * @return true if the object is Neutral or Peaceful.
 	 */
 	public final boolean isNeutral() {

--- a/src/com/palmergames/bukkit/towny/object/Government.java
+++ b/src/com/palmergames/bukkit/towny/object/Government.java
@@ -312,5 +312,4 @@ public abstract class Government extends TownyObject implements BankEconomyHandl
 	public void setUUID(UUID uuid) {
 		this.uuid = uuid;
 	}
-
 }

--- a/src/com/palmergames/bukkit/towny/object/Nation.java
+++ b/src/com/palmergames/bukkit/towny/object/Nation.java
@@ -17,7 +17,6 @@ import com.palmergames.bukkit.towny.object.economy.AccountAuditor;
 import com.palmergames.bukkit.towny.object.economy.GovernmentAccountAuditor;
 import com.palmergames.bukkit.towny.object.metadata.CustomDataField;
 import com.palmergames.bukkit.towny.permissions.TownyPerms;
-import com.palmergames.bukkit.towny.war.flagwar.FlagWar;
 import com.palmergames.bukkit.util.BukkitTools;
 import com.palmergames.util.StringMgmt;
 import org.bukkit.Location;
@@ -729,22 +728,12 @@ public class Nation extends Government {
 	}
 
 	/**
-	 * @deprecated As of 0.96.5.0, please use {@link #setNeutral()} instead.
+	 * @deprecated As of 0.96.5.0, please use {@link Government#setNeutral(boolean)} instead.
 	 * 
-	 * @param neutral
-	 * @throws TownyException
+	 * @param neutral The value which will be used to set Neutrality true or false.
 	 */
 	@Deprecated
-	public void toggleNeutral(boolean neutral) throws TownyException {
-
-		if (!TownySettings.isDeclaringNeutral() && neutral)
-			throw new TownyException(Translation.of("msg_err_fight_like_king"));
-		else {
-			if (neutral && !FlagWar.getCellsUnderAttack().isEmpty())
-				for (Resident resident : getResidents())
-					FlagWar.removeAttackerFlags(resident.getName());
-			
-			setNeutral(neutral);
-		}
+	public void toggleNeutral(boolean neutral) {
+		setNeutral(neutral);
 	}
 }

--- a/src/com/palmergames/bukkit/towny/object/Nation.java
+++ b/src/com/palmergames/bukkit/towny/object/Nation.java
@@ -39,7 +39,6 @@ public class Nation extends Government {
 	private List<Nation> allies = new ArrayList<>();
 	private List<Nation> enemies = new ArrayList<>();
 	private Town capital;
-	private boolean neutral = false;
 	private String mapColorHexCode = "";
 	public UUID uuid;
 	private Location nationSpawn;
@@ -463,29 +462,6 @@ public class Nation extends Government {
 		return removedTowns;
 	}	
 
-	public void toggleNeutral(boolean neutral) throws TownyException {
-
-		if (!TownySettings.isDeclaringNeutral() && neutral)
-			throw new TownyException(Translation.of("msg_err_fight_like_king"));
-		else {
-			if (neutral && !FlagWar.getCellsUnderAttack().isEmpty())
-				for (Resident resident : getResidents())
-					FlagWar.removeAttackerFlags(resident.getName());
-			
-			setNeutral(neutral);
-		}
-	}
-	
-	public void setNeutral(boolean neutral) {
-
-		this.neutral = neutral;
-	}
-
-	public boolean isNeutral() {
-
-		return neutral;
-	}
-
 	public void setKing(Resident king) throws TownyException {
 
 		if (!hasResident(king))
@@ -750,5 +726,25 @@ public class Nation extends Government {
 	@Deprecated
 	public String getNationBoard() {
 		return getBoard();
+	}
+
+	/**
+	 * @deprecated As of 0.96.5.0, please use {@link #setNeutral()} instead.
+	 * 
+	 * @param neutral
+	 * @throws TownyException
+	 */
+	@Deprecated
+	public void toggleNeutral(boolean neutral) throws TownyException {
+
+		if (!TownySettings.isDeclaringNeutral() && neutral)
+			throw new TownyException(Translation.of("msg_err_fight_like_king"));
+		else {
+			if (neutral && !FlagWar.getCellsUnderAttack().isEmpty())
+				for (Resident resident : getResidents())
+					FlagWar.removeAttackerFlags(resident.getName());
+			
+			setNeutral(neutral);
+		}
 	}
 }

--- a/src/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
+++ b/src/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
@@ -142,6 +142,7 @@ public enum PermissionNodes {
 			TOWNY_COMMAND_TOWN_TOGGLE_TAXPERCENT("towny.command.town.toggle.taxpercent"),
 			TOWNY_COMMAND_TOWN_TOGGLE_OPEN("towny.command.town.toggle.open"),
 			TOWNY_COMMAND_TOWN_TOGGLE_JAIL("towny.command.town.toggle.jail"),
+			TOWNY_COMMAND_TOWN_TOGGLE_NEUTRAL("towny.command.town.toggle.neutral"),
 		
 		
 		TOWNY_COMMAND_TOWN_MAYOR("towny.command.town.mayor"),

--- a/src/com/palmergames/bukkit/towny/war/common/WarZoneListener.java
+++ b/src/com/palmergames/bukkit/towny/war/common/WarZoneListener.java
@@ -8,6 +8,7 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 
 import com.palmergames.bukkit.towny.Towny;
@@ -20,6 +21,7 @@ import com.palmergames.bukkit.towny.event.actions.TownyExplodingBlocksEvent;
 import com.palmergames.bukkit.towny.event.actions.TownyExplosionDamagesEntityEvent;
 import com.palmergames.bukkit.towny.event.actions.TownyItemuseEvent;
 import com.palmergames.bukkit.towny.event.actions.TownySwitchEvent;
+import com.palmergames.bukkit.towny.event.nation.toggle.NationToggleNeutralEvent;
 import com.palmergames.bukkit.towny.object.Coord;
 import com.palmergames.bukkit.towny.object.Translation;
 import com.palmergames.bukkit.towny.object.PlayerCache.TownBlockStatus;
@@ -229,6 +231,14 @@ public class WarZoneListener implements Listener {
 			} else {
 				event.setCancelled(true);
 			}
+		}
+	}
+	
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+	public void onNationToggleNeutral(NationToggleNeutralEvent event) {
+		if (!TownySettings.isDeclaringNeutral() && event.getFutureState()) {
+			event.setCancelled(true);
+			event.setCancelMessage(Translation.of("msg_err_fight_like_king"));
 		}
 	}
 }

--- a/src/com/palmergames/bukkit/towny/war/flagwar/listeners/FlagWarCustomListener.java
+++ b/src/com/palmergames/bukkit/towny/war/flagwar/listeners/FlagWarCustomListener.java
@@ -301,18 +301,17 @@ public class FlagWarCustomListener implements Listener {
 		}
 	}
 
-	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
-	public void onNationToggle(NationToggleNeutralEvent event) {
-//		if (FlagWarConfig.isAllowingAttacks()) {
-//			String arg = event.getArg();
-//			
-//			if (arg != null) {
-//				System.out.println("arg " + arg);
-//				if (event.getArg().equalsIgnoreCase("peaceful")) {
-//					event.setCancelled(true);
-//					event.setCancellationMsg(Translation.of("msg_err_fight_like_king"));
-//				}	
-//			}
-//		}
+	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+	public void onNationToggleNeutral(NationToggleNeutralEvent event) {
+		if (FlagWarConfig.isAllowingAttacks()) {
+			if (!TownySettings.isDeclaringNeutral() && event.getFutureState()) {
+				event.setCancelled(true);
+				event.setCancelMessage(Translation.of("msg_err_fight_like_king"));
+			} else {
+				if (event.getFutureState() && !FlagWar.getCellsUnderAttack().isEmpty())
+					for (Resident resident : event.getNation().getResidents())
+						FlagWar.removeAttackerFlags(resident.getName());
+			}
+		}
 	}
 }


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This PR will again lower the changes between Towny and SiegeWar Towny. 

It will also increase customize-ability of Event War and other plugins.

- Add towny.command.town.toggle.neutral permission node.
- Adds setNeutral, isNeutral to Government.
- Adds neutral setting to Towns in the database.
- Deprecates the Nation toggleNeutral.
- Does NOT add the /town toggle neutral|peaceful command yet.
- Moves the neutrality tests for war off of the Nation object and onto the war listeners.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->

Permission node: towny.command.town.toggle.neutral
  - Child node of towny.command.town.toggle.*
____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #4531 

____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
