### PR TITLE
Fix/Improve Town Toggle Events

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -22,6 +22,7 @@ import com.palmergames.bukkit.towny.event.TownPreTransactionEvent;
 import com.palmergames.bukkit.towny.event.TownTransactionEvent;
 import com.palmergames.bukkit.towny.event.town.TownLeaveEvent;
 import com.palmergames.bukkit.towny.event.town.TownPreSetHomeBlockEvent;
+import com.palmergames.bukkit.towny.event.town.toggle.TownToggleNeutralEvent;
 import com.palmergames.bukkit.towny.event.town.toggle.TownToggleUnknownEvent;
 import com.palmergames.bukkit.towny.event.town.toggle.TownToggleExplosionEvent;
 import com.palmergames.bukkit.towny.event.town.toggle.TownToggleFireEvent;
@@ -1460,13 +1461,13 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 			if (split[0].equalsIgnoreCase("public")) {
 
 				// Fire cancellable event directly before setting the toggle.
-				TownTogglePublicEvent preEvent = new TownTogglePublicEvent(sender, town, admin);
+				TownTogglePublicEvent preEvent = new TownTogglePublicEvent(sender, town, admin, choice.orElse(!town.isPublic()));
 				Bukkit.getPluginManager().callEvent(preEvent);
 				if (preEvent.isCancelled())
 					throw new TownyException(preEvent.getCancellationMsg());
 
 				// Set the toggle setting.
-				town.setPublic(choice.orElse(!town.isPublic()));
+				town.setPublic(preEvent.getFutureState());
 				
 				// Send message feedback.
 				TownyMessaging.sendPrefixedTownMessage(town, Translation.of("msg_changed_public", town.isPublic() ? Translation.of("enabled") : Translation.of("disabled")));
@@ -1496,13 +1497,13 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 				}
 
 				// Fire cancellable event directly before setting the toggle.
-				TownTogglePVPEvent preEvent = new TownTogglePVPEvent(sender, town, admin);
+				TownTogglePVPEvent preEvent = new TownTogglePVPEvent(sender, town, admin, choice.orElse(!town.isPVP()));
 				Bukkit.getPluginManager().callEvent(preEvent);
 				if (preEvent.isCancelled())
 					throw new TownyException(preEvent.getCancellationMsg());
 
 				// Set the toggle setting.
-				town.setPVP(choice.orElse(!town.isPVP()));
+				town.setPVP(preEvent.getFutureState());
 
 				// Send message feedback.
 				TownyMessaging.sendPrefixedTownMessage(town, Translation.of("msg_changed_pvp", town.getName(), town.isPVP() ? Translation.of("enabled") : Translation.of("disabled")));
@@ -1520,13 +1521,13 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 					toggleTest((Player) sender, town, StringMgmt.join(split, " "));
 				
 				// Fire cancellable event directly before setting the toggle.
-				TownToggleExplosionEvent preEvent = new TownToggleExplosionEvent(sender, town, admin);
+				TownToggleExplosionEvent preEvent = new TownToggleExplosionEvent(sender, town, admin, choice.orElse(!town.isBANG()));
 				Bukkit.getPluginManager().callEvent(preEvent);
 				if (preEvent.isCancelled())
 					throw new TownyException(preEvent.getCancellationMsg());
 
 				// Set the toggle setting.
-				town.setBANG(choice.orElse(!town.isBANG()));
+				town.setBANG(preEvent.getFutureState());
 
 				// Send message feedback.
 				TownyMessaging.sendPrefixedTownMessage(town, Translation.of("msg_changed_expl", town.getName(), town.isBANG() ? Translation.of("enabled") : Translation.of("disabled")));
@@ -1540,13 +1541,13 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 					toggleTest((Player) sender, town, StringMgmt.join(split, " "));
 				
 				// Fire cancellable event directly before setting the toggle.
-				TownToggleFireEvent preEvent = new TownToggleFireEvent(sender, town, admin);
+				TownToggleFireEvent preEvent = new TownToggleFireEvent(sender, town, admin, choice.orElse(!town.isFire()));
 				Bukkit.getPluginManager().callEvent(preEvent);
 				if (preEvent.isCancelled())
 					throw new TownyException(preEvent.getCancellationMsg());
 
 				// Set the toggle setting.
