### PR TITLE
Add town/nation name blacklist config option

### DIFF
--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1001,6 +1001,13 @@ public enum ConfigNodes {
 		"",
 		"# If enabled, particles will appear around town, nation, outpost & jail spawns."
 	),
+	PLUGIN_NAME_BLACKLIST(
+		"plugin.name_blacklist",
+		"",
+		"",
+		"# A blacklist used for validating town/nation names.",
+		"# Names must be seperated by a comma: name1,name2"
+	),
 	FILTERS_COLOUR_CHAT(
 			"filters_colour_chat",
 			"",

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -3020,5 +3020,9 @@ public class TownySettings {
 	public static boolean getVisualizedSpawnPointsEnabled() {
 		return getBoolean(ConfigNodes.PLUGIN_VISUALIZED_SPAWN_POINTS_ENABLED);
 	}
+
+	public static List<String> getBlacklistedNames() {
+		return getStrArr(ConfigNodes.PLUGIN_NAME_BLACKLIST);
+	}
 }
 

--- a/src/com/palmergames/bukkit/util/NameValidation.java
+++ b/src/com/palmergames/bukkit/util/NameValidation.java
@@ -8,6 +8,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
 
 /**
  * @author ElgarL
@@ -96,6 +97,9 @@ public class NameValidation {
 		 */
 		// Banned names
 		if (bannedNames.contains(name.toLowerCase()))
+			return true;
+		
+		if (TownySettings.getBlacklistedNames().stream().map(String::toLowerCase).collect(Collectors.toList()).contains(name.toLowerCase()))
 			return true;
 
 		return !isValidName(name);


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Adds a configurable blacklist that can be used to block certain town/nation names.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
Adds plugin.name_blacklist:
- Default: empty
- A blacklist used for validating town/nation names.
- Names must be seperated by a comma: name1,name2

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #4875

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
