### PR TITLE
Add TownPreInvitePlayerEvent

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -23,6 +23,7 @@ import com.palmergames.bukkit.towny.event.town.TownKickEvent;
 import com.palmergames.bukkit.towny.event.town.TownLeaveEvent;
 import com.palmergames.bukkit.towny.event.town.TownMayorChangeEvent;
 import com.palmergames.bukkit.towny.event.town.TownMergeEvent;
+import com.palmergames.bukkit.towny.event.town.TownPreInvitePlayerEvent;
 import com.palmergames.bukkit.towny.event.town.TownPreMergeEvent;
 import com.palmergames.bukkit.towny.event.town.TownPreSetHomeBlockEvent;
 import com.palmergames.bukkit.towny.event.town.TownPreUnclaimCmdEvent;
@@ -2859,6 +2860,12 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 	private static void townInviteResident(CommandSender sender,Town town, Resident newMember) throws TownyException {
 
 		PlayerJoinTownInvite invite = new PlayerJoinTownInvite(sender, newMember, town);
+
+		TownPreInvitePlayerEvent townPreInvitePlayerEvent = new TownPreInvitePlayerEvent(invite);
+		Bukkit.getPluginManager().callEvent(townPreInvitePlayerEvent);
+		if (townPreInvitePlayerEvent.isCancelled())
+			throw new TownyException(townPreInvitePlayerEvent.getCancelMessage());
+		
 		try {
 			if (!InviteHandler.inviteIsActive(invite)) {
 				newMember.newReceivedInvite(invite);

--- a/src/com/palmergames/bukkit/towny/event/town/TownPreInvitePlayerEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/town/TownPreInvitePlayerEvent.java
@@ -1,0 +1,70 @@
+package com.palmergames.bukkit.towny.event.town;
+
+import com.palmergames.bukkit.towny.invites.Invite;
+import com.palmergames.bukkit.towny.object.Resident;
+import com.palmergames.bukkit.towny.object.Town;
+import org.bukkit.Bukkit;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Cancellable event that gets fired before a resident is invited to a town.
+ * @since 0.96.7.12
+ */
+public class TownPreInvitePlayerEvent extends Event implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private final Invite invite;
+    private boolean cancelled = false;
+    private String cancelMessage = "Sorry, but this event was cancelled.";
+
+    public TownPreInvitePlayerEvent(Invite invite) {
+        super(!Bukkit.getServer().isPrimaryThread());
+        this.invite = invite;
+    }
+
+    public Invite getInvite() {
+        return invite;
+    }
+
+    /**
+     * Convenience method for getting the resident that was invited.
+     * @return The {@link Resident} that was invited.
+     */
+    public Resident getInvitedResident() {
+        return (Resident) invite.getReceiver();
+    }
+
+    /**
+     * Convenience method for getting the town that sent the invite.
+     * @return The {@link Town} that the resident is invited to join.
+     */
+    public Town getTown() {
+        return (Town) invite.getSender();
+    }
+
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    public String getCancelMessage() {
+        return cancelMessage;
+    }
+
+    public void setCancelMessage(String cancelMessage) {
+        this.cancelMessage = cancelMessage;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+}

--- a/src/com/palmergames/bukkit/towny/event/town/TownPreInvitePlayerEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/town/TownPreInvitePlayerEvent.java
@@ -16,7 +16,7 @@ public class TownPreInvitePlayerEvent extends Event implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private final Invite invite;
     private boolean cancelled = false;
-    private String cancelMessage = "Sorry, but this event was cancelled.";
+    private String cancelMessage = "You cannot invite this player to your town.";
 
     public TownPreInvitePlayerEvent(Invite invite) {
         super(!Bukkit.getServer().isPrimaryThread());


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Adds TownPreInvitePlayerEvent, a cancellable event that gets fired before a resident is invited to a town.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
