### PR TITLE
Fix for displayed-nation-list events

### DIFF
--- a/src/com/palmergames/bukkit/towny/TownySpigotMessaging.java
+++ b/src/com/palmergames/bukkit/towny/TownySpigotMessaging.java
@@ -1,5 +1,8 @@
 package com.palmergames.bukkit.towny;
 
+import com.palmergames.bukkit.towny.event.nation.NationListDisplayedNumResidentsCalculationEvent;
+import com.palmergames.bukkit.towny.event.nation.NationListDisplayedNumTownBlocksCalculationEvent;
+import com.palmergames.bukkit.towny.event.nation.NationListDisplayedNumTownsCalculationEvent;
 import com.palmergames.bukkit.towny.invites.Invite;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Town;
@@ -15,6 +18,7 @@ import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.chat.hover.content.Text;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.command.CommandSender;
@@ -246,13 +250,22 @@ public class TownySpigotMessaging {
 				slug = TownyEconomyHandler.getFormattedBalance(nation.getAccount().getCachedBalance());
 				break;
 			case TOWNBLOCKS:
-				slug = nation.getTownBlocks().size() + "";
+				int rawNumTownsBlocks = nation.getTownBlocks().size();
+				NationListDisplayedNumTownBlocksCalculationEvent tbEvent = new NationListDisplayedNumTownBlocksCalculationEvent(nation, rawNumTownsBlocks);
+				Bukkit.getPluginManager().callEvent(tbEvent);
+				slug = tbEvent.getDisplayedValue() + "";
 				break;
 			case TOWNS:
-				slug = nation.getTowns().size() + "";
+				int rawNumTowns = nation.getTowns().size();
+				NationListDisplayedNumTownsCalculationEvent tEvent = new NationListDisplayedNumTownsCalculationEvent(nation, rawNumTowns);
+				Bukkit.getPluginManager().callEvent(tEvent);
+				slug = tEvent.getDisplayedValue() + "";
 				break;
 			default:
-				slug = nation.getResidents().size() + "";
+				int rawNumResidents = nation.getResidents().size();
+				NationListDisplayedNumResidentsCalculationEvent rEvent = new NationListDisplayedNumResidentsCalculationEvent(nation, rawNumResidents);
+				Bukkit.getPluginManager().callEvent(rEvent);
+				slug = rEvent.getDisplayedValue() + "";
 				break;
 			}
 			

--- a/src/com/palmergames/bukkit/towny/event/nation/NationListDisplayedNumTownBlocksCalculationEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/nation/NationListDisplayedNumTownBlocksCalculationEvent.java
@@ -1,0 +1,10 @@
+package com.palmergames.bukkit.towny.event.nation;
+
+import com.palmergames.bukkit.towny.object.Nation;
+
+public class NationListDisplayedNumTownBlocksCalculationEvent extends NationListDisplayedValueCalculationEvent {
+
+	public NationListDisplayedNumTownBlocksCalculationEvent(Nation nation, int displayedNumTowns) {
+		super(nation, displayedNumTowns);
+	}
+}


### PR DESCRIPTION
#### Description: 
- With current code, the new list events do not fire on spigot
- This is because the logic for displaying the list branches for spigot (I didn't spot the branching)
- In this PR, I fix the issue (also was able to test to confirm the fix, now that I can use 0.96.7.8)

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Towny Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
