### PR TITLE
Fix trident lightning strike on pvp disabled plots

### DIFF
--- a/src/com/palmergames/bukkit/towny/listeners/TownyWorldListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyWorldListener.java
@@ -12,6 +12,7 @@ import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.TownyWorld;
+import com.palmergames.bukkit.towny.object.TownyPermission;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,6 +30,7 @@ import org.bukkit.event.world.PortalCreateEvent;
 import org.bukkit.event.world.StructureGrowEvent;
 import org.bukkit.event.world.WorldInitEvent;
 import org.bukkit.event.world.WorldLoadEvent;
+import org.bukkit.event.weather.LightningStrikeEvent;
 
 public class TownyWorldListener implements Listener {
 	
@@ -201,6 +203,20 @@ public class TownyWorldListener implements Listener {
 				TownyMessaging.sendErrorMsg(event.getEntity(), Translation.of("msg_err_you_are_not_allowed_to_create_the_other_side_of_this_portal"));
 				event.setCancelled(true);
 				break;
+			}
+		}
+	}
+
+	@EventHandler(priority = EventPriority.NORMAL)
+	public void onLightningStrike(LightningStrikeEvent event){
+		if (!TownyAPI.getInstance().isWilderness(event.getLightning().getLocation())){
+			Location location = event.getLightning().getLocation();
+			TownBlock townBlock = TownyAPI.getInstance().getTownBlock(location);
+			TownyPermission blockPerm = townBlock.getPermissions();
+			if (!blockPerm.pvp
+				&& !townBlock.isWarZone()
+				&& event.getCause().equals(LightningStrikeEvent.Cause.TRIDENT)){
+				event.setCancelled(true);
 			}
 		}
 	}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
Fix trident lightning strike on pvp disabled plots
Known bug: Lightning Strike is disabled but sound of Channeling enchantment isnt cancelled

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
