### PR TITLE
Town and Nation Listing get Cached.

### DIFF
--- a/src/com/palmergames/bukkit/towny/TownyMessaging.java
+++ b/src/com/palmergames/bukkit/towny/TownyMessaging.java
@@ -1,9 +1,5 @@
 package com.palmergames.bukkit.towny;
 
-import com.palmergames.bukkit.towny.event.nation.NationListDisplayedNumOnlinePlayersCalculationEvent;
-import com.palmergames.bukkit.towny.event.nation.NationListDisplayedNumResidentsCalculationEvent;
-import com.palmergames.bukkit.towny.event.nation.NationListDisplayedNumTownBlocksCalculationEvent;
-import com.palmergames.bukkit.towny.event.nation.NationListDisplayedNumTownsCalculationEvent;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.invites.Invite;
 import com.palmergames.bukkit.towny.object.Nation;
@@ -21,7 +17,6 @@ import com.palmergames.util.StringMgmt;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.command.CommandSender;
@@ -634,7 +629,7 @@ public class TownyMessaging {
 		);
 	}
 
-	public static void sendTownList(CommandSender sender, List<Town> towns, ComparatorType compType, int page, int total) {
+	public static void sendTownList(CommandSender sender, List<TextComponent> towns, ComparatorType compType, int page, int total) {
 		int iMax = Math.min(page * 10, towns.size());
 
 		TextComponent[] townsformatted;
@@ -645,45 +640,9 @@ public class TownyMessaging {
 			townsformatted = new TextComponent[10];
 		}
 		
-		
+		// Populate the page with TextComponents.
 		for (int i = (page - 1) * 10; i < iMax; i++) {
-			Town town = towns.get(i);
-			TextComponent townName = Component.text(Colors.LightBlue + StringMgmt.remUnderscore(town.getName()))
-				.clickEvent(ClickEvent.runCommand("/towny:town spawn " + town + " -ignore"));
-			
-			String slug = null;
-			switch (compType) {
-			case BALANCE:
-				slug = Colors.LightBlue + "(" + TownyEconomyHandler.getFormattedBalance(town.getAccount().getCachedBalance()) + ")";
-				break;
-			case TOWNBLOCKS:
-				slug = Colors.LightBlue + "(" + town.getTownBlocks().size() + ")";
-				break;
-			case RUINED:
-				slug = Colors.LightBlue + "(" + town.getResidents().size() + ") " + (town.isRuined() ? Translation.of("msg_ruined"):"");
-				break;
-			case BANKRUPT:
-				slug = Colors.LightBlue + "(" + town.getResidents().size() + ") " + (town.isBankrupt() ? Translation.of("msg_bankrupt"):"");
-				break;
-			case ONLINE:
-				slug = Colors.LightBlue + "(" + TownyAPI.getInstance().getOnlinePlayersInTown(town).size() + ")";
-				break;
-			default:
-				slug = Colors.LightBlue + "(" + town.getResidents().size() + ")";
-				break;
-			}
-			townName = townName.append(Component.text(Colors.Gray + " - " + slug));
-			
-			if (town.isOpen())
-				townName = townName.append(Component.text(" " + Colors.LightBlue + Translation.of("status_title_open")));
-			
-			String spawnCost = "Free";
-			if (TownyEconomyHandler.isActive())
-				spawnCost = ChatColor.RESET + Translation.of("msg_spawn_cost", TownyEconomyHandler.getFormattedBalance(town.getSpawnCost()));
-
-			townName = townName.hoverEvent(HoverEvent.showText(Component.text(Translation.of("msg_click_spawn", town) + "\n" + spawnCost).color(NamedTextColor.GOLD)));
-			
-			townsformatted[i % 10] = townName;
+			townsformatted[i % 10] = towns.get(i);
 		}
 		
 		Audience audience = Towny.getAdventure().sender(sender);
@@ -722,7 +681,7 @@ public class TownyMessaging {
 		return backButton.append(pageText).append(forwardButton);
 	}
 
-	public static void sendNationList(CommandSender sender, List<Nation> nations, ComparatorType compType, int page, int total) {
+	public static void sendNationList(CommandSender sender, List<TextComponent> nations, ComparatorType compType, int page, int total) {
 		int iMax = Math.min(page * 10, nations.size());
 
 		TextComponent[] nationsformatted;
@@ -732,53 +691,9 @@ public class TownyMessaging {
 			nationsformatted = new TextComponent[10];
 		}
 		
+		// Populate the page with TextComponents.
 		for (int i = (page - 1) * 10; i < iMax; i++) {
-			Nation nation = nations.get(i);
-			TextComponent nationName = Component.text(Colors.LightBlue + StringMgmt.remUnderscore(nation.getName()))
-				.clickEvent(ClickEvent.runCommand("/towny:nation spawn " + nation + " -ignore"));
-
-			String slug = "";
-			switch (compType) {
-			case BALANCE:
-				slug = TownyEconomyHandler.getFormattedBalance(nation.getAccount().getCachedBalance());
-				break;
-			case TOWNBLOCKS:
-				int rawNumTownsBlocks = nation.getTownBlocks().size();
-				NationListDisplayedNumTownBlocksCalculationEvent tbEvent = new NationListDisplayedNumTownBlocksCalculationEvent(nation, rawNumTownsBlocks);
-				Bukkit.getPluginManager().callEvent(tbEvent);
-				slug = tbEvent.getDisplayedValue() + "";
-				break;
-			case TOWNS:
-				int rawNumTowns = nation.getTowns().size();
-				NationListDisplayedNumTownsCalculationEvent tEvent = new NationListDisplayedNumTownsCalculationEvent(nation, rawNumTowns);
-				Bukkit.getPluginManager().callEvent(tEvent);
-				slug = tEvent.getDisplayedValue() + "";
-				break;
-			case ONLINE:
-				int rawNumOnlinePlayers = TownyAPI.getInstance().getOnlinePlayersInNation(nation).size();
-				NationListDisplayedNumOnlinePlayersCalculationEvent opEvent = new NationListDisplayedNumOnlinePlayersCalculationEvent(nation, rawNumOnlinePlayers);
-				Bukkit.getPluginManager().callEvent(opEvent);
-				slug = opEvent.getDisplayedValue() + "";
-				break;
-			default:
-				int rawNumResidents = nation.getResidents().size();
-				NationListDisplayedNumResidentsCalculationEvent rEvent = new NationListDisplayedNumResidentsCalculationEvent(nation, rawNumResidents);
-				Bukkit.getPluginManager().callEvent(rEvent);
-				slug = rEvent.getDisplayedValue() + "";
-				break;
-			}
-			
-			nationName = nationName.append(Component.text(Colors.Gray + " - " + Colors.LightBlue + "(" + slug + ")"));
-
-			if (nation.isOpen())
-				nationName = nationName.append(Component.text(" " + Colors.LightBlue + Translation.of("status_title_open")));
-
-			String spawnCost = "Free";
-			if (TownyEconomyHandler.isActive())
-				spawnCost = ChatColor.RESET + Translation.of("msg_spawn_cost", TownyEconomyHandler.getFormattedBalance(nation.getSpawnCost()));
-			
-			nationName = nationName.hoverEvent(HoverEvent.showText(Component.text(Colors.Gold + Translation.of("msg_click_spawn", nation) + "\n" + spawnCost)));
-			nationsformatted[i % 10] = nationName;
+			nationsformatted[i % 10] = nations.get(i);
 		}
 
 		sender.sendMessage(ChatTools.formatTitle(Translation.of("nation_plu")));

--- a/src/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -52,6 +52,7 @@ import com.palmergames.bukkit.towny.object.SpawnType;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.Translation;
+import com.palmergames.bukkit.towny.object.comparators.ComparatorCaches;
 import com.palmergames.bukkit.towny.object.comparators.ComparatorType;
 import com.palmergames.bukkit.towny.object.inviteobjects.NationAllyNationInvite;
 import com.palmergames.bukkit.towny.object.inviteobjects.TownJoinNationInvite;
@@ -79,7 +80,6 @@ import java.io.InvalidObjectException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -978,7 +978,6 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 	 * @param split  - Current command arguments.
 	 * @throws TownyException - Thrown when player does not have permission node.
 	 */
-	@SuppressWarnings("unchecked")
 	public void listNations(CommandSender sender, String[] split) throws TownyException {
 		
 		TownyPermissionSource permSource = TownyUniverse.getInstance().getPermissionSource();
@@ -1058,14 +1057,11 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 	        return;
 	    }
 
-	    final List<Nation> nations = nationsToSort;
-		final Comparator comparator = type.getComparator();
 	    final ComparatorType finalType = type;
 	    final int pageNumber = page;
 		try {
 			Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-				nations.sort(comparator);
-				TownyMessaging.sendNationList(sender, nations, finalType, pageNumber, total);
+				TownyMessaging.sendNationList(sender, ComparatorCaches.getNationListCache(finalType), finalType, pageNumber, total);
 			});
 		} catch (RuntimeException e) {
 			TownyMessaging.sendErrorMsg(sender, Translation.of("msg_error_comparator_failed"));

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -47,6 +47,7 @@ import com.palmergames.bukkit.towny.invites.InviteReceiver;
 import com.palmergames.bukkit.towny.invites.InviteSender;
 import com.palmergames.bukkit.towny.invites.exceptions.TooManyInvitesException;
 import com.palmergames.bukkit.towny.object.Coord;
+import com.palmergames.bukkit.towny.object.comparators.ComparatorCaches;
 import com.palmergames.bukkit.towny.object.comparators.ComparatorType;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Resident;
@@ -101,7 +102,6 @@ import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -1199,7 +1199,6 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 	 * @param split  - Current command arguments.
 	 * @throws TownyException when a player lacks the permission node.
 	 */
-	@SuppressWarnings("unchecked")
 	public void listTowns(CommandSender sender, String[] split) throws TownyException {
 
 		TownyPermissionSource permSource = TownyUniverse.getInstance().getPermissionSource();
@@ -1282,20 +1281,17 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 			return;
 		}
 		
-		final List<Town> towns = townsToSort;
-		final Comparator comparator = type.getComparator();
 		final int pageNumber = page;
 		final int totalNumber = total; 
 		final ComparatorType finalType = type;
 		try {
 			if (!TownySettings.isTownListRandom()) {
 				Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-					towns.sort(comparator);
-					TownyMessaging.sendTownList(sender, towns, finalType, pageNumber, totalNumber);
+					TownyMessaging.sendTownList(sender, ComparatorCaches.getTownListCache(finalType), finalType, pageNumber, totalNumber);
 				});
-			} else { 
-				Collections.shuffle(towns);
-				TownyMessaging.sendTownList(sender, towns, finalType, pageNumber, totalNumber);
+//			} else { 
+//				Collections.shuffle(towns);
+//				TownyMessaging.sendTownList(sender, towns, finalType, pageNumber, totalNumber);
 			}
 		} catch (RuntimeException e) {
 			TownyMessaging.sendErrorMsg(sender, Translation.of("msg_error_comparator_failed"));

--- a/src/com/palmergames/bukkit/towny/object/comparators/ComparatorCaches.java
+++ b/src/com/palmergames/bukkit/towny/object/comparators/ComparatorCaches.java
@@ -1,0 +1,175 @@
+package com.palmergames.bukkit.towny.object.comparators;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.palmergames.bukkit.towny.TownyAPI;
+import com.palmergames.bukkit.towny.TownyEconomyHandler;
+import com.palmergames.bukkit.towny.TownyUniverse;
+import com.palmergames.bukkit.towny.event.nation.NationListDisplayedNumOnlinePlayersCalculationEvent;
+import com.palmergames.bukkit.towny.event.nation.NationListDisplayedNumResidentsCalculationEvent;
+import com.palmergames.bukkit.towny.event.nation.NationListDisplayedNumTownBlocksCalculationEvent;
+import com.palmergames.bukkit.towny.event.nation.NationListDisplayedNumTownsCalculationEvent;
+import com.palmergames.bukkit.towny.object.Nation;
+import com.palmergames.bukkit.towny.object.Town;
+import com.palmergames.bukkit.towny.object.Translation;
+import com.palmergames.bukkit.util.Colors;
+import com.palmergames.util.StringMgmt;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+
+public class ComparatorCaches {
+	
+	private static LoadingCache<ComparatorType, List<TextComponent>> townCompCache = CacheBuilder.newBuilder()
+			.expireAfterWrite(10, TimeUnit.MINUTES)
+			.build(new CacheLoader<ComparatorType, List<TextComponent>>() {
+				public List<TextComponent> load(ComparatorType compType) throws Exception {
+					return gatherTownLines(compType);
+				}
+			});
+	
+	private static LoadingCache<ComparatorType, List<TextComponent>> nationCompCache = CacheBuilder.newBuilder()
+			.expireAfterWrite(10, TimeUnit.MINUTES)
+			.build(new CacheLoader<ComparatorType, List<TextComponent>>() {
+				public List<TextComponent> load(ComparatorType compType) throws Exception {
+					return gatherNationLines(compType);
+				}
+			}); 
+	
+	public static List<TextComponent> getTownListCache(ComparatorType compType) {
+		System.out.println("Comparator: " + compType.name());
+		try {
+			return townCompCache.get(compType);
+		} catch (ExecutionException e) {
+			e.printStackTrace();
+			return null;
+		}
+	}
+	
+	public static List<TextComponent> getNationListCache(ComparatorType compType) {
+		System.out.println("Comparator: " + compType.name());
+		try {
+			return nationCompCache.get(compType);
+		} catch (ExecutionException e) {
+			e.printStackTrace();
+			return null;
+		}
+	}
+	
+	@SuppressWarnings("unchecked")
+	private static List<TextComponent> gatherTownLines(ComparatorType compType) {
+		System.out.println("Making new Cache for comparator type: " + compType.name());
+		List<TextComponent> output = new ArrayList<>();
+		List<Town> towns = TownyUniverse.getInstance().getDataSource().getTowns();
+		towns.sort((Comparator<? super Town>) compType.getComparator());
+		
+		for (Town town : towns) {
+			TextComponent townName = Component.text(Colors.LightBlue + StringMgmt.remUnderscore(town.getName()))
+					.clickEvent(ClickEvent.runCommand("/towny:town spawn " + town + " -ignore"));
+				
+			String slug = "";
+			switch (compType) {
+			case BALANCE:
+				slug = Colors.LightBlue + "(" + TownyEconomyHandler.getFormattedBalance(town.getAccount().getCachedBalance()) + ")";
+				break;
+			case TOWNBLOCKS:
+				slug = Colors.LightBlue + "(" + town.getTownBlocks().size() + ")";
+				break;
+			case RUINED:
+				slug = Colors.LightBlue + "(" + town.getResidents().size() + ") " + (town.isRuined() ? Translation.of("msg_ruined"):"");
+				break;
+			case BANKRUPT:
+				slug = Colors.LightBlue + "(" + town.getResidents().size() + ") " + (town.isBankrupt() ? Translation.of("msg_bankrupt"):"");
+				break;
+			case ONLINE:
+				slug = Colors.LightBlue + "(" + TownyAPI.getInstance().getOnlinePlayersInTown(town).size() + ")";
+				break;
+			default:
+				slug = Colors.LightBlue + "(" + town.getResidents().size() + ")";
+				break;
+			}
+			townName = townName.append(Component.text(Colors.Gray + " - " + slug));
+			
+			if (town.isOpen())
+				townName = townName.append(Component.text(" " + Colors.LightBlue + Translation.of("status_title_open")));
+			
+			String spawnCost = "Free";
+			if (TownyEconomyHandler.isActive())
+				spawnCost = ChatColor.RESET + Translation.of("msg_spawn_cost", TownyEconomyHandler.getFormattedBalance(town.getSpawnCost()));
+
+			townName = townName.hoverEvent(HoverEvent.showText(Component.text(Translation.of("msg_click_spawn", town) + "\n" + spawnCost).color(NamedTextColor.GOLD)));
+			output.add(townName);
+		}
+		return output;
+	}
+	
+	@SuppressWarnings("unchecked")
+	private static List<TextComponent> gatherNationLines(ComparatorType compType) {
+		System.out.println("Making new Cache for comparator type: " + compType.name());
+		List<TextComponent> output = new ArrayList<>();
+		List<Nation> nations = TownyUniverse.getInstance().getDataSource().getNations();
+		nations.sort((Comparator<? super Nation>) compType.getComparator());
+		
+		for (Nation nation : nations) {
+			TextComponent nationName = Component.text(Colors.LightBlue + StringMgmt.remUnderscore(nation.getName()))
+					.clickEvent(ClickEvent.runCommand("/towny:nation spawn " + nation + " -ignore"));
+
+			String slug = "";
+			switch (compType) {
+			case BALANCE:
+				slug = TownyEconomyHandler.getFormattedBalance(nation.getAccount().getCachedBalance());
+				break;
+			case TOWNBLOCKS:
+				int rawNumTownsBlocks = nation.getTownBlocks().size();
+				NationListDisplayedNumTownBlocksCalculationEvent tbEvent = new NationListDisplayedNumTownBlocksCalculationEvent(nation, rawNumTownsBlocks);
+				Bukkit.getPluginManager().callEvent(tbEvent);
+				slug = tbEvent.getDisplayedValue() + "";
+				break;
+			case TOWNS:
+				int rawNumTowns = nation.getTowns().size();
+				NationListDisplayedNumTownsCalculationEvent tEvent = new NationListDisplayedNumTownsCalculationEvent(nation, rawNumTowns);
+				Bukkit.getPluginManager().callEvent(tEvent);
+				slug = tEvent.getDisplayedValue() + "";
+				break;
+			case ONLINE:
+				int rawNumOnlinePlayers = TownyAPI.getInstance().getOnlinePlayersInNation(nation).size();
+				NationListDisplayedNumOnlinePlayersCalculationEvent opEvent = new NationListDisplayedNumOnlinePlayersCalculationEvent(nation, rawNumOnlinePlayers);
+				Bukkit.getPluginManager().callEvent(opEvent);
+				slug = opEvent.getDisplayedValue() + "";
+				break;
+			default:
+				int rawNumResidents = nation.getResidents().size();
+				NationListDisplayedNumResidentsCalculationEvent rEvent = new NationListDisplayedNumResidentsCalculationEvent(nation, rawNumResidents);
+				Bukkit.getPluginManager().callEvent(rEvent);
+				slug = rEvent.getDisplayedValue() + "";
+				break;
+			}
+			
+			nationName = nationName.append(Component.text(Colors.Gray + " - " + Colors.LightBlue + "(" + slug + ")"));
+
+			if (nation.isOpen())
+				nationName = nationName.append(Component.text(" " + Colors.LightBlue + Translation.of("status_title_open")));
+
+			String spawnCost = "Free";
+			if (TownyEconomyHandler.isActive())
+				spawnCost = ChatColor.RESET + Translation.of("msg_spawn_cost", TownyEconomyHandler.getFormattedBalance(nation.getSpawnCost()));
+			
+			nationName = nationName.hoverEvent(HoverEvent.showText(Component.text(Colors.Gold + Translation.of("msg_click_spawn", nation) + "\n" + spawnCost)));
+			output.add(nationName);
+		}
+		return output;
+	}
+}

--- a/src/com/palmergames/bukkit/towny/object/comparators/ComparatorCaches.java
+++ b/src/com/palmergames/bukkit/towny/object/comparators/ComparatorCaches.java
@@ -50,28 +50,25 @@ public class ComparatorCaches {
 			}); 
 	
 	public static List<TextComponent> getTownListCache(ComparatorType compType) {
-		System.out.println("Comparator: " + compType.name());
 		try {
 			return townCompCache.get(compType);
 		} catch (ExecutionException e) {
 			e.printStackTrace();
-			return null;
+			return new ArrayList<>();
 		}
 	}
 	
 	public static List<TextComponent> getNationListCache(ComparatorType compType) {
-		System.out.println("Comparator: " + compType.name());
 		try {
 			return nationCompCache.get(compType);
 		} catch (ExecutionException e) {
 			e.printStackTrace();
-			return null;
+			return new ArrayList<>();
 		}
 	}
 	
 	@SuppressWarnings("unchecked")
 	private static List<TextComponent> gatherTownLines(ComparatorType compType) {
-		System.out.println("Making new Cache for comparator type: " + compType.name());
 		List<TextComponent> output = new ArrayList<>();
 		List<Town> towns = TownyUniverse.getInstance().getDataSource().getTowns();
 		towns.sort((Comparator<? super Town>) compType.getComparator());
@@ -118,7 +115,6 @@ public class ComparatorCaches {
 	
 	@SuppressWarnings("unchecked")
 	private static List<TextComponent> gatherNationLines(ComparatorType compType) {
-		System.out.println("Making new Cache for comparator type: " + compType.name());
 		List<TextComponent> output = new ArrayList<>();
 		List<Nation> nations = TownyUniverse.getInstance().getDataSource().getNations();
 		nations.sort((Comparator<? super Nation>) compType.getComparator());


### PR DESCRIPTION
Creates caches for the town and nation lists:

- One cache for town listing, one for nation listing,
- Indexed by the ComparatorType, values are pre-formatted TextComponent lists.

~~TODO: return the ability to have the town list at random.~~
~~TODO: re-test that the newly-built caches are returning new data (I have seen the /t list by balance not update correctly.)~~
  - I found that it does update, but sometimes the bank's cachedBalance hasn't quite expired due to both caches having 10 minute expirations.

<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
