### PR TITLE
Fix towns being able to go over the maximum residents.

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/InviteCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/InviteCommand.java
@@ -247,7 +247,11 @@ public class InviteCommand extends BaseCommand implements CommandExecutor {
 
 		if (toAccept != null) {
 			try {
-				InviteHandler.acceptInvite(toAccept);
+				if (TownySettings.getMaxResidentsPerTown() > 0 && town.getResidents().size() >= TownySettings.getMaxResidentsPerTown()) {
+					TownyMessaging.sendMessage(player, Translation.of("msg_err_max_residents_per_town_reached", TownySettings.getMaxResidentsPerTown()));
+					return;
+				} else
+					InviteHandler.acceptInvite(toAccept);
 			} catch (TownyException | InvalidObjectException e) {
 				e.printStackTrace();
 			}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
The purpose of this PR is to fix the bug of Towns being able to surpass the `max_residents_per_town` config option by inviting multiple residents before hitting the cap, and having them all join. This PR adds a check from the /town invite command to make sure the town the resident is trying to join isn't at or above the cap.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
