### PR TITLE
Custom Metadata Types

### DIFF
--- a/src/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/src/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -797,7 +797,7 @@ public class TownyFormatter {
 		List<String> extraFields = new ArrayList<>();
 		for (CustomDataField<?> cdf : to.getMetadata()) {
 			String newAdd = "";
-			if (!cdf.hasLabel())
+			if (!cdf.shouldDisplayInStatus())
 				continue;
 			
 			newAdd = Colors.Green + cdf.getLabel() + ": ";

--- a/src/com/palmergames/bukkit/towny/TownyUniverse.java
+++ b/src/com/palmergames/bukkit/towny/TownyUniverse.java
@@ -21,6 +21,7 @@ import com.palmergames.bukkit.towny.object.TownyWorld;
 import com.palmergames.bukkit.towny.object.Translation;
 import com.palmergames.bukkit.towny.object.WorldCoord;
 import com.palmergames.bukkit.towny.object.metadata.CustomDataField;
+import com.palmergames.bukkit.towny.object.metadata.MetadataLoader;
 import com.palmergames.bukkit.towny.permissions.TownyPermissionSource;
 import com.palmergames.bukkit.towny.permissions.TownyPerms;
 import com.palmergames.bukkit.towny.tasks.BackupTask;
@@ -124,6 +125,9 @@ public class TownyUniverse {
         // Try to load and save the database.
         if (!loadAndSaveDatabase(TownySettings.getLoadDatabase(), TownySettings.getSaveDatabase()))
         	return false;
+        
+        // Schedule metadata to be loaded
+		MetadataLoader.getInstance().scheduleDeserialization();
 
         // Try migrating the config and world files if the version has changed.
         if (!TownySettings.getLastRunVersion().equals(towny.getVersion())) {

--- a/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -1956,7 +1956,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 				// Check if the given value is valid for this field.
 				try {
 					if (val == null)
-						throw new InvalidMetadataTypeException(cdf.getType());
+						throw new InvalidMetadataTypeException(cdf);
 
 					cdf.isValidType(val);
 				} catch (InvalidMetadataTypeException e) {
@@ -2055,7 +2055,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 				// Change state
 				try {
 					if (val == null)
-						throw new InvalidMetadataTypeException(cdf.getType()); 
+						throw new InvalidMetadataTypeException(cdf); 
 							
 					cdf.isValidType(val);
 				} catch (InvalidMetadataTypeException e) {

--- a/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
@@ -31,6 +31,7 @@ import com.palmergames.bukkit.towny.object.TownyObject;
 import com.palmergames.bukkit.towny.object.TownyWorld;
 import com.palmergames.bukkit.towny.object.Translation;
 import com.palmergames.bukkit.towny.object.WorldCoord;
+import com.palmergames.bukkit.towny.object.metadata.DataFieldIO;
 import com.palmergames.bukkit.towny.regen.PlotBlockData;
 import com.palmergames.bukkit.towny.regen.TownyRegenAPI;
 import com.palmergames.bukkit.towny.tasks.DeleteFileTask;
@@ -1467,6 +1468,10 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 			
 		}
 		
+	}
+	
+	protected final String serializeMetadata(TownyObject obj) {
+		return DataFieldIO.serializeCDFs(obj.getMetadata());
 	}
 	
 	@Override

--- a/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -18,6 +18,7 @@ import com.palmergames.bukkit.towny.object.TownyObject;
 import com.palmergames.bukkit.towny.object.TownyWorld;
 import com.palmergames.bukkit.towny.object.WorldCoord;
 import com.palmergames.bukkit.towny.object.metadata.CustomDataField;
+import com.palmergames.bukkit.towny.object.metadata.MetadataLoader;
 import com.palmergames.bukkit.towny.tasks.DeleteFileTask;
 import com.palmergames.bukkit.towny.utils.MapUtil;
 import com.palmergames.util.FileMgmt;
@@ -469,7 +470,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 
 				line = keys.get("metadata");
 				if (line != null && !line.isEmpty())
-					resident.setMetadata(line.trim());
+					MetadataLoader.getInstance().deserializeMetadata(resident, line.trim());
 
 				line = keys.get("town");
 				if (line != null) {
@@ -824,7 +825,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 
 				line = keys.get("metadata");
 				if (line != null && !line.isEmpty())
-					town.setMetadata(line.trim());
+					MetadataLoader.getInstance().deserializeMetadata(town, line.trim());
 				
 				line = keys.get("nation");
 				if (line != null && !line.isEmpty()) {
@@ -1025,7 +1026,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 				
 				line = keys.get("metadata");
 				if (line != null && !line.isEmpty())
-					nation.setMetadata(line.trim());
+					MetadataLoader.getInstance().deserializeMetadata(nation, line.trim());
 
 			} catch (Exception e) {
 				TownyMessaging.sendErrorMsg("Loading Error: Exception while reading nation file " + nation.getName() + " at line: " + line + ", in towny\\data\\nations\\" + nation.getName() + ".txt");
@@ -1320,7 +1321,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 
 				line = keys.get("metadata");
 				if (line != null && !line.isEmpty())
-					world.setMetadata(line.trim());
+					MetadataLoader.getInstance().deserializeMetadata(world, line.trim());
 				
 			} catch (Exception e) {
 				TownyMessaging.sendErrorMsg("Loading Error: Exception while reading world file " + path + " at line: " + line + ", in towny\\data\\worlds\\" + world.getName() + ".txt");
@@ -1503,7 +1504,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 
 					line = keys.get("metadata");
 					if (line != null && !line.isEmpty())
-						townBlock.setMetadata(line.trim());
+						MetadataLoader.getInstance().deserializeMetadata(townBlock, line.trim());
 
 					line = keys.get("groupID");
 					UUID groupID = null;
@@ -2034,18 +2035,6 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 
 		return true;
 
-	}
-
-	private String serializeMetadata(TownyObject obj) {
-		if (!obj.hasMeta())
-			return "";
-
-		StringJoiner serializer = new StringJoiner(";");
-		for (CustomDataField<?> cdf : obj.getMetadata()) {
-			serializer.add(cdf.toString());
-		}
-
-		return serializer.toString();
 	}
 
 	/*

--- a/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -14,10 +14,8 @@ import com.palmergames.bukkit.towny.object.PlotGroup;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
-import com.palmergames.bukkit.towny.object.TownyObject;
 import com.palmergames.bukkit.towny.object.TownyWorld;
 import com.palmergames.bukkit.towny.object.WorldCoord;
-import com.palmergames.bukkit.towny.object.metadata.CustomDataField;
 import com.palmergames.bukkit.towny.object.metadata.MetadataLoader;
 import com.palmergames.bukkit.towny.tasks.DeleteFileTask;
 import com.palmergames.bukkit.towny.utils.MapUtil;
@@ -34,7 +32,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.StringJoiner;
 import java.util.UUID;
 
 public final class TownyFlatFileSource extends TownyDatabaseHandler {

--- a/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -21,6 +21,7 @@ import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.TownyWorld;
 import com.palmergames.bukkit.towny.object.WorldCoord;
 import com.palmergames.bukkit.towny.object.metadata.CustomDataField;
+import com.palmergames.bukkit.towny.object.metadata.MetadataLoader;
 import com.palmergames.bukkit.towny.tasks.GatherResidentUUIDTask;
 import com.palmergames.bukkit.towny.utils.MapUtil;
 import com.palmergames.bukkit.util.BukkitTools;
@@ -807,7 +808,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			try {
 				line = rs.getString("metadata");
 				if (line != null && !line.isEmpty()) {
-					resident.setMetadata(line);
+					MetadataLoader.getInstance().deserializeMetadata(resident, line);
 				}
 			} catch (SQLException ignored) {
 			}
@@ -1103,7 +1104,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			try {
 				line = rs.getString("metadata");
 				if (line != null && !line.isEmpty()) {
-					town.setMetadata(line);
+					MetadataLoader.getInstance().deserializeMetadata(town, line);
 				}
 			} catch (SQLException ignored) {
 			}
@@ -1292,7 +1293,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			try {
 				line = rs.getString("metadata");
 				if (line != null && !line.isEmpty()) {
-					nation.setMetadata(line);
+					MetadataLoader.getInstance().deserializeMetadata(nation, line);
 				}
 			} catch (SQLException ignored) {
 			}
@@ -1609,7 +1610,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			try {
 				line = rs.getString("metadata");
 				if (line != null && !line.isEmpty()) {
-					world.setMetadata(line);
+					MetadataLoader.getInstance().deserializeMetadata(world, line);
 				}
 			} catch (SQLException ignored) {
 			}
@@ -1738,7 +1739,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 				try {
 					line = rs.getString("metadata");
 					if (line != null && !line.isEmpty()) {
-						townBlock.setMetadata(line);
+						MetadataLoader.getInstance().deserializeMetadata(townBlock, line);
 					}
 				} catch (SQLException ignored) {
 				}
@@ -1857,7 +1858,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			res_hm.put("protectionStatus", resident.getPermissions().toString().replaceAll(",", "#"));
 
 			if (resident.hasMeta())
-				res_hm.put("metadata", StringMgmt.join(new ArrayList<CustomDataField<?>>(resident.getMetadata()), ";"));
+				res_hm.put("metadata", serializeMetadata(resident));
 			else
 				res_hm.put("metadata", "");
 
@@ -1903,7 +1904,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			twn_hm.put("admindisabledpvp", town.isAdminDisabledPVP());
 			twn_hm.put("adminenabledpvp", town.isAdminEnabledPVP());
 			if (town.hasMeta())
-				twn_hm.put("metadata", StringMgmt.join(town.getMetadata(), ";"));
+				twn_hm.put("metadata", serializeMetadata(town));
 			else
 				twn_hm.put("metadata", "");
 
@@ -2009,7 +2010,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			nat_hm.put("isOpen", nation.isOpen());
 
 			if (nation.hasMeta())
-				nat_hm.put("metadata", StringMgmt.join(nation.getMetadata(), ";"));
+				nat_hm.put("metadata", serializeMetadata(nation));
 			else
 				nat_hm.put("metadata", "");
 
@@ -2119,7 +2120,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			nat_hm.put("warAllowed", world.isWarAllowed());
 
 			if (world.hasMeta())
-				nat_hm.put("metadata", StringMgmt.join(world.getMetadata(), ";"));
+				nat_hm.put("metadata", serializeMetadata(world));
 			else
 				nat_hm.put("metadata", "");
 
@@ -2158,7 +2159,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			else
 				tb_hm.put("groupID", "");
 			if (townBlock.hasMeta())
-				tb_hm.put("metadata", StringMgmt.join(new ArrayList<CustomDataField<?>>(townBlock.getMetadata()), ";"));
+				tb_hm.put("metadata", serializeMetadata(townBlock));
 			else
 				tb_hm.put("metadata", "");
 

--- a/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -20,7 +20,6 @@ import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.TownyWorld;
 import com.palmergames.bukkit.towny.object.WorldCoord;
-import com.palmergames.bukkit.towny.object.metadata.CustomDataField;
 import com.palmergames.bukkit.towny.object.metadata.MetadataLoader;
 import com.palmergames.bukkit.towny.tasks.GatherResidentUUIDTask;
 import com.palmergames.bukkit.towny.utils.MapUtil;

--- a/src/com/palmergames/bukkit/towny/event/LoadedMetadataEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/LoadedMetadataEvent.java
@@ -1,0 +1,28 @@
+package com.palmergames.bukkit.towny.event;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Called when Towny has finished deserializing all metadata.
+ * 
+ * Useful if plugins are relying on metadata in order to load plugin data 
+ * or relying on custom metadata types registered by other plugins.
+ * 
+ * Purely an informative event.
+ */
+public class LoadedMetadataEvent extends Event  {
+	
+	private static final HandlerList handlers = new HandlerList();
+	
+	@NotNull
+	@Override
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
+}

--- a/src/com/palmergames/bukkit/towny/exceptions/InvalidMetadataTypeException.java
+++ b/src/com/palmergames/bukkit/towny/exceptions/InvalidMetadataTypeException.java
@@ -1,11 +1,11 @@
 package com.palmergames.bukkit.towny.exceptions;
 
-import com.palmergames.bukkit.towny.object.metadata.CustomDataFieldType;
+import com.palmergames.bukkit.towny.object.metadata.CustomDataField;
 
 public class InvalidMetadataTypeException extends TownyException {
     private static final long serialVersionUID = 2335936343233569066L;
     
-    public InvalidMetadataTypeException(CustomDataFieldType type) {
-        super("The given string for type " + type.getTypeName() + " is not valid!");
+    public InvalidMetadataTypeException(CustomDataField<?> cdf) {
+        super("The given string for type " + cdf.getClass().getName() + " is not valid!");
     }
 }

--- a/src/com/palmergames/bukkit/towny/object/Nation.java
+++ b/src/com/palmergames/bukkit/towny/object/Nation.java
@@ -20,6 +20,7 @@ import com.palmergames.bukkit.util.BukkitTools;
 import com.palmergames.util.StringMgmt;
 import org.bukkit.Location;
 import org.bukkit.World;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -565,17 +566,13 @@ public class Nation extends Government {
 	}
 	
 	@Override
-	public void addMetaData(CustomDataField<?> md) {
-		super.addMetaData(md);
-
-		this.save();
+	public void addMetaData(@NotNull CustomDataField<?> md) {
+		this.addMetaData(md, true);
 	}
 
 	@Override
-	public void removeMetaData(CustomDataField<?> md) {
-		super.removeMetaData(md);
-
-		this.save();
+	public void removeMetaData(@NotNull CustomDataField<?> md) {
+		this.removeMetaData(md, true);
 	}
 
 	@Override

--- a/src/com/palmergames/bukkit/towny/object/Resident.java
+++ b/src/com/palmergames/bukkit/towny/object/Resident.java
@@ -33,6 +33,7 @@ import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -774,17 +775,13 @@ public class Resident extends TownyObject implements InviteReceiver, EconomyHand
 	}
 
 	@Override
-	public void addMetaData(CustomDataField<?> md) {
-		super.addMetaData(md);
-
-		this.save();
+	public void addMetaData(@NotNull CustomDataField<?> md) {
+		this.addMetaData(md, true);
 	}
 
 	@Override
-	public void removeMetaData(CustomDataField<?> md) {
-		super.removeMetaData(md);
-
-		this.save();
+	public void removeMetaData(@NotNull CustomDataField<?> md) {
+		this.removeMetaData(md, true);
 	}
 
 	@Override

--- a/src/com/palmergames/bukkit/towny/object/Town.java
+++ b/src/com/palmergames/bukkit/towny/object/Town.java
@@ -19,6 +19,7 @@ import com.palmergames.bukkit.util.BukkitTools;
 import com.palmergames.util.StringMgmt;
 import org.bukkit.Location;
 import org.bukkit.World;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1158,16 +1159,13 @@ public class Town extends Government implements TownBlockOwner {
 	}
 	
     @Override
-	public void addMetaData(CustomDataField<?> md) {
-		super.addMetaData(md);
-
-		this.save();
+	public void addMetaData(@NotNull CustomDataField<?> md) {
+		this.addMetaData(md, true);
 	}
 
 	@Override
-	public void removeMetaData(CustomDataField<?> md) {
-		super.removeMetaData(md);
-		this.save();
+	public void removeMetaData(@NotNull CustomDataField<?> md) {
+		this.removeMetaData(md, true);
 	}
 	
 	public void setConquered(boolean conquered) {

--- a/src/com/palmergames/bukkit/towny/object/TownBlock.java
+++ b/src/com/palmergames/bukkit/towny/object/TownBlock.java
@@ -16,6 +16,7 @@ import com.palmergames.bukkit.towny.tasks.CooldownTimerTask.CooldownType;
 
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
@@ -387,15 +388,13 @@ public class TownBlock extends TownyObject {
 	}
 	
 	@Override
-	public void addMetaData(CustomDataField<?> md) {
-		super.addMetaData(md);
-		this.save();
+	public void addMetaData(@NotNull CustomDataField<?> md) {
+		this.addMetaData(md, true);
 	}
 	
 	@Override
-	public void removeMetaData(CustomDataField<?> md) {
-		super.removeMetaData(md);
-		this.save();
+	public void removeMetaData(@NotNull CustomDataField<?> md) {
+		this.removeMetaData(md, true);
 	}
 	
 	public boolean hasPlotObjectGroup() { return plotGroup != null; }

--- a/src/com/palmergames/bukkit/towny/object/TownyObject.java
+++ b/src/com/palmergames/bukkit/towny/object/TownyObject.java
@@ -1,6 +1,10 @@
 package com.palmergames.bukkit.towny.object;
 
+import com.palmergames.annotations.Unmodifiable;
 import com.palmergames.bukkit.towny.object.metadata.CustomDataField;
+import org.apache.commons.lang.Validate;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -52,14 +56,16 @@ public abstract class TownyObject implements Nameable, Savable {
 		return getName();
 	}
 
-	public void addMetaData(CustomDataField<?> md) {
+	public void addMetaData(@NotNull CustomDataField<?> md) {
+		Validate.notNull(md);
 		if (metadata == null)
 			metadata = new HashMap<>();
 		
 		metadata.put(md.getKey(), md);
 	}
 
-	public void removeMetaData(CustomDataField<?> md) {
+	public void removeMetaData(@NotNull CustomDataField<?> md) {
+		Validate.notNull(md);
 		if (!hasMeta())
 			return;
 		
@@ -69,6 +75,7 @@ public abstract class TownyObject implements Nameable, Savable {
 			this.metadata = null;
 	}
 	
+	@Unmodifiable
 	public Collection<CustomDataField<?>> getMetadata() {
 		if (metadata == null || metadata.isEmpty())
 			return Collections.emptyList();
@@ -76,10 +83,29 @@ public abstract class TownyObject implements Nameable, Savable {
 		return Collections.unmodifiableCollection(metadata.values());
 	}
 	
-	public CustomDataField<?> getMetadata(String key) {
+	@Nullable
+	public CustomDataField<?> getMetadata(@NotNull String key) {
+		Validate.notNull(key);
+		
 		if(metadata != null)
 			return metadata.get(key);
 		
+		return null;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Nullable
+	public <T extends CustomDataField<?>> T getMetadata(@NotNull String key, @NotNull Class<T> cdfClass) {
+		Validate.notNull(cdfClass);
+		Validate.notNull(key);
+		
+		if(metadata != null) {
+			CustomDataField<?> cdf = metadata.get(key);
+			if (cdfClass.isInstance(cdf)) {
+				return (T) cdf;
+			}
+		}
+
 		return null;
 	}
 
@@ -87,23 +113,24 @@ public abstract class TownyObject implements Nameable, Savable {
 		return metadata != null;
 	}
 
-	public boolean hasMeta(String key) {
+	public boolean hasMeta(@NotNull String key) {
+		Validate.notNull(key);
 		if (metadata != null)
 			return metadata.containsKey(key);
 		
 		return false;
 	}
+	
+	public <T extends CustomDataField<?>> boolean hasMeta(@NotNull String key, @NotNull Class<T> cdfClass) {
+		Validate.notNull(cdfClass);
+		Validate.notNull(key);
 
-	public void setMetadata(String str) {
-		String[] objects = str.split(";");
-
-		if (metadata == null)
-			metadata = new HashMap<>(objects.length);
-		
-		for (String object : objects) {
-			CustomDataField<?> cdf = CustomDataField.load(object);
-			metadata.put(cdf.getKey(), cdf);
+		if(metadata != null) {
+			CustomDataField<?> cdf = metadata.get(key);
+			return cdfClass.isInstance(cdf);
 		}
+
+		return false;
 	}
 	
 }

--- a/src/com/palmergames/bukkit/towny/object/TownyObject.java
+++ b/src/com/palmergames/bukkit/towny/object/TownyObject.java
@@ -56,10 +56,24 @@ public abstract class TownyObject implements Nameable, Savable {
 		return getName();
 	}
 
+	/**
+	 * Add a specific metadata to this TownyObject.
+	 * Overrides existing metadata of the same key.
+	 * Most implementations will save the object after this method is called.
+	 * 
+	 * @param md CustomDataField to add.
+	 */
 	public void addMetaData(@NotNull CustomDataField<?> md) {
 		this.addMetaData(md, false);
 	}
 
+	/**
+	 * Add a specific metadata to this TownyObject.
+	 * Overrides existing metadata of the same key.
+	 * 
+	 * @param md CustomDataField to add.
+	 * @param save whether to save this object after the metadata is added.
+	 */
 	// Exists to maintain backwards compatibility
 	// DO NOT OVERRIDE THIS METHOD ANYWHERE
 	public void addMetaData(@NotNull CustomDataField<?> md, boolean save) {
@@ -73,10 +87,29 @@ public abstract class TownyObject implements Nameable, Savable {
 			this.save();
 	}
 
+	/**
+	 * Remove a specific metadata from the TownyObject.
+	 * The metadata does not need to be the same instance of the one added,
+	 * but must have the same key.
+	 * Most implementations will save the TownyObject after removing the metadata.
+	 *
+	 * 
+	 * @param md CustomDataField to remove.
+	 */
 	public void removeMetaData(@NotNull CustomDataField<?> md) {
 		this.removeMetaData(md, false);
 	}
 
+	/**
+	 * Remove a specific metadata from the TownyObject.
+	 * The metadata does not need to be the same instance of the one added,
+	 * but must have the same key.
+	 *
+	 * @param md CustomDataField to remove.
+	 * @param save whether to save the object or not after the metadata is removed.
+	 *             
+	 * @return whether the metadata was successfully removed. 
+	 */
 	// Exists to maintain backwards compatibility
 	// DO NOT OVERRIDE THIS METHOD ANYWHERE
 	public boolean removeMetaData(@NotNull CustomDataField<?> md, boolean save) {
@@ -95,7 +128,15 @@ public abstract class TownyObject implements Nameable, Savable {
 		
 		return removed;
 	}
-	
+
+	/**
+	 * A collection of all metadata on the TownyObject.
+	 * This collection cannot be modified.
+	 * 
+	 * Collection reflects current metadata, and is not thread safe.
+	 * 
+	 * @return an unmodifiable collection of all metadata on the object. 
+	 */
 	@Unmodifiable
 	public Collection<CustomDataField<?>> getMetadata() {
 		if (metadata == null || metadata.isEmpty())
@@ -103,7 +144,14 @@ public abstract class TownyObject implements Nameable, Savable {
 		
 		return Collections.unmodifiableCollection(metadata.values());
 	}
-	
+
+	/**
+	 * Fetch the metadata associated with the specific key.
+	 * 
+	 * @param key Key of the metadata to fetch.
+	 *               
+	 * @return the metadata associated with the key or {@code null} if none associated.
+	 */
 	@Nullable
 	public CustomDataField<?> getMetadata(@NotNull String key) {
 		Validate.notNull(key);
@@ -114,6 +162,14 @@ public abstract class TownyObject implements Nameable, Savable {
 		return null;
 	}
 
+	/**
+	 * Fetch the metadata associated with the specific key and class.
+	 * 
+	 * @param key Key of the metadata to fetch.
+	 * @param cdfClass Class of the CustomDataField to fetch.
+	 *
+	 * @return the specific metadata associated with the key and class or {@code null} if none exist.
+	 */
 	@SuppressWarnings("unchecked")
 	@Nullable
 	public <T extends CustomDataField<?>> T getMetadata(@NotNull String key, @NotNull Class<T> cdfClass) {
@@ -130,10 +186,20 @@ public abstract class TownyObject implements Nameable, Savable {
 		return null;
 	}
 
+	/**
+	 * 
+	 * @return whether this object has metadata or not.
+	 */
 	public boolean hasMeta() {
 		return metadata != null;
 	}
 
+	/**
+	 * Check whether metadata associated with the key exists.
+	 * 
+	 * @param key Key of the metadata to check.
+	 * @return whether metadata associated with the key exists.
+	 */
 	public boolean hasMeta(@NotNull String key) {
 		Validate.notNull(key);
 		if (metadata != null)
@@ -141,7 +207,15 @@ public abstract class TownyObject implements Nameable, Savable {
 		
 		return false;
 	}
-	
+
+	/**
+	 * Check whether metadata associated with the given key and class exists.
+	 * 
+	 * @param key Key of the metadata to check
+	 * @param cdfClass Class extending CustomDataField to check.
+	 * 
+	 * @return whether metadata associated with the key and class exists.
+	 */
 	public <T extends CustomDataField<?>> boolean hasMeta(@NotNull String key, @NotNull Class<T> cdfClass) {
 		Validate.notNull(cdfClass);
 		Validate.notNull(key);

--- a/src/com/palmergames/bukkit/towny/object/TownyObject.java
+++ b/src/com/palmergames/bukkit/towny/object/TownyObject.java
@@ -57,22 +57,43 @@ public abstract class TownyObject implements Nameable, Savable {
 	}
 
 	public void addMetaData(@NotNull CustomDataField<?> md) {
+		this.addMetaData(md, false);
+	}
+
+	// Exists to maintain backwards compatibility
+	// DO NOT OVERRIDE THIS METHOD ANYWHERE
+	public void addMetaData(@NotNull CustomDataField<?> md, boolean save) {
 		Validate.notNull(md);
 		if (metadata == null)
 			metadata = new HashMap<>();
-		
+
 		metadata.put(md.getKey(), md);
+		
+		if (save) 
+			this.save();
 	}
 
 	public void removeMetaData(@NotNull CustomDataField<?> md) {
+		this.removeMetaData(md, false);
+	}
+
+	// Exists to maintain backwards compatibility
+	// DO NOT OVERRIDE THIS METHOD ANYWHERE
+	public boolean removeMetaData(@NotNull CustomDataField<?> md, boolean save) {
 		Validate.notNull(md);
 		if (!hasMeta())
-			return;
-		
-		metadata.remove(md.getKey());
-		
+			return false;
+
+		final boolean removed = metadata.remove(md.getKey()) != null;
+
 		if (metadata.isEmpty())
 			this.metadata = null;
+		
+		// Only save if the element was actually removed
+		if (save && removed)
+			this.save();
+		
+		return removed;
 	}
 	
 	@Unmodifiable

--- a/src/com/palmergames/bukkit/towny/object/TownyWorld.java
+++ b/src/com/palmergames/bukkit/towny/object/TownyWorld.java
@@ -12,6 +12,7 @@ import com.palmergames.util.MathUtil;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -796,17 +797,13 @@ public class TownyWorld extends TownyObject {
 	}
 
 	@Override
-	public void addMetaData(CustomDataField<?> md) {
-		super.addMetaData(md);
-
-		this.save();
+	public void addMetaData(@NotNull CustomDataField<?> md) {
+		this.addMetaData(md, true);
 	}
 
 	@Override
-	public void removeMetaData(CustomDataField<?> md) {
-		super.removeMetaData(md);
-
-		this.save();
+	public void removeMetaData(@NotNull CustomDataField<?> md) {
+		this.removeMetaData(md, true);
 	}
 	
 	/**

--- a/src/com/palmergames/bukkit/towny/object/metadata/BooleanDataField.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/BooleanDataField.java
@@ -18,6 +18,15 @@ public class BooleanDataField extends CustomDataField<Boolean> {
     }
 
 	@Override
+	protected String getTypeID() {
+		return typeID();
+	}
+	
+	public static String typeID() {
+    	return "towny_booldf";
+	}
+
+	@Override
 	public void setValueFromString(String strValue) {
 		setValue(Boolean.parseBoolean(strValue));
 	}

--- a/src/com/palmergames/bukkit/towny/object/metadata/BooleanDataField.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/BooleanDataField.java
@@ -5,20 +5,20 @@ import com.palmergames.bukkit.util.Colors;
 public class BooleanDataField extends CustomDataField<Boolean> {
     
     public BooleanDataField(String key, Boolean value) {
-        super(key, CustomDataFieldType.BooleanField, value);
+        super(key, value);
     }
     
     public BooleanDataField(String key, Boolean value, String label) {
-    	super(key, CustomDataFieldType.BooleanField, value, label);
+    	super(key, value, label);
 	}
     
     public BooleanDataField(String key) {
         // Initialized to false
-        super(key, CustomDataFieldType.BooleanField, false);
+        super(key, false);
     }
 
 	@Override
-	protected String getTypeID() {
+	public String getTypeID() {
 		return typeID();
 	}
 	

--- a/src/com/palmergames/bukkit/towny/object/metadata/CustomDataField.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/CustomDataField.java
@@ -35,6 +35,8 @@ public abstract class CustomDataField<T> implements Cloneable {
     public CustomDataFieldType getType() {
         return type;
     }
+    
+    protected abstract String getTypeID();
 
     public T getValue() {
         
@@ -48,6 +50,10 @@ public abstract class CustomDataField<T> implements Cloneable {
     }
     
     public abstract void setValueFromString(String strValue);
+    
+    protected String serializeValueToString() {
+    	return String.valueOf(getValue());
+	}
 
     public String getKey() {
         return key;

--- a/src/com/palmergames/bukkit/towny/object/metadata/CustomDataField.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/CustomDataField.java
@@ -1,6 +1,8 @@
 package com.palmergames.bukkit.towny.object.metadata;
 
 import com.palmergames.bukkit.towny.exceptions.InvalidMetadataTypeException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public abstract class CustomDataField<T> implements Cloneable {
     private T value;
@@ -29,8 +31,16 @@ public abstract class CustomDataField<T> implements Cloneable {
     {
         this(key, null, null);
     }
-    
-    public abstract String getTypeID();
+
+	/**
+	 * Gets the type id for the given CustomDataField class. 
+	 * This value is attached to the class, and not a specific instance. 
+	 * Used for serialization purposes. 
+	 * 
+	 * @return type id of the given CustomDataField class.
+	 */
+	@NotNull
+	public abstract String getTypeID();
 
     public T getValue() {
         
@@ -40,13 +50,27 @@ public abstract class CustomDataField<T> implements Cloneable {
     public void setValue(T value) {
         this.value = value;
     }
-    
-    public abstract void setValueFromString(String strValue);
-    
-    protected String serializeValueToString() {
+
+	/**
+	 * Sets the value based on the given input.
+	 * Used when admins want to edit metadata in-game.
+	 * 
+	 * @param strValue input.
+	 */
+	public abstract void setValueFromString(String strValue);
+
+	/**
+	 * Serializes the current value to a string. 
+	 * Used for saving the CustomDataField object.
+	 * 
+	 * @return serialized string
+	 */
+	@Nullable
+	protected String serializeValueToString() {
     	return String.valueOf(getValue());
 	}
 
+	@NotNull
     public String getKey() {
         return key;
     }
@@ -55,6 +79,7 @@ public abstract class CustomDataField<T> implements Cloneable {
     	return hasLabel();
 	}
     
+	@NotNull
     public String getLabel() {
     	if (hasLabel())
     		return label;
@@ -90,7 +115,14 @@ public abstract class CustomDataField<T> implements Cloneable {
         return out;
     }
 
-    // Overridable validation function
+	/**
+	 * Determines whether the given input can be parsed to the appropriate value.
+	 * Used to parse admin input for in-game metadata editing.
+	 * 
+	 * @param strValue admin input
+	 * @return whether the string can be parsed or not
+	 */
+	// Overridable validation function
 	protected boolean canParseFromString(String strValue) {
     	return true;
 	}
@@ -120,6 +152,7 @@ public abstract class CustomDataField<T> implements Cloneable {
         return getKey().hashCode();
     }
     
+    @NotNull
     public abstract CustomDataField<T> clone();
     
 	/**

--- a/src/com/palmergames/bukkit/towny/object/metadata/CustomDataField.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/CustomDataField.java
@@ -3,40 +3,34 @@ package com.palmergames.bukkit.towny.object.metadata;
 import com.palmergames.bukkit.towny.exceptions.InvalidMetadataTypeException;
 
 public abstract class CustomDataField<T> implements Cloneable {
-    private final CustomDataFieldType type;
     private T value;
     private final String key;
     
     protected String label;
     
-    public CustomDataField(String key, CustomDataFieldType type, T value, String label)
+    public CustomDataField(String key, T value, String label)
     {
-        this.type = type;
         this.setValue(value);
         this.key = key;
         this.label = label;
     }
 
-	public CustomDataField(String key, CustomDataFieldType type, T value)
+	public CustomDataField(String key, T value)
 	{
-		this(key, type, value, null);
+		this(key, value, null);
 	}
 
-	public CustomDataField(String key, CustomDataFieldType type, String label)
+	public CustomDataField(String key, String label)
 	{
-		this(key, type, null, label);
+		this(key, null, label);
 	}
 
-    public CustomDataField(String key, CustomDataFieldType type)
+    public CustomDataField(String key)
     {
-        this(key, type, null, null);
-    }
-
-    public CustomDataFieldType getType() {
-        return type;
+        this(key, null, null);
     }
     
-    protected abstract String getTypeID();
+    public abstract String getTypeID();
 
     public T getValue() {
         
@@ -74,12 +68,13 @@ public abstract class CustomDataField<T> implements Cloneable {
 		this.label = label;
 	}
 
+	// Not used for serialization anymore. Just for human readable format.
 	@Override
     public String toString() {
         String out = "";
         
         // Type
-        out += type.getValue().toString();
+        out += getTypeID();
         
         // Key
         out += "," + getKey();
@@ -93,48 +88,6 @@ public abstract class CustomDataField<T> implements Cloneable {
         return out;
     }
 
-	/**
-	 * @param str - The metadata string to load
-	 * @return - The data field defined by the string
-	 */
-    public static CustomDataField<?> load(String str) {
-        String[] tokens = str.split(",");
-        CustomDataFieldType type = CustomDataFieldType.fromValue(Integer.parseInt(tokens[0]));
-        String key = tokens[1];
-        CustomDataField<?> field = null;
-        
-        switch (type) {
-            case IntegerField:
-                field = new IntegerDataField(key);
-                break;
-            case StringField:
-                field = new StringDataField(key);
-                break;
-            case BooleanField:
-                field = new BooleanDataField(key);
-                break;
-            case DecimalField:
-                field = new DecimalDataField(key);
-                break;
-			case LongField:
-				field = new LongDataField(key);
-				break;
-        }
-        
-        if (field.canParseFromString(tokens[2]))
-        	field.setValueFromString(tokens[2]);
-        
-		String label;
-		if (tokens[3] == null || tokens[3].equalsIgnoreCase("nil"))
-			label = null;
-		else
-			label = tokens[3];
-        
-		field.setLabel(label);
-		
-        return field;
-    }
-
     // Overridable validation function
 	protected boolean canParseFromString(String strValue) {
     	return true;
@@ -142,7 +95,7 @@ public abstract class CustomDataField<T> implements Cloneable {
 	
 	public final void isValidType(String str) throws InvalidMetadataTypeException {
     	if (!canParseFromString(str))
-    		throw new InvalidMetadataTypeException(this.type);
+    		throw new InvalidMetadataTypeException(this);
 	}
 
 	/**

--- a/src/com/palmergames/bukkit/towny/object/metadata/CustomDataField.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/CustomDataField.java
@@ -38,8 +38,6 @@ public abstract class CustomDataField<T> implements Cloneable {
     }
 
     public void setValue(T value) {
-        // TODO: Save to yml
-        
         this.value = value;
     }
     
@@ -52,6 +50,10 @@ public abstract class CustomDataField<T> implements Cloneable {
     public String getKey() {
         return key;
     }
+    
+    public boolean shouldDisplayInStatus() {
+    	return hasLabel();
+	}
     
     public String getLabel() {
     	if (hasLabel())

--- a/src/com/palmergames/bukkit/towny/object/metadata/DataFieldDeserializer.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/DataFieldDeserializer.java
@@ -1,0 +1,12 @@
+package com.palmergames.bukkit.towny.object.metadata;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@FunctionalInterface
+public interface DataFieldDeserializer<T extends CustomDataField<?>> {
+	
+	@Nullable
+	T deserialize(@NotNull String key, @Nullable String value);
+	
+}

--- a/src/com/palmergames/bukkit/towny/object/metadata/DataFieldDeserializer.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/DataFieldDeserializer.java
@@ -3,9 +3,24 @@ package com.palmergames.bukkit.towny.object.metadata;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Functional interface for deserializing a specific CustomDataField class.
+ * 
+ * @param <T> Specific CustomDataField class to deserialize.
+ */
 @FunctionalInterface
 public interface DataFieldDeserializer<T extends CustomDataField<?>> {
-	
+
+	/**
+	 * Returns a new class that extends CustomDataField given a key and string value.
+	 * If this method returns {@code null}, the specific metadata with this key and value will
+	 * not be loaded and skipped.
+	 * 
+	 * @param key Key for the CustomDataField
+	 * @param value String value for the CustomDataField which can be {@code null}.
+	 *                 
+	 * @return the deserialized CustomDataField class.
+	 */
 	@Nullable
 	T deserialize(@NotNull String key, @Nullable String value);
 	

--- a/src/com/palmergames/bukkit/towny/object/metadata/DataFieldIO.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/DataFieldIO.java
@@ -1,0 +1,93 @@
+package com.palmergames.bukkit.towny.object.metadata;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public class DataFieldIO {
+	
+	public static String serializeCDFs(Collection<CustomDataField<?>> cdfs) {
+		if (cdfs.isEmpty())
+			return "";
+		
+		JsonArray array = new JsonArray();
+		for (CustomDataField<?> cdf : cdfs) {
+			JsonArray serializedArray = serializeCDF(cdf);
+			array.add(serializedArray);
+		}
+		
+		return array.toString();
+	}
+	
+	private static JsonArray serializeCDF(CustomDataField<?> cdf) {
+		JsonArray array = new JsonArray();
+		array.add(cdf.getTypeID());
+		array.add(cdf.getKey());
+		array.add(cdf.serializeValueToString());
+		if (cdf.hasLabel())
+			array.add(cdf.getLabel());
+		else
+			array.add(JsonNull.INSTANCE);
+		
+		return array;
+	}
+	
+	private static JsonArray convertToArray(String metadata) throws IOException {
+		try {
+			JsonElement element = new JsonParser().parse(metadata);
+
+			if (!element.isJsonArray())
+				throw new IOException("Metadata cannot be read as a JSON Array!");
+
+			return element.getAsJsonArray();
+		} catch (JsonSyntaxException jse) {
+			// Just throw an IOException for everything
+			throw new IOException(jse.getMessage(), jse.getCause());
+		}
+	}
+	
+	public static Collection<CustomDataField<?>> deserializeMeta(String metadata, Map<String, DataFieldDeserializer<?>> deserializerMap) throws IOException {
+		JsonArray array = convertToArray(metadata);
+		List<CustomDataField<?>> cdfList = new ArrayList<>(array.size());
+		for (JsonElement element : array) {
+			if (!element.isJsonArray())
+				continue;
+			
+			JsonArray cdfArray = element.getAsJsonArray();
+			if (cdfArray.size() < 2)
+				continue;
+			
+			String typeID = cdfArray.get(0).getAsString();
+			CustomDataField<?> cdf = deserializeCDF(cdfArray, deserializerMap.get(typeID));
+			if (cdf != null)
+				cdfList.add(cdf);
+		}
+		
+		return cdfList;
+	}
+	
+	private static <T extends CustomDataField<?>> T deserializeCDF(JsonArray array, DataFieldDeserializer<T> deserializer) {
+		if (deserializer == null)
+			return null;
+		
+		final String key = array.get(1).getAsString();
+		final String value = array.get(2).isJsonNull() ? null : array.get(2).getAsString();
+		final String label = array.get(3).isJsonNull() ? null : array.get(3).getAsString();
+		
+		T cdf = deserializer.deserialize(key, value);
+		
+		if (cdf != null && label != null)
+			cdf.setLabel(label);
+		
+		return cdf;
+	}
+	
+}

--- a/src/com/palmergames/bukkit/towny/object/metadata/DataFieldIO.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/DataFieldIO.java
@@ -37,10 +37,8 @@ public class DataFieldIO {
 		else
 			array.add(JsonNull.INSTANCE);
 		
-		final String label = cdf.getLabel();
-		// RawDataFields return false for hasLabel regardless, so do a null check instead.
-		if (label != null)
-			array.add(label);
+		if (cdf.hasLabel())
+			array.add(cdf.getLabel());
 		
 		return array;
 	}

--- a/src/com/palmergames/bukkit/towny/object/metadata/DecimalDataField.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/DecimalDataField.java
@@ -16,6 +16,15 @@ public class DecimalDataField extends CustomDataField<Double> {
     }
 
 	@Override
+	protected String getTypeID() {
+		return typeID();
+	}
+	
+	public static String typeID() {
+    	return "towny_decdf";
+	}
+
+	@Override
 	public void setValueFromString(String strValue) {
     	setValue(Double.parseDouble(strValue));
 	}

--- a/src/com/palmergames/bukkit/towny/object/metadata/DecimalDataField.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/DecimalDataField.java
@@ -4,19 +4,19 @@ import com.palmergames.bukkit.util.Colors;
 
 public class DecimalDataField extends CustomDataField<Double> {
     public DecimalDataField(String key, Double value) {
-        super(key, CustomDataFieldType.DecimalField, value);
+        super(key, value);
     }
 
 	public DecimalDataField(String key, Double value, String label) {
-		super(key, CustomDataFieldType.DecimalField, value, label);
+		super(key, value, label);
 	}
 
     public DecimalDataField(String key) {
-        super(key, CustomDataFieldType.DecimalField, 0.0);
+        super(key, 0.0);
     }
 
 	@Override
-	protected String getTypeID() {
+	public String getTypeID() {
 		return typeID();
 	}
 	

--- a/src/com/palmergames/bukkit/towny/object/metadata/IntegerDataField.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/IntegerDataField.java
@@ -19,6 +19,15 @@ public class IntegerDataField extends CustomDataField<Integer> {
     }
 
 	@Override
+	protected String getTypeID() {
+		return typeID();
+	}
+	
+	public static String typeID() {
+		return "towny_intdf";
+	}
+
+	@Override
 	public void setValueFromString(String strValue) {
 		setValue(Integer.parseInt(strValue));
 	}

--- a/src/com/palmergames/bukkit/towny/object/metadata/IntegerDataField.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/IntegerDataField.java
@@ -6,20 +6,20 @@ public class IntegerDataField extends CustomDataField<Integer> {
     
     // Initializes default value to zero.
     public IntegerDataField(String key) {
-        super(key, CustomDataFieldType.IntegerField);
+        super(key);
     }
 
 	public IntegerDataField(String key, Integer value, String label) {
-		super(key, CustomDataFieldType.IntegerField, value, label);
+		super(key, value, label);
 	}
     
     // Allow for initialization with default value provided.
     public IntegerDataField(String key, Integer value) {
-        super(key, CustomDataFieldType.IntegerField, value);
+        super(key, value);
     }
 
 	@Override
-	protected String getTypeID() {
+	public String getTypeID() {
 		return typeID();
 	}
 	

--- a/src/com/palmergames/bukkit/towny/object/metadata/LongDataField.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/LongDataField.java
@@ -17,6 +17,15 @@ public class LongDataField extends CustomDataField<Long> {
 	}
 
 	@Override
+	protected String getTypeID() {
+		return typeID();
+	}
+	
+	public static String typeID() {
+		return "towny_longdf";
+	}
+
+	@Override
 	public void setValueFromString(String strValue) {
 		setValue(Long.parseLong(strValue));
 	}

--- a/src/com/palmergames/bukkit/towny/object/metadata/LongDataField.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/LongDataField.java
@@ -5,11 +5,11 @@ import com.palmergames.bukkit.util.Colors;
 public class LongDataField extends CustomDataField<Long> {
 
 	public LongDataField(String key, Long value) {
-		super(key, CustomDataFieldType.LongField, value);
+		super(key, value);
 	}
 
 	public LongDataField(String key, Long value, String label) {
-		super(key, CustomDataFieldType.LongField, value, label);
+		super(key, value, label);
 	}
 	
 	public LongDataField(String key) {
@@ -17,7 +17,7 @@ public class LongDataField extends CustomDataField<Long> {
 	}
 
 	@Override
-	protected String getTypeID() {
+	public String getTypeID() {
 		return typeID();
 	}
 	

--- a/src/com/palmergames/bukkit/towny/object/metadata/MetadataLoader.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/MetadataLoader.java
@@ -1,0 +1,89 @@
+package com.palmergames.bukkit.towny.object.metadata;
+
+import com.palmergames.bukkit.towny.Towny;
+import com.palmergames.bukkit.towny.object.TownyObject;
+import org.bukkit.Bukkit;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+public class MetadataLoader {
+	
+	private static class ObjectMetadata {
+		private final TownyObject object;
+		private final String serializedMetadata;
+		
+		private ObjectMetadata(TownyObject obj, String metadata) {
+			this.object = obj;
+			this.serializedMetadata = metadata;
+		}
+	}
+	
+	private static final MetadataLoader instance = new MetadataLoader();
+	
+	public static MetadataLoader getInstance() {
+		return instance;
+	}
+	
+	
+	Map<String, DataFieldDeserializer<?>> deserializerMap = new HashMap<>();
+	ArrayList<ObjectMetadata> storedMetadata = new ArrayList<>();
+	
+	
+	private MetadataLoader() {
+		
+		// Register Towny Datafields
+		deserializerMap.put(IntegerDataField.typeID(), TownyCDFDeserializer.INTEGER_DF);
+		deserializerMap.put(StringDataField.typeID(), TownyCDFDeserializer.STRING_DF);
+		deserializerMap.put(BooleanDataField.typeID(), TownyCDFDeserializer.BOOLEAN_DF);
+		deserializerMap.put(DecimalDataField.typeID(), TownyCDFDeserializer.DECIMAL_DF);
+		deserializerMap.put(LongDataField.typeID(), TownyCDFDeserializer.LONG_DF);
+	}
+	
+	
+	public boolean registerDeserializer(String typeID, DataFieldDeserializer<?> deserializer) {
+		if (deserializerMap.containsKey(typeID))
+			return false;
+		
+		deserializerMap.put(typeID, deserializer);
+		return true;
+	}
+
+	public void deserializeMetadata(TownyObject object, String serializedMetadata) {
+		storedMetadata.add(new ObjectMetadata(object, serializedMetadata));
+	}
+	
+	public void scheduleDeserialization() {
+		Bukkit.getScheduler().runTask(Towny.getPlugin(), this::runDeserialization);
+	}
+	
+	private void runDeserialization() {
+		if (storedMetadata.isEmpty())
+			return;
+		
+		for (ObjectMetadata storedMeta : storedMetadata) {
+			try {
+				Collection<CustomDataField<?>> fields = DataFieldIO.deserializeMeta(
+					storedMeta.serializedMetadata, deserializerMap
+				);
+
+				for (CustomDataField<?> cdf : fields) {
+					storedMeta.object.addMetaData(cdf);
+				}
+			} catch (IOException ex) {
+				// TODO Throw Error
+			}
+		}
+		storedMetadata.clear();
+		// Reduce memory alloc after load.
+		storedMetadata.trimToSize();
+	}
+	
+	
+	
+	
+	
+}

--- a/src/com/palmergames/bukkit/towny/object/metadata/MetadataLoader.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/MetadataLoader.java
@@ -1,6 +1,7 @@
 package com.palmergames.bukkit.towny.object.metadata;
 
 import com.palmergames.bukkit.towny.Towny;
+import com.palmergames.bukkit.towny.event.LoadedMetadataEvent;
 import com.palmergames.bukkit.towny.object.TownyObject;
 import org.bukkit.Bukkit;
 
@@ -131,6 +132,9 @@ public class MetadataLoader {
 		storedMetadata.clear();
 		// Reduce memory alloc after load.
 		storedMetadata.trimToSize();
+		
+		// Call event
+		Bukkit.getPluginManager().callEvent(new LoadedMetadataEvent());
 	}
 	
 	private CustomDataField<?> convertRawMetadata(RawDataField rdf) {

--- a/src/com/palmergames/bukkit/towny/object/metadata/MetadataLoader.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/MetadataLoader.java
@@ -33,8 +33,14 @@ public class MetadataLoader {
 		deserializerMap.put(DecimalDataField.typeID(), TownyCDFDeserializer.DECIMAL_DF);
 		deserializerMap.put(LongDataField.typeID(), TownyCDFDeserializer.LONG_DF);
 	}
-	
-	
+
+	/**
+	 * Register a deserializer for a specific custom CustomDataField class.
+	 * @param typeID type id of the CustomDataField class to deserialize.
+	 * @param deserializer actual deserializer for the class.
+	 *                        
+	 * @return whether or not the deserializer was registered.
+	 */
 	public boolean registerDeserializer(String typeID, DataFieldDeserializer<?> deserializer) {
 		if (deserializerMap.containsKey(typeID))
 			return false;

--- a/src/com/palmergames/bukkit/towny/object/metadata/MetadataLoader.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/MetadataLoader.java
@@ -100,10 +100,9 @@ public class MetadataLoader {
 				
 				if (deserializedCDF == null)
 					continue;
-
-				final String label = rdf.getLabel();
-				if (label != null)
-					deserializedCDF.setLabel(label);
+				
+				if (rdf.hasLabel())
+					deserializedCDF.setLabel(rdf.getLabel());
 				
 				deserializedFields.add(deserializedCDF);
 			}

--- a/src/com/palmergames/bukkit/towny/object/metadata/RawDataField.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/RawDataField.java
@@ -30,16 +30,10 @@ class RawDataField extends CustomDataField<String> {
 		return "UNLOADED - " + getValue();
 	}
 
-	// Never display a RawDataField on the status board of an object. 
+	// Never display a RawDataField on the status board of an object.
 	@Override
-	public boolean hasLabel() {
+	public boolean shouldDisplayInStatus() {
 		return false;
-	}
-
-	// Return the raw label which can actually be a null value.
-	@Override
-	public String getLabel() {
-		return label;
 	}
 
 	@Override

--- a/src/com/palmergames/bukkit/towny/object/metadata/RawDataField.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/RawDataField.java
@@ -1,0 +1,49 @@
+package com.palmergames.bukkit.towny.object.metadata;
+
+// This class represents unparsed metadata. 
+// Only exists if no plugin deserializers their metadata, 
+class RawDataField extends CustomDataField<String> {
+	private final String typeID;
+	
+	RawDataField(String typeID, String key, String value, String label) {
+		super(key, value, label);
+		this.typeID = typeID;
+	}
+
+	@Override
+	public String getTypeID() {
+		return typeID;
+	}
+
+	@Override
+	protected boolean canParseFromString(String strValue) {
+		return false;
+	}
+
+	@Override
+	public void setValueFromString(String strValue) {
+		setValue(strValue);
+	}
+
+	@Override
+	public String displayFormattedValue() {
+		return "UNLOADED - " + getValue();
+	}
+
+	// Never display a RawDataField on the status board of an object. 
+	@Override
+	public boolean hasLabel() {
+		return false;
+	}
+
+	// Return the raw label which can actually be a null value.
+	@Override
+	public String getLabel() {
+		return label;
+	}
+
+	@Override
+	public RawDataField clone() {
+		return new RawDataField(typeID, getKey(), getValue(), getLabel());
+	}
+}

--- a/src/com/palmergames/bukkit/towny/object/metadata/StringDataField.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/StringDataField.java
@@ -17,6 +17,15 @@ public class StringDataField extends CustomDataField<String> {
     }
 
 	@Override
+	protected String getTypeID() {
+		return typeID();
+	}
+	
+	public static String typeID() {
+    	return "towny_stringdf";
+	}
+
+	@Override
 	public void setValueFromString(String strValue) {
 		setValue(strValue);
 	}

--- a/src/com/palmergames/bukkit/towny/object/metadata/StringDataField.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/StringDataField.java
@@ -5,19 +5,19 @@ import com.palmergames.bukkit.util.Colors;
 public class StringDataField extends CustomDataField<String> {
 
     public StringDataField(String key) {
-        super(key, CustomDataFieldType.StringField);
+        super(key);
     }
 
 	public StringDataField(String key, String value, String label) {
-		super(key, CustomDataFieldType.StringField, value, label);
+		super(key, value, label);
 	}
     
     public StringDataField(String key, String value) {
-        super(key, CustomDataFieldType.StringField, value, null);
+        super(key, value, null);
     }
 
 	@Override
-	protected String getTypeID() {
+	public String getTypeID() {
 		return typeID();
 	}
 	

--- a/src/com/palmergames/bukkit/towny/object/metadata/TownyCDFDeserializer.java
+++ b/src/com/palmergames/bukkit/towny/object/metadata/TownyCDFDeserializer.java
@@ -1,0 +1,27 @@
+package com.palmergames.bukkit.towny.object.metadata;
+
+public class TownyCDFDeserializer {
+	
+	private static <T extends CustomDataField<?>> T deserializeDF(T cdf, String value) {
+		if (value != null && cdf.canParseFromString(value))
+			cdf.setValueFromString(value);
+		
+		return cdf;
+	} 
+	
+	static final DataFieldDeserializer<IntegerDataField> INTEGER_DF = 
+		(key, value) -> deserializeDF(new IntegerDataField(key), value);
+
+	static final DataFieldDeserializer<BooleanDataField> BOOLEAN_DF =
+		(key, value) -> deserializeDF(new BooleanDataField(key), value);
+
+	static final DataFieldDeserializer<StringDataField> STRING_DF =
+		(key, value) -> deserializeDF(new StringDataField(key), value);
+
+	static final DataFieldDeserializer<DecimalDataField> DECIMAL_DF =
+		(key, value) -> deserializeDF(new DecimalDataField(key), value);
+
+	static final DataFieldDeserializer<LongDataField> LONG_DF =
+		(key, value) -> deserializeDF(new LongDataField(key), value);
+	
+}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This is the last phase of metadata improvements. It allows for plugins to create and store their own custom metadata types.  It also changes how metadata is stored. Metadata is now stored as a JSON array of arrays. The reason for this is so that type ids, keys, values, and labels have no serialization restrictions. Previously, if any of those contained a `,` or `;`, then it would break. 

There is also some new useful API. Instead of fetching metadata by key and then having to check the type in two separate steps it can be done as one. E.g. To fetch an `IntegerDataField` meta with the key "kills", you can do `townyobject.getMetadata("kills", IntegerDataField.class)`.

The way to create a custom metadata type is pretty simple. A developer just needs to create a new class extending `CustomDataField` and then register a new `DataFieldDeserializer` on the `MetadataLoader`. 

To demonstrate, let's suppose I want to create a new field type for storing a UUID List. I'll call this `UUIDListDataField`. 
First, I create a class that extends `CustomDataField`
```java
public class UUIDListDataField extends CustomDataField<List<UUID>> {

    public UUIDListDataField (String key) {
        super(key, new ArrayList<>());
    }

        public UUIDListDataField (String key, List<UUID> value) {
            super(key, value);
        }

	@Override
	protected String getTypeID() {
		return typeID();
	}
	
        // The static function is not required, it's just convenient to get the type id when registering.
	public static String typeID() {
    	    return "plugin_uuidlistdf"; // "plugin" should be the plugin name.
	}

	@Override
	public void setValueFromString(String strValue) {
		... // Allow admins to set values from strings
	}

	@Override
	public String displayFormattedValue() {
		... // Choose how to display the value.
	}

        public String serializeValueToString() {
            return StringUtil.join(getValue(), ","); // Separate the UUIDs with commas or whatever
        }

	@Override
	public CustomDataField<List<UUID>> clone() {
		return new UUIDListDataField(getKey(), getValue(), this.label);
	}
}
```
Next, I register a deserializer for the class in my onEnable:
```java
   // In the plugin's onEnable()
   MetadataLoader.getInstance().registerDeserializer(UUIDListDataField.typeID(), 
   (key, value) -> {
       List<UUID> uuids = parseUUIDsFromString(); // Load the UUIDs
       return new UUIDListDataField(key, uuids);
   });
```

That's it!
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
