### PR TITLE
TownCommand/NationCommand, setting "rank" to LowerCase after its defined. Issue #4538

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -935,6 +935,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 			}
 
 			rank = split[2];
+			rank.toLowerCase();
 			/*
 			 * Is this a known rank?
 			 */

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -1797,6 +1797,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor, TabComp
 			}
 
 			rank = split[2];
+			rank.toLowerCase();
 			/*
 			 * Match correct casing of rank, if that rank exists.
 			 */


### PR DESCRIPTION
#### Description: 
This pull changes TownCommand and NationCommand to get the argument of rank in the command /n rank add {user} {rank} and switches it to Lower Case.

____
#### Relevant Towny Issue ticket:
Fixes issues on #4538 where rank doesn't exist unless it matches capitalization to a key.


____
- [X] I have tested this pull request for defects on a server. 
-> Previous pull didn't have my recent push. Apologizes for the clutter.

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.