### PR TITLE
Allow admins to force delete a town if it's already ruined

### DIFF
--- a/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
@@ -702,7 +702,7 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 		
 		TownyMessaging.sendGlobalMessage(Translation.of("msg_del_town", town.getName()));
 		
-		if (delayFullRemoval) {
+		if (delayFullRemoval && !town.isRuined()) {
 			/*
 			 * When Town ruining is active, send the Town into a ruined state, prior to real removal.
 			 */

--- a/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
@@ -694,7 +694,7 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 		 * If Town Ruining is enabled set the town into a ruined state
 		 * rather than deleting.
 		 */
-		removeTown(town, TownRuinSettings.getTownRuinsEnabled());
+		removeTown(town, TownRuinSettings.getTownRuinsEnabled() && !town.isRuined());
 	}
 
 	@Override
@@ -702,7 +702,7 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 		
 		TownyMessaging.sendGlobalMessage(Translation.of("msg_del_town", town.getName()));
 		
-		if (delayFullRemoval && !town.isRuined()) {
+		if (delayFullRemoval) {
 			/*
 			 * When Town ruining is active, send the Town into a ruined state, prior to real removal.
 			 */


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This PR allows admins to force delete a town right away by running `/ta town [town] delete` if it's already in ruins.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [X] I have tested this pull request for defects on a server. 
<!--- Place x between [X] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
