### PR TITLE
Fix command always being null

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -686,7 +686,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 
 					TownyUniverse.getInstance().getResident(player.getUniqueId()).getTown().getNation().generateBankHistoryBook(player, pages);
 				} else if (TownyCommandAddonAPI.hasCommand(CommandType.NATION, split[0])) {
-					TownyCommandAddonAPI.getAddonCommand(CommandType.NATION, split[0]).run(player, null, "nation", split);
+					TownyCommandAddonAPI.getAddonCommand(CommandType.NATION, split[0]).execute(player, "nation", split);
 				} else {
 
 					final Nation nation = TownyUniverse.getInstance().getNation(split[0]);
@@ -2455,7 +2455,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 					TownyMessaging.sendPrefixedNationMessage(nation, Translation.of("msg_nation_map_color_changed", line.toLowerCase()));
 				}
 			} else if (TownyCommandAddonAPI.hasCommand(CommandType.NATION_SET, split[0])) {
-				TownyCommandAddonAPI.getAddonCommand(CommandType.NATION_SET, split[0]).run(player, null, "nation", split);
+				TownyCommandAddonAPI.getAddonCommand(CommandType.NATION_SET, split[0]).execute(player, "nation", split);
 			} else {
 				TownyMessaging.sendErrorMsg(player, Translation.of("msg_err_invalid_property", split[0]));
 				return;
@@ -2582,7 +2582,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
                 // Send message feedback.
                 TownyMessaging.sendPrefixedNationMessage(nation, Translation.of("msg_nation_changed_open", nation.isOpen() ? Translation.of("enabled") : Translation.of("disabled")));
 			} else if (TownyCommandAddonAPI.hasCommand(CommandType.NATION_TOGGLE, split[0])) {
-				TownyCommandAddonAPI.getAddonCommand(CommandType.NATION_TOGGLE, split[0]).run(sender, null, "nation", split);
+				TownyCommandAddonAPI.getAddonCommand(CommandType.NATION_TOGGLE, split[0]).execute(sender, "nation", split);
             } else {
             	/*
             	 * Fire of an event if we don't recognize the command being used.

--- a/src/com/palmergames/bukkit/towny/command/PlotCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/PlotCommand.java
@@ -696,7 +696,7 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 							}
 							return true;
 						} else if (TownyCommandAddonAPI.hasCommand(CommandType.PLOT_SET, split[0])) {
-							TownyCommandAddonAPI.getAddonCommand(CommandType.PLOT_SET, split[0]).run(player, null, "plot", split);
+							TownyCommandAddonAPI.getAddonCommand(CommandType.PLOT_SET, split[0]).execute(player, "plot", split);
 							return true;
 						}
 						
@@ -823,7 +823,7 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 
 					return handlePlotGroupCommand(StringMgmt.remFirstArg(split), player);
 				} else if (TownyCommandAddonAPI.hasCommand(CommandType.PLOT, split[0])) {
-					TownyCommandAddonAPI.getAddonCommand(CommandType.PLOT, split[0]).run(player, null, "plot", split);
+					TownyCommandAddonAPI.getAddonCommand(CommandType.PLOT, split[0]).execute(player, "plot", split);
 				} else
 					throw new TownyException(Translation.of("msg_err_invalid_property", split[0]));
 
@@ -1121,7 +1121,7 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 					
 					TownyMessaging.sendMessage(player, Translation.of("msg_changed_mobs", "the Plot", townBlock.getPermissions().mobs ? Translation.of("enabled") : Translation.of("disabled")));
 				} else if (TownyCommandAddonAPI.hasCommand(CommandType.PLOT_TOGGLE, split[0])) {
-					TownyCommandAddonAPI.getAddonCommand(CommandType.PLOT_TOGGLE, split[0]).run(player, null, "plot", split);
+					TownyCommandAddonAPI.getAddonCommand(CommandType.PLOT_TOGGLE, split[0]).execute(player, "plot", split);
 				} else {
 					TownyMessaging.sendErrorMsg(player, Translation.of("msg_err_invalid_property", "plot"));
 					return;

--- a/src/com/palmergames/bukkit/towny/command/ResidentCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/ResidentCommand.java
@@ -357,7 +357,7 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 				
 				SpawnUtil.sendToTownySpawn(player, split, res, Translation.of("msg_err_cant_afford_tp"), false, false, SpawnType.RESIDENT);
 			} else if (TownyCommandAddonAPI.hasCommand(CommandType.RESIDENT, split[0])) {
-				TownyCommandAddonAPI.getAddonCommand(CommandType.RESIDENT, split[0]).run(player, null, "resident", split);
+				TownyCommandAddonAPI.getAddonCommand(CommandType.RESIDENT, split[0]).execute(player, "resident", split);
 			} else {
 				final Resident resident = TownyUniverse.getInstance().getResidentOpt(split[0])
 											.orElseThrow(() -> new TownyException(Translation.of("msg_err_not_registered_1", split[0])));
@@ -442,7 +442,7 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 		} else if (newSplit[0].equalsIgnoreCase("mobs")) {
 			perm.mobs = choice.orElse(!perm.mobs);
 		} else if (TownyCommandAddonAPI.hasCommand(CommandType.RESIDENT_TOGGLE, newSplit[0])) {
-			TownyCommandAddonAPI.getAddonCommand(CommandType.RESIDENT_TOGGLE, newSplit[0]).run(player, null, "resident", newSplit);
+			TownyCommandAddonAPI.getAddonCommand(CommandType.RESIDENT_TOGGLE, newSplit[0]).execute(player, "resident", newSplit);
 		} else {
 
 			resident.toggleMode(newSplit, true);
@@ -548,7 +548,7 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 				String[] newSplit = StringMgmt.remFirstArg(split);
 				setMode(player, newSplit);
 			} else if (TownyCommandAddonAPI.hasCommand(CommandType.RESIDENT_SET, split[0])) {
-				TownyCommandAddonAPI.getAddonCommand(CommandType.RESIDENT_SET, split[0]).run(player, null, "resident", split);
+				TownyCommandAddonAPI.getAddonCommand(CommandType.RESIDENT_SET, split[0]).execute(player, "resident", split);
 			} else {
 
 				TownyMessaging.sendErrorMsg(player, Translation.of("msg_err_invalid_property", "resident"));

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -754,7 +754,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 
 					parseTownMergeCommand(player, newSplit);
 				} else if (TownyCommandAddonAPI.hasCommand(CommandType.TOWN, split[0])) {
-					TownyCommandAddonAPI.getAddonCommand(CommandType.TOWN, split[0]).run(player, null, "town", split);
+					TownyCommandAddonAPI.getAddonCommand(CommandType.TOWN, split[0]).execute(player, "town", split);
 				} else {
 					/*
 					 * We've gotten this far without a match, check if the argument is a town name.
@@ -1547,7 +1547,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 					}
 				}
 			} else if (TownyCommandAddonAPI.hasCommand(CommandType.TOWN_TOGGLE, split[0])) {
-				TownyCommandAddonAPI.getAddonCommand(CommandType.TOWN_TOGGLE, split[0]).run(sender, null, "town", split);
+				TownyCommandAddonAPI.getAddonCommand(CommandType.TOWN_TOGGLE, split[0]).execute(sender, "town", split);
 			} else {
             	/*
             	 * Fire of an event if we don't recognize the command being used.
@@ -2169,7 +2169,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 					String[] newSplit = StringMgmt.remFirstArg(split);
 					setTownBlockOwnerPermissions(player, town, newSplit);
 				} else if (TownyCommandAddonAPI.hasCommand(CommandType.TOWN_SET, split[0])) {
-					TownyCommandAddonAPI.getAddonCommand(CommandType.TOWN_SET, split[0]).run(player, null, "town", split);
+					TownyCommandAddonAPI.getAddonCommand(CommandType.TOWN_SET, split[0]).execute(player, "town", split);
 				} else {
 					TownyMessaging.sendErrorMsg(player, Translation.of("msg_err_invalid_property", "town"));
 					return;

--- a/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -602,7 +602,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 				
 				parseAdminDepositAllCommand(StringMgmt.remFirstArg(split));
 			} else if (TownyCommandAddonAPI.hasCommand(CommandType.TOWNYADMIN, split[0])) {
-				TownyCommandAddonAPI.getAddonCommand(CommandType.TOWNYADMIN, split[0]).run(getSender(), null, "townyadmin", split);
+				TownyCommandAddonAPI.getAddonCommand(CommandType.TOWNYADMIN, split[0]).execute(getSender(), "townyadmin", split);
 			}  else {
 				TownyMessaging.sendErrorMsg(getSender(), Translation.of("msg_err_invalid_sub"));
 				return false;
@@ -1765,7 +1765,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 
 			}
 		} else if (TownyCommandAddonAPI.hasCommand(CommandType.TOWNYADMIN_SET, split[0])) {
-			TownyCommandAddonAPI.getAddonCommand(CommandType.TOWNYADMIN_SET, split[0]).run(getSender(), null, "townyadmin", split);
+			TownyCommandAddonAPI.getAddonCommand(CommandType.TOWNYADMIN_SET, split[0]).execute(getSender(), "townyadmin", split);
 		} else {
 			TownyMessaging.sendErrorMsg(getSender(), Translation.of("msg_err_invalid_property", "administrative"));
 		}
@@ -2061,7 +2061,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 
 			TownyMessaging.sendMessage(sender, Translation.of("msg_npc_flag", resident.isNPC(), resident.getName()));
 		} else if (TownyCommandAddonAPI.hasCommand(CommandType.TOWNYADMIN_TOGGLE, split[0])) {
-			TownyCommandAddonAPI.getAddonCommand(CommandType.TOWNYADMIN_TOGGLE, split[0]).run(getSender(), null, "townyadmin", split);
+			TownyCommandAddonAPI.getAddonCommand(CommandType.TOWNYADMIN_TOGGLE, split[0]).execute(getSender(), "townyadmin", split);
 		} else {
 			// parameter error message
 			// peaceful/war/townmobs/worldmobs

--- a/src/com/palmergames/bukkit/towny/command/TownyCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyCommand.java
@@ -298,7 +298,7 @@ public class TownyCommand extends BaseCommand implements CommandExecutor {
 				} else
 					TownyMessaging.sendErrorMsg(player, Translation.of("msg_err_command_disable"));
 			} else if (TownyCommandAddonAPI.hasCommand(CommandType.TOWNY, split[0])) {
-				TownyCommandAddonAPI.getAddonCommand(CommandType.TOWNY, split[0]).run(player, null, "towny", split);
+				TownyCommandAddonAPI.getAddonCommand(CommandType.TOWNY, split[0]).execute(player, "towny", split);
 			} else
 				sendErrorMsg(player, "Invalid sub command.");
 

--- a/src/com/palmergames/bukkit/towny/command/TownyWorldCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyWorldCommand.java
@@ -256,7 +256,7 @@ public class TownyWorldCommand extends BaseCommand implements CommandExecutor {
 //					}
 
 			} else if (TownyCommandAddonAPI.hasCommand(CommandType.TOWNYWORLD, split[0])) {
-				TownyCommandAddonAPI.getAddonCommand(CommandType.TOWNYWORLD, split[0]).run(sender, null, "townyworld", split);
+				TownyCommandAddonAPI.getAddonCommand(CommandType.TOWNYWORLD, split[0]).execute(sender, "townyworld", split);
 			} else {
 				TownyMessaging.sendErrorMsg(sender, Translation.of("msg_err_invalid_property", "townyworld"));
 			}
@@ -492,7 +492,7 @@ public class TownyWorldCommand extends BaseCommand implements CommandExecutor {
 				else
 					TownyMessaging.sendMsg(msg);
 			} else if (TownyCommandAddonAPI.hasCommand(CommandType.TOWNYWORLD_TOGGLE, split[0])) {
-				TownyCommandAddonAPI.getAddonCommand(CommandType.TOWNYWORLD_TOGGLE, split[0]).run(sender, null, "townyworld", split);
+				TownyCommandAddonAPI.getAddonCommand(CommandType.TOWNYWORLD_TOGGLE, split[0]).execute(sender, "townyworld", split);
 			} else {
 				msg = Translation.of("msg_err_invalid_property", "'" + split[0] + "'");
 				if (player != null)
@@ -618,9 +618,9 @@ public class TownyWorldCommand extends BaseCommand implements CommandExecutor {
 					}
 			} else if (TownyCommandAddonAPI.hasCommand(CommandType.TOWNYWORLD_SET, split[0])) {
 				try {
-					TownyCommandAddonAPI.getAddonCommand(CommandType.TOWNYWORLD_SET, split[0]).run(sender, null, "townyworld", split);
-				} catch (TownyException e) {
-					return;
+					TownyCommandAddonAPI.getAddonCommand(CommandType.TOWNYWORLD_SET, split[0]).execute(sender, "townyworld", split);
+				} catch (Exception e) {
+					TownyMessaging.sendErrorMsg(player, e.getMessage());
 				}
 			} else {
 				if (player != null)

--- a/src/com/palmergames/bukkit/towny/object/AddonCommand.java
+++ b/src/com/palmergames/bukkit/towny/object/AddonCommand.java
@@ -6,28 +6,29 @@ import java.util.List;
 import java.util.Map;
 
 import com.palmergames.bukkit.towny.TownyCommandAddonAPI.CommandType;
-import com.palmergames.bukkit.towny.exceptions.TownyException;
 
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
 
-public class AddonCommand {
+public class AddonCommand extends Command {
     private CommandType commandType;
     private String name;
     private CommandExecutor commandExecutor;
     private Map<Integer, List<String>> tabCompletions = new HashMap<Integer, List<String>>();
 
     public AddonCommand(CommandType commandType, String name, CommandExecutor commandExecutor) {
+    	super(name);
         this.commandType = commandType;
         this.name = name;
         this.commandExecutor = commandExecutor;
     }
 
-    public void run(CommandSender sender, Command command, String label, String[] args) throws TownyException {
-        if (!commandExecutor.onCommand(sender, command, label, args))
-            throw new TownyException();
-    }
+	@Override
+	public boolean execute(@NotNull CommandSender sender, @NotNull String label, @NotNull String[] args) {
+		return commandExecutor.onCommand(sender, this, label, args);
+	}
 
     public CommandType getCommandType() {
         return commandType;
@@ -48,9 +49,10 @@ public class AddonCommand {
     public void setCommandType(CommandType commandType) {
         this.commandType = commandType;
     }
-
-    public void setName(String name) {
+    
+    public boolean setName(String name) {
         this.name = name;
+        return true;
     }
 
     public void setCommandExecutor(CommandExecutor commandExecutor) {


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Fixes the command variable always being null while running a subcommand, and fixed a TownyException being thrown if onCommand returns null.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #4971 

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