-				town.setFire(choice.orElse(!town.isFire()));
+				town.setFire(preEvent.getFutureState());
 				
 				// Send message feedback.
 				TownyMessaging.sendPrefixedTownMessage(town, Translation.of("msg_changed_fire", town.getName(), town.isFire() ? Translation.of("enabled") : Translation.of("disabled")));
@@ -1560,13 +1561,13 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 					toggleTest((Player) sender, town, StringMgmt.join(split, " "));
 
 				// Fire cancellable event directly before setting the toggle.
-				TownToggleMobsEvent preEvent = new TownToggleMobsEvent(sender, town, admin);
+				TownToggleMobsEvent preEvent = new TownToggleMobsEvent(sender, town, admin, choice.orElse(!town.hasMobs()));
 				Bukkit.getPluginManager().callEvent(preEvent);
 				if (preEvent.isCancelled())
 					throw new TownyException(preEvent.getCancellationMsg());
 
 				// Set the toggle setting.
-				town.setHasMobs(choice.orElse(!town.hasMobs()));
+				town.setHasMobs(preEvent.getFutureState());
 				
 				// Send message feedback.
 				TownyMessaging.sendPrefixedTownMessage(town, Translation.of("msg_changed_mobs", town.getName(), town.hasMobs() ? Translation.of("enabled") : Translation.of("disabled")));
