### PR TITLE
Fix water & lava being usable to grief others.

### DIFF
--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -760,6 +760,12 @@ public enum ConfigNodes {
 			"# All ranks should be as defined in `townyperms.yml`.",
 			"# For example, to give a `visemayor` preference over an `assistant`, change this parameter to `visemayor,assistant`."
 	),
+	GTOWN_SETTINGS_PREVENT_FLUID_GRIEFING(
+			"global_town_settings.prevent_fluid_griefing",
+			"true",
+			"",
+			"# When enabled, blocks like lava or water will be unable to flow into other plots, if the owners aren't the same."
+	),
 	
 	GTOWN_SETTINGS_COMMAND_BLACKLISTING(
 			"global_town_settings.town_command_blacklisting",

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -3060,5 +3060,9 @@ public class TownySettings {
 	public static List<String> getPlayerOwnedPlotLimitedCommands() {
 		return getStrArr(ConfigNodes.GTOWN_TOWN_LIMITED_COMMANDS);
 	}
+
+	public static boolean getPreventFluidGriefingEnabled() {
+		return getBoolean(ConfigNodes.GTOWN_SETTINGS_PREVENT_FLUID_GRIEFING);
+	}
 }
 

--- a/src/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
@@ -16,6 +16,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.Directional;
 import org.bukkit.block.data.type.Chest;
 import org.bukkit.block.data.type.Chest.Type;
 import org.bukkit.entity.Player;
@@ -24,7 +25,9 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockBurnEvent;
+import org.bukkit.event.block.BlockDispenseEvent;
 import org.bukkit.event.block.BlockExplodeEvent;
+import org.bukkit.event.block.BlockFromToEvent;
 import org.bukkit.event.block.BlockIgniteEvent;
 import org.bukkit.event.block.BlockPistonExtendEvent;
 import org.bukkit.event.block.BlockPistonRetractEvent;
@@ -174,7 +177,7 @@ public class TownyBlockListener implements Listener {
 			return;
 		}
 
-		if (testBlockMove(event.getBlock(), event.isSticky() ? event.getDirection().getOppositeFace() : event.getDirection()))
+		if (testBlockMove(event.getBlock(), event.isSticky() ? event.getBlock().getRelative(event.getDirection().getOppositeFace()) : event.getBlock().getRelative(event.getDirection())))
 			event.setCancelled(true);
 
 		List<Block> blocks = event.getBlocks();
@@ -182,7 +185,7 @@ public class TownyBlockListener implements Listener {
 		if (!blocks.isEmpty()) {
 			//check each block to see if it's going to pass a plot boundary
 			for (Block block : blocks) {
-				if (testBlockMove(block, event.getDirection()))
+				if (testBlockMove(block, block.getRelative(event.getDirection())))
 					event.setCancelled(true);
 			}
 		}
@@ -196,7 +199,7 @@ public class TownyBlockListener implements Listener {
 			return;
 		}
 		
-		if (testBlockMove(event.getBlock(), event.getDirection()))
+		if (testBlockMove(event.getBlock(), event.getBlock().getRelative(event.getDirection())))
 			event.setCancelled(true);
 		
 		List<Block> blocks = event.getBlocks();
@@ -204,25 +207,27 @@ public class TownyBlockListener implements Listener {
 		if (!blocks.isEmpty()) {
 			//check each block to see if it's going to pass a plot boundary
 			for (Block block : blocks) {
-				if (testBlockMove(block, event.getDirection()))
+				if (testBlockMove(block, block.getRelative(event.getDirection())))
 					event.setCancelled(true);
 			}
 		}
 	}
 
 	/**
-	 * Decides whether blocks moved by pistons follow the rules.
+	 * Decides whether blocks moved by pistons or fluids flowing follow the rules.
 	 * 
 	 * @param block - block that is being moved.
-	 * @param direction - direction the piston is facing.
+	 * @param blockTo - block that is being moved to.
 	 * 
-	 * @return true if block is able to be moved. 
+	 * @return true if block shouldn't be able to be moved.
 	 */
-	private boolean testBlockMove(Block block, BlockFace direction) {
-
-		Block blockTo = block.getRelative(direction);
+	private boolean testBlockMove(Block block, Block blockTo) {
 		Location loc = block.getLocation();
 		Location locTo = blockTo.getLocation();
+
+		if (TownyAPI.getInstance().isWilderness(locTo))
+			return false;
+		
 		TownBlock currentTownBlock = null, destinationTownBlock = null;
 
 		currentTownBlock = TownyAPI.getInstance().getTownBlock(loc);
@@ -316,4 +321,39 @@ public class TownyBlockListener implements Listener {
 		}
 	}
 	
+	/*
+	* Prevents water or lava from going into other people's plots.
+	*/
+	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+	public void onBlockFromToEvent(BlockFromToEvent event) {
+		if (plugin.isError()) {
+			event.setCancelled(true);
+			return;
+		}
+
+		if (!TownySettings.getPreventFluidGriefingEnabled() || event.getBlock().getType() == Material.DRAGON_EGG)
+			return;
+				
+		event.setCancelled(testBlockMove(event.getBlock(), event.getToBlock()));
+	}
+
+	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+	public void onBlockDispense(BlockDispenseEvent event) {
+		if (plugin.isError()) {
+			event.setCancelled(true);
+			return;
+		}
+
+		if (!TownySettings.getPreventFluidGriefingEnabled())
+			return;
+		
+		if (event.getItem().getType() != Material.WATER_BUCKET && event.getItem().getType() != Material.LAVA_BUCKET && event.getItem().getType() != Material.BUCKET)
+			return;
+
+		if (event.getBlock().getType() != Material.DISPENSER)
+			return;
+		
+		event.setCancelled(testBlockMove(event.getBlock(), event.getBlock().getRelative(((Directional) event.getBlock().getBlockData()).getFacing())));
+	}
+
 }

--- a/src/com/palmergames/bukkit/towny/object/WorldCoord.java
+++ b/src/com/palmergames/bukkit/towny/object/WorldCoord.java
@@ -112,7 +112,7 @@ public class WorldCoord extends Coord {
 	 * Shortcut for TownyUniverse.getInstance().getTownBlock(WorldCoord).
 	 * 
 	 * @return the relevant TownBlock instance.
-	 * @throws NotRegisteredException - If there is no TownBlock @ WorldCoord, then this exception.
+	 * @throws NotRegisteredException If there is no TownBlock at this WorldCoord.
 	 */
 	public TownBlock getTownBlock() throws NotRegisteredException {
 		if (!hasTownBlock())


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Fixes water & lava being usable to grief other towns, by using the same testBlockMove function that pistons use.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
New Config Option: global_town_settings.prevent_fluid_griefing
- Default: true
- When enabled, blocks like lava or water will be unable to flow into other plots, if the owners aren't the same.

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
