### PR TITLE
Fixed Conquered Flag not changing when town leaves nation

### DIFF
--- a/src/com/palmergames/bukkit/towny/object/Town.java
+++ b/src/com/palmergames/bukkit/towny/object/Town.java
@@ -200,6 +200,10 @@ public class Town extends Government implements TownBlockOwner {
 			// Cannot occur when setting null;
 		}
 		
+		//The town is no longer conquered/occupied because it has left the nation
+		this.isConquered = false;
+		this.conqueredDays = 0;
+		
 		this.save();
 		BukkitTools.getPluginManager().callEvent(new NationRemoveTownEvent(this, nation));
 	}


### PR DESCRIPTION
#### Description: 
- With current code , when a town with an "isConquered" value of true (AKA an 'occupied town), leaves a nation, it retains the true value.
- This makes no sense, because by leaving the nation it is of course no longer occupied by any national power,
- Also the status of "(Conquered)" is still displayed on the town screen
- I fixed the above bug in this small PR by setting isConquered to false when a town leaves its nation
____
#### New Nodes/Commands/ConfigOptions: 
NA

____
#### Relevant Towny Issue ticket:
NA

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