@@ -1576,13 +1577,13 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 			} else if (split[0].equalsIgnoreCase("taxpercent")) {
 
 				// Fire cancellable event directly before setting the toggle.
-				TownToggleTaxPercentEvent preEvent = new TownToggleTaxPercentEvent(sender, town, admin);
+				TownToggleTaxPercentEvent preEvent = new TownToggleTaxPercentEvent(sender, town, admin, choice.orElse(!town.isTaxPercentage()));
 				Bukkit.getPluginManager().callEvent(preEvent);
 				if (preEvent.isCancelled())
 					throw new TownyException(preEvent.getCancellationMsg());
 
 				// Set the toggle setting.
-				town.setTaxPercentage(choice.orElse(!town.isTaxPercentage()));
+				town.setTaxPercentage(preEvent.getFutureState());
 				
 				// Send message feedback.
 				TownyMessaging.sendPrefixedTownMessage(town, Translation.of("msg_changed_taxpercent", town.isTaxPercentage() ? Translation.of("enabled") : Translation.of("disabled")));
@@ -1595,13 +1596,13 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 					throw new TownyException(Translation.of("msg_err_bankrupt_town_cannot_toggle_open"));
 
 				// Fire cancellable event directly before setting the toggle.
-				TownToggleOpenEvent preEvent = new TownToggleOpenEvent(sender, town, admin);
+				TownToggleOpenEvent preEvent = new TownToggleOpenEvent(sender, town, admin, choice.orElse(!town.isOpen()));
 				Bukkit.getPluginManager().callEvent(preEvent);
 				if (preEvent.isCancelled())
 					throw new TownyException(preEvent.getCancellationMsg());
 
 				// Set the toggle setting.
-				town.setOpen(choice.orElse(!town.isOpen()));
+				town.setOpen(preEvent.getFutureState());
 				
 				// Send message feedback.
 				TownyMessaging.sendPrefixedTownMessage(town, Translation.of("msg_changed_open", town.isOpen() ? Translation.of("enabled") : Translation.of("disabled")));
@@ -1615,13 +1616,13 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 			} else if (split[0].equalsIgnoreCase("neutral") || split[0].equalsIgnoreCase("peaceful")) {
 				
 				// Fire cancellable event directly before setting the toggle.
-				TownToggleOpenEvent preEvent = new TownToggleOpenEvent(sender, town, admin);
+				TownToggleNeutralEvent preEvent = new TownToggleNeutralEvent(sender, town, admin, choice.orElse(!town.isNeutral()));
 				Bukkit.getPluginManager().callEvent(preEvent);
 				if (preEvent.isCancelled())
 					throw new TownyException(preEvent.getCancellationMsg());
 
 				// Set the toggle setting.
-				town.setNeutral(choice.orElse(!town.isNeutral()));
+				town.setNeutral(preEvent.getFutureState());
 
 				// Send message feedback.
 				TownyMessaging.sendPrefixedTownMessage(town, Translation.of("msg_changed_peaceful", town.isNeutral() ? Translation.of("enabled") : Translation.of("disabled")));

--- a/src/com/palmergames/bukkit/towny/event/town/toggle/TownToggleEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/town/toggle/TownToggleEvent.java
@@ -17,7 +17,6 @@ import com.palmergames.bukkit.towny.object.Translation;
 public abstract class TownToggleEvent extends Event implements Cancellable {
 
 	private static final HandlerList handlers = new HandlerList();
-	private Player player = null;
 	private final Town town;
 	private final CommandSender sender;
 	private final boolean isAdminAction;
@@ -34,8 +33,6 @@ public abstract class TownToggleEvent extends Event implements Cancellable {
 	public TownToggleEvent(CommandSender sender, Town town, boolean admin) {
 		super(!Bukkit.getServer().isPrimaryThread());
 		this.sender = sender;
-		if (sender instanceof Player)
-			this.player = (Player) sender;
 		this.town = town;
 		this.isAdminAction = admin;
 	}
@@ -61,15 +58,20 @@ public abstract class TownToggleEvent extends Event implements Cancellable {
 
 	@Nullable
 	public Resident getResident() {
-		try {
-			return TownyUniverse.getInstance().getDataSource().getResident(player.getName());
-		} catch (NotRegisteredException ignored) {}
+		Player player = getPlayer();
+		
+		if (player != null) {
+			try {
+				return TownyUniverse.getInstance().getDataSource().getResident(player.getName());
+			} catch (NotRegisteredException ignored) {}
+		}
+		
 		return null;
 	}
 	
 	@Nullable
 	public Player getPlayer() {
-		return player;
+		return sender instanceof Player ? (Player) sender : null;
 	}
 
 	public Town getTown() {

--- a/src/com/palmergames/bukkit/towny/event/town/toggle/TownToggleExplosionEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/town/toggle/TownToggleExplosionEvent.java
@@ -2,28 +2,12 @@ package com.palmergames.bukkit.towny.event.town.toggle;
 
 import org.bukkit.command.CommandSender;
 import com.palmergames.bukkit.towny.object.Town;
+import org.bukkit.event.HandlerList;
 
-public class TownToggleExplosionEvent extends TownToggleEvent {
-
-	private final boolean state;
+public class TownToggleExplosionEvent extends TownToggleStateEvent {
 	
-	public TownToggleExplosionEvent(CommandSender sender, Town town, boolean admin) {
-		super(sender, town, admin);
-		state = town.isBANG();
-	}
-
-	/**
-	 * @return the current toggle's state.
-	 */
-	public boolean getCurrentState() {
-		return state;
-	}
-	
-	/**
-	 * @return the future state of the toggle after the event.
-	 */
-	public boolean getFutureState() {
-		return !state;
+	public TownToggleExplosionEvent(CommandSender sender, Town town, boolean admin, boolean newState) {
+		super(sender, town, admin, town.isBANG(), newState);
 	}
 
 }

--- a/src/com/palmergames/bukkit/towny/event/town/toggle/TownToggleFireEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/town/toggle/TownToggleFireEvent.java
@@ -2,28 +2,12 @@ package com.palmergames.bukkit.towny.event.town.toggle;
 
 import org.bukkit.command.CommandSender;
 import com.palmergames.bukkit.towny.object.Town;
+import org.bukkit.event.HandlerList;
 
-public class TownToggleFireEvent extends TownToggleEvent {
-
-	private final boolean state;
+public class TownToggleFireEvent extends TownToggleStateEvent {
 	
-	public TownToggleFireEvent(CommandSender sender, Town town, boolean admin) {
-		super(sender, town, admin);
-		state = town.isFire();
-	}
-
-	/**
-	 * @return the current toggle's state.
-	 */
-	public boolean getCurrentState() {
-		return state;
-	}
-	
-	/**
-	 * @return the future state of the toggle after the event.
-	 */
-	public boolean getFutureState() {
-		return !state;
+	public TownToggleFireEvent(CommandSender sender, Town town, boolean admin, boolean newState) {
+		super(sender, town, admin, town.isFire(), newState);
 	}
 
 }

--- a/src/com/palmergames/bukkit/towny/event/town/toggle/TownToggleMobsEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/town/toggle/TownToggleMobsEvent.java
@@ -2,28 +2,12 @@ package com.palmergames.bukkit.towny.event.town.toggle;
 
 import org.bukkit.command.CommandSender;
 import com.palmergames.bukkit.towny.object.Town;
+import org.bukkit.event.HandlerList;
 
-public class TownToggleMobsEvent extends TownToggleEvent {
-
-	private final boolean state;
+public class TownToggleMobsEvent extends TownToggleStateEvent {
 	
-	public TownToggleMobsEvent(CommandSender sender, Town town, boolean admin) {
-		super(sender, town, admin);
-		state = town.hasMobs();
-	}
-
-	/**
-	 * @return the current toggle's state.
-	 */
-	public boolean getCurrentState() {
-		return state;
-	}
-	
-	/**
-	 * @return the future state of the toggle after the event.
-	 */
-	public boolean getFutureState() {
-		return !state;
+	public TownToggleMobsEvent(CommandSender sender, Town town, boolean admin, boolean newState) {
+		super(sender, town, admin, town.hasMobs(), newState);
 	}
 
 }

--- a/src/com/palmergames/bukkit/towny/event/town/toggle/TownToggleNeutralEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/town/toggle/TownToggleNeutralEvent.java
@@ -2,28 +2,12 @@ package com.palmergames.bukkit.towny.event.town.toggle;
 
 import org.bukkit.command.CommandSender;
 import com.palmergames.bukkit.towny.object.Town;
+import org.bukkit.event.HandlerList;
 
-public class TownToggleNeutralEvent extends TownToggleEvent {
-
-	private final boolean state;
+public class TownToggleNeutralEvent extends TownToggleStateEvent {
 	
-	public TownToggleNeutralEvent(CommandSender sender, Town town, boolean admin) {
-		super(sender, town, admin);
-		state = town.isNeutral();
-	}
-
-	/**
-	 * @return the current toggle's state.
-	 */
-	public boolean getCurrentState() {
-		return state;
-	}
-	
-	/**
-	 * @return the future state of the toggle after the event.
-	 */
-	public boolean getFutureState() {
-		return !state;
+	public TownToggleNeutralEvent(CommandSender sender, Town town, boolean admin, boolean newState) {
+		super(sender, town, admin, town.isNeutral(), newState);
 	}
 
 }

--- a/src/com/palmergames/bukkit/towny/event/town/toggle/TownToggleOpenEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/town/toggle/TownToggleOpenEvent.java
@@ -2,28 +2,12 @@ package com.palmergames.bukkit.towny.event.town.toggle;
 
 import org.bukkit.command.CommandSender;
 import com.palmergames.bukkit.towny.object.Town;
+import org.bukkit.event.HandlerList;
 
-public class TownToggleOpenEvent extends TownToggleEvent {
-
-	private final boolean state;
+public class TownToggleOpenEvent extends TownToggleStateEvent {
 	
-	public TownToggleOpenEvent(CommandSender sender, Town town, boolean admin) {
-		super(sender, town, admin);
-		state = town.isOpen();
-	}
-
-	/**
-	 * @return the current toggle's state.
-	 */
-	public boolean getCurrentState() {
-		return state;
-	}
-	
-	/**
-	 * @return the future state of the toggle after the event.
-	 */
-	public boolean getFutureState() {
-		return !state;
+	public TownToggleOpenEvent(CommandSender sender, Town town, boolean admin, boolean newState) {
+		super(sender, town, admin, town.isOpen(), newState);
 	}
 
 }

--- a/src/com/palmergames/bukkit/towny/event/town/toggle/TownTogglePVPEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/town/toggle/TownTogglePVPEvent.java
@@ -2,28 +2,12 @@ package com.palmergames.bukkit.towny.event.town.toggle;
 
 import org.bukkit.command.CommandSender;
 import com.palmergames.bukkit.towny.object.Town;
+import org.bukkit.event.HandlerList;
 
-public class TownTogglePVPEvent extends TownToggleEvent {
-
-	private final boolean state;
+public class TownTogglePVPEvent extends TownToggleStateEvent {
 	
-	public TownTogglePVPEvent(CommandSender sender, Town town, boolean admin) {
-		super(sender, town, admin);
-		state = town.isPVP();
-	}
-
-	/**
-	 * @return the current toggle's state.
-	 */
-	public boolean getCurrentState() {
-		return state;
-	}
-	
-	/**
-	 * @return the future state of the toggle after the event.
-	 */
-	public boolean getFutureState() {
-		return !state;
+	public TownTogglePVPEvent(CommandSender sender, Town town, boolean admin, boolean newState) {
+		super(sender, town, admin, town.isPVP(), newState);
 	}
 
 }

--- a/src/com/palmergames/bukkit/towny/event/town/toggle/TownTogglePublicEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/town/toggle/TownTogglePublicEvent.java
@@ -2,28 +2,12 @@ package com.palmergames.bukkit.towny.event.town.toggle;
 
 import org.bukkit.command.CommandSender;
 import com.palmergames.bukkit.towny.object.Town;
+import org.bukkit.event.HandlerList;
 
-public class TownTogglePublicEvent extends TownToggleEvent {
-
-	private final boolean state;
+public class TownTogglePublicEvent extends TownToggleStateEvent {
 	
-	public TownTogglePublicEvent(CommandSender sender, Town town, boolean admin) {
-		super(sender, town, admin);
-		state = town.isPublic();
-	}
-
-	/**
-	 * @return the current toggle's state.
-	 */
-	public boolean getCurrentState() {
-		return state;
-	}
-	
-	/**
-	 * @return the future state of the toggle after the event.
-	 */
-	public boolean getFutureState() {
-		return !state;
+	public TownTogglePublicEvent(CommandSender sender, Town town, boolean admin, boolean newState) {
+		super(sender, town, admin, town.isPublic(), newState);
 	}
 
 }

--- a/src/com/palmergames/bukkit/towny/event/town/toggle/TownToggleStateEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/town/toggle/TownToggleStateEvent.java
@@ -1,0 +1,28 @@
+package com.palmergames.bukkit.towny.event.town.toggle;
+
+import com.palmergames.bukkit.towny.object.Town;
+import org.bukkit.command.CommandSender;
+
+abstract class TownToggleStateEvent extends TownToggleEvent {
+	private boolean newState, currState;
+	
+	TownToggleStateEvent(CommandSender sender, Town town, boolean admin, boolean currState, boolean newState) {
+		super(sender, town, admin);
+		this.currState = currState;
+		this.newState = newState;
+	}
+
+	/**
+	 * @return the current toggle's state.
+	 */
+	public boolean getCurrentState() {
+		return currState;
+	}
+
+	/**
+	 * @return the future state of the toggle after the event.
+	 */
+	public boolean getFutureState() {
+		return newState;
+	}
+}

--- a/src/com/palmergames/bukkit/towny/event/town/toggle/TownToggleTaxPercentEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/town/toggle/TownToggleTaxPercentEvent.java
@@ -2,28 +2,11 @@ package com.palmergames.bukkit.towny.event.town.toggle;
 
 import org.bukkit.command.CommandSender;
 import com.palmergames.bukkit.towny.object.Town;
+import org.bukkit.event.HandlerList;
 
-public class TownToggleTaxPercentEvent extends TownToggleEvent {
-
-	private final boolean state;
+public class TownToggleTaxPercentEvent extends TownToggleStateEvent {
 	
-	public TownToggleTaxPercentEvent(CommandSender sender, Town town, boolean admin) {
-		super(sender, town, admin);
-		state = town.isTaxPercentage();
+	public TownToggleTaxPercentEvent(CommandSender sender, Town town, boolean admin, boolean newState) {
+		super(sender, town, admin, town.isTaxPercentage(), newState);
 	}
-
-	/**
-	 * @return the current toggle's state.
-	 */
-	public boolean getCurrentState() {
-		return state;
-	}
-	
-	/**
-	 * @return the future state of the toggle after the event.
-	 */
-	public boolean getFutureState() {
-		return !state;
-	}
-
 }


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
These just make the TownToggleEvent subclasses prettier by adding an intermediary class called `TownToggleStateEvent` which is abstract and can be extended by events in the package. Furthermore, this PR resolves two bugs.
The first issue is that previously the toggle events assumed that the future state was going to be the opposite of the current state, however this is not the case if a boolean is specified when toggling. Thus, this PR forces all the toggle events to manually take in the new state. 
The second issue was that the `TownToggleOpenEvent` was being fired where the `TownToggleNeutralEvent` should have been.

Will make a similar PR fixing the Nation toggle events soon.
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
