### PR TITLE
Feature/invite expiration

### DIFF
--- a/resources/ChangeLog.txt
+++ b/resources/ChangeLog.txt
@@ -5692,3 +5692,8 @@ v0.92.0.11:
   - Fix spanish.yml having bad yaml.
   - Potentially fix Towny not getting the largest meta node value in some cases where a player's primary permission group could not be resolved.
   - Fix mayors and assistants not being able to /plot nfs their own personal plots.
+  - New Config Option: invite_system.expirationtime
+    - default: 0m
+    - When set for more than 0m, the amount of time (in minutes) until an invite is considered expired and is removed. Invites are checked for expiration once every hour.
+    - Valid values would include: 30s, 30m, 24h, 2d, etc.
+    - Closes #4086.

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1449,6 +1449,12 @@ public enum ConfigNodes {
 			"",
 			"# When set for more than 0m, the amount of time (in minutes) which must have passed between",
 			"# a player's first log in and when they can be invited to a town."),
+	INVITE_SYSTEM_EXPIRATION_TIME(
+			"invite_system.expirationtime",
+			"0m",
+			"",
+			"# When set for more than 0m, the amount of time (in minutes) until an invite",
+			"# is considered expired and is removed."),	
 	INVITE_SYSTEM_MAXIMUM_INVITES_SENT(
 			"invite_system.maximum_invites_sent",
 			"",

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1453,8 +1453,9 @@ public enum ConfigNodes {
 			"invite_system.expirationtime",
 			"0m",
 			"",
-			"# When set for more than 0m, the amount of time (in minutes) until an invite is considered",
-			"# expired and is removed. Invites are checked for expiration once every hour."),
+			"# When set for more than 0m, the amount of time until an invite is considered",
+			"# expired and is removed. Invites are checked for expiration once every hour.",
+			"# Valid values would include: 30s, 30m, 24h, 2d, etc."),
 	INVITE_SYSTEM_MAXIMUM_INVITES_SENT(
 			"invite_system.maximum_invites_sent",
 			"",

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1453,8 +1453,8 @@ public enum ConfigNodes {
 			"invite_system.expirationtime",
 			"0m",
 			"",
-			"# When set for more than 0m, the amount of time (in minutes) until an invite",
-			"# is considered expired and is removed."),	
+			"# When set for more than 0m, the amount of time (in minutes) until an invite is considered",
+			"# expired and is removed. Invites are checked for expiration once every hour."),
 	INVITE_SYSTEM_MAXIMUM_INVITES_SENT(
 			"invite_system.maximum_invites_sent",
 			"",

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -2499,6 +2499,11 @@ public class TownySettings {
 
 		return getSeconds(ConfigNodes.INVITE_SYSTEM_COOLDOWN_TIME);
 	}
+	
+	public static long getInviteExpirationTime() {
+		
+		return getSeconds(ConfigNodes.INVITE_SYSTEM_EXPIRATION_TIME);
+	}
 
 	public static boolean isAppendingToLog() {
 

--- a/src/com/palmergames/bukkit/towny/invites/InviteHandler.java
+++ b/src/com/palmergames/bukkit/towny/invites/InviteHandler.java
@@ -65,15 +65,11 @@ public class InviteHandler {
 	}
 	
 	public static void searchForExpiredInvites() {
+		final long time = TownySettings.getInviteExpirationTime() * 1000;
 		for (Invite activeInvite : getActiveInvites()) {
-			if (getInviteTime(activeInvite) + TownySettings.getInviteExpirationTime() > System.currentTimeMillis()) {
+			if (getInviteTime(activeInvite) + time < System.currentTimeMillis()) {
 				activeInvite.getReceiver().deleteReceivedInvite(activeInvite);
 				activeInvite.getSender().deleteSentInvite(activeInvite);
-				try {
-					declineInvite(activeInvite, false);
-				} catch (InvalidObjectException e) {
-					System.err.println(e.getMessage());
-				}
 			}
 		}
 	}

--- a/src/com/palmergames/bukkit/towny/invites/InviteHandler.java
+++ b/src/com/palmergames/bukkit/towny/invites/InviteHandler.java
@@ -70,6 +70,7 @@ public class InviteHandler {
 			if (getInviteTime(activeInvite) + time < System.currentTimeMillis()) {
 				activeInvite.getReceiver().deleteReceivedInvite(activeInvite);
 				activeInvite.getSender().deleteSentInvite(activeInvite);
+				removeInvite(activeInvite);
 			}
 		}
 	}

--- a/src/com/palmergames/bukkit/towny/tasks/HourlyTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/HourlyTimerTask.java
@@ -28,6 +28,7 @@ public class HourlyTimerTask extends TownyTimerTask {
 			TownRuinUtil.evaluateRuinedTownRemovals();
 		}
 		
+		System.out.println("exp time " + TownySettings.getInviteExpirationTime());
 		if (TownySettings.getInviteExpirationTime() > 0)
 			InviteHandler.searchForExpiredInvites();
 		

--- a/src/com/palmergames/bukkit/towny/tasks/HourlyTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/HourlyTimerTask.java
@@ -3,7 +3,9 @@ package com.palmergames.bukkit.towny.tasks;
 import org.bukkit.Bukkit;
 
 import com.palmergames.bukkit.towny.Towny;
+import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.event.time.NewHourEvent;
+import com.palmergames.bukkit.towny.invites.InviteHandler;
 import com.palmergames.bukkit.towny.war.common.townruin.TownRuinSettings;
 import com.palmergames.bukkit.towny.war.common.townruin.TownRuinUtil;
 
@@ -25,6 +27,9 @@ public class HourlyTimerTask extends TownyTimerTask {
 		if (TownRuinSettings.getTownRuinsEnabled()) {
 			TownRuinUtil.evaluateRuinedTownRemovals();
 		}
+		
+		if (TownySettings.getInviteExpirationTime() > 0)
+			InviteHandler.searchForExpiredInvites();
 		
 		/*
 		 * Fire an event other plugins can use.

--- a/src/com/palmergames/bukkit/towny/tasks/HourlyTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/HourlyTimerTask.java
@@ -28,7 +28,6 @@ public class HourlyTimerTask extends TownyTimerTask {
 			TownRuinUtil.evaluateRuinedTownRemovals();
 		}
 		
-		System.out.println("exp time " + TownySettings.getInviteExpirationTime());
 		if (TownySettings.getInviteExpirationTime() > 0)
 			InviteHandler.searchForExpiredInvites();
 		


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Adds an optional expiration time to invites, which are checked for once an hour using the HourlyTimerTask.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
  - New Config Option: invite_system.expirationtime
    - default: 0m
    - When set for more than 0m, the amount of time (in minutes) until an invite is considered expired and is removed. Invites are checked for expiration once every hour.
    - Valid values would include: 30s, 30m, 24h, 2d, etc.
____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

  - Closes #4086.
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
