### PR TITLE
Fixing /n deposit [amount] [town] to go into the specified town bank …

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -2650,7 +2650,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 					if (!resident.getTown().getNation().hasTown(town))
 						throw new TownyException(Translation.of("msg_err_not_same_nation", town.getName()));
 
-					MoneyUtil.townDeposit(player, resident, resident.getTown(), resident.getTown().getNation(), amount);
+					MoneyUtil.townDeposit(player, resident, town, resident.getTown().getNation(), amount);
 
 				} else {
 					throw new NotRegisteredException();


### PR DESCRIPTION
…rather than the town bank of the depositor.

Signed-off-by: Momshroom <Momshroom@gmail.com>

<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
/n deposit [amount] [town] was broken such that the deposit went to the depositor's town rather than the specified one. This fixes that.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
