### PR TITLE
Add event for the calculation of town map color

### DIFF
--- a/src/com/palmergames/bukkit/towny/event/town/TownMapColourCalculationEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/town/TownMapColourCalculationEvent.java
@@ -1,0 +1,43 @@
+package com.palmergames.bukkit.towny.event.town;
+
+import com.palmergames.bukkit.towny.object.Town;
+import org.bukkit.Bukkit;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Event called whenever town map color is being calculated
+ */
+public class TownMapColourCalculationEvent extends Event {
+	private static final HandlerList handlers = new HandlerList();
+
+	private final Town town;
+	private String mapColorHexCode;
+
+	public TownMapColourCalculationEvent(Town town, String mapColorHexCode) {
+		super(!Bukkit.getServer().isPrimaryThread());
+		this.town = town;
+		this.mapColorHexCode = mapColorHexCode;
+	}
+
+	public Town getTown() {
+		return town;
+	}
+
+	public String getMapColorHexCode() {
+		return mapColorHexCode;
+	}
+
+	private void setMapColorHexCode(String mapColorHexCode) {
+		this.mapColorHexCode = mapColorHexCode;
+	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
+
+	@Override
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+}

--- a/src/com/palmergames/bukkit/towny/event/town/TownMapColourCalculationEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/town/TownMapColourCalculationEvent.java
@@ -4,6 +4,7 @@ import com.palmergames.bukkit.towny.object.Town;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Event called whenever town map color is being calculated
@@ -24,6 +25,7 @@ public class TownMapColourCalculationEvent extends Event {
 		return town;
 	}
 
+	@Nullable
 	public String getMapColorHexCode() {
 		return mapColorHexCode;
 	}

--- a/src/com/palmergames/bukkit/towny/object/Town.java
+++ b/src/com/palmergames/bukkit/towny/object/Town.java
@@ -1330,6 +1330,7 @@ public class Town extends Government implements TownBlockOwner {
 		return ruinedTime;
 	}
 
+	@Nullable 
 	public String getMapColorHexCode() {
 		String rawMapColorHexCode = hasNation() ? nation.getMapColorHexCode() : null;
 		TownMapColourCalculationEvent event = new TownMapColourCalculationEvent(this, rawMapColorHexCode);

--- a/src/com/palmergames/bukkit/towny/object/Town.java
+++ b/src/com/palmergames/bukkit/towny/object/Town.java
@@ -7,6 +7,7 @@ import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.event.NationAddTownEvent;
 import com.palmergames.bukkit.towny.event.NationRemoveTownEvent;
+import com.palmergames.bukkit.towny.event.town.TownMapColourCalculationEvent;
 import com.palmergames.bukkit.towny.exceptions.AlreadyRegisteredException;
 import com.palmergames.bukkit.towny.exceptions.EconomyException;
 import com.palmergames.bukkit.towny.exceptions.EmptyNationException;
@@ -19,6 +20,7 @@ import com.palmergames.bukkit.towny.permissions.TownyPerms;
 import com.palmergames.bukkit.util.BukkitTools;
 import com.palmergames.util.MathUtil;
 import com.palmergames.util.StringMgmt;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.jetbrains.annotations.NotNull;
@@ -1326,6 +1328,13 @@ public class Town extends Government implements TownBlockOwner {
 	
 	public long getRuinedTime() {
 		return ruinedTime;
+	}
+
+	public String getMapColorHexCode() {
+		String rawMapColorHexCode = hasNation() ? nation.getMapColorHexCode() : null;
+		TownMapColourCalculationEvent event = new TownMapColourCalculationEvent(this, rawMapColorHexCode);
+		Bukkit.getPluginManager().callEvent(event);
+		return event.getMapColorHexCode();
 	}
 
 	@Override


### PR DESCRIPTION
#### Description: 
- I need an event for something I'm doing at the moment.
- This event will be when a town returns its map colour.
- This is to allow siegewar (for example) to intervene in the display of individual town map (ie dynmap) colours.

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Towny Issue ticket:
N/A

____
- [N/A] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
