### PR TITLE
TownCommand/NationCommand "rank" to LowerCase #4538

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -909,7 +909,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 			Resident resident, target;
 			Town town = null;
 			Town targetTown = null;
-			String rank;
+			String rank.toLowerCase();
 			TownyUniverse townyUniverse = TownyUniverse.getInstance();
 
 			/*

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -1776,7 +1776,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 
 			Resident resident, target;
 			Town town = null;
-			String rank;
+			String rank.toLowerCase();
 
 			/*
 			 * Does the command have enough arguments?


### PR DESCRIPTION
#### Description: 
This pull changes TownCommand and NationCommand to get the argument of `rank` in the command `/n rank add {user} {rank}` and switches it to Lower Case.
____


____
#### Relevant Towny Issue ticket:
Fixes issues on #4538 


____
- [X] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
