### PR TITLE
Added fix to explode listener to deal with Cannons

### DIFF
--- a/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
@@ -704,8 +704,13 @@ public class TownyEntityListener implements Listener {
 			return;
 		}
 
-		if (!TownyAPI.getInstance().isTownyWorld(event.getEntity().getWorld()))
-			return;
+		if(event.getEntity() != null) {
+			if (!TownyAPI.getInstance().isTownyWorld(event.getEntity().getWorld()))
+				return;
+		} else {
+			if (!TownyAPI.getInstance().isTownyWorld(event.getLocation().getWorld()))
+				return;
+		}
 
 		TownyWorld townyWorld = null;
 		try {


### PR DESCRIPTION
#### Description: 
- With the latest Cannons plugin version 2.5.8, and Towny 0.96.7.0, Towny allows cannon balls to destroy blocks inside towns, and throws a null pointer exception
- The reason is that Towny is expecting an Entity it the EntityExplodeEvent, but Cannons is not sending it
- However it is sending a Location
- In this PR I fix the issue by having Towny check for an Entity. If its not found, it picks up the location

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Towny Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
