### PR TITLE
Fix entity-vs-entity combat always being allowed

### DIFF
--- a/src/com/palmergames/bukkit/towny/utils/CombatUtil.java
+++ b/src/com/palmergames/bukkit/towny/utils/CombatUtil.java
@@ -84,7 +84,7 @@ public class CombatUtil {
 				b = (Player) defender;
 
 			// Allow players to injure themselves
-			if (a == b)
+			if (a == b && a != null && b != null)
 				return false;
 
 			return preventDamageCall(plugin, world, attacker, defender, a, b, cause);
@@ -233,8 +233,9 @@ public class CombatUtil {
 				 * 
 				 * Prevent pvp and remove Wolf targeting.
 				 */
-				if ( attackingEntity instanceof Wolf && ((Wolf) attackingEntity).isTamed() && (preventPvP(world, attackerTB) || preventPvP(world, defenderTB))) {
+				if (attackingEntity instanceof Wolf && (preventPvP(world, attackerTB) || preventPvP(world, defenderTB))) {
 					((Wolf) attackingEntity).setTarget(null);
+					((Wolf) attackingEntity).setAngry(false);
 					return true;
 				}
 				
@@ -256,6 +257,15 @@ public class CombatUtil {
 			     */
 				if (attackingEntity instanceof Projectile) {
 					return true;	
+				}
+
+				/*
+				* Allow wolves to attack unprotected entites (such as skeletons), but not protected ones.
+				*/
+				if (attackingEntity instanceof Wolf && (EntityTypeUtil.isInstanceOfAny(TownySettings.getProtectedEntityTypes(), defendingEntity))) {
+					((Wolf) attackingEntity).setTarget(null);
+					((Wolf) attackingEntity).setAngry(false);
+					return true;
 				}
 			}
 		}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
Fixes entity vs entity combat always being allowed, because of the a == b check always returning true because both would be null. Also fixes wolves being able to attack protected mobs and players inside claimed areas.

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
