### PR TITLE
SW-310: Added event for custom ordering of displayed nations list

### DIFF
--- a/src/com/palmergames/bukkit/towny/event/nation/DisplayedNationsListSortEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/nation/DisplayedNationsListSortEvent.java
@@ -1,0 +1,42 @@
+package com.palmergames.bukkit.towny.event.nation;
+
+import com.palmergames.bukkit.towny.object.Nation;
+import com.palmergames.bukkit.towny.object.comparators.ComparatorType;
+import org.bukkit.Bukkit;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+import java.util.List;
+
+public class DisplayedNationsListSortEvent extends Event {
+	private static final HandlerList handlers = new HandlerList();
+	private List<Nation> nations;
+	private final ComparatorType comparatorType;
+
+	public DisplayedNationsListSortEvent(List<Nation> nations, ComparatorType comparatorType) {
+		super(!Bukkit.getServer().isPrimaryThread());
+		this.nations = nations;
+		this.comparatorType = comparatorType;
+	}
+
+	@Override
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
+
+	public List<Nation> getNations() {
+		return nations;
+	}
+
+	public void setNations(List<Nation> nations) {
+		this.nations = nations;
+	}
+
+	public ComparatorType getComparatorType() {
+		return comparatorType;
+	}
+}

--- a/src/com/palmergames/bukkit/towny/object/comparators/ComparatorCaches.java
+++ b/src/com/palmergames/bukkit/towny/object/comparators/ComparatorCaches.java
@@ -15,6 +15,7 @@ import com.google.common.cache.LoadingCache;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownyEconomyHandler;
 import com.palmergames.bukkit.towny.TownyUniverse;
+import com.palmergames.bukkit.towny.event.nation.DisplayedNationsListSortEvent;
 import com.palmergames.bukkit.towny.event.nation.NationListDisplayedNumOnlinePlayersCalculationEvent;
 import com.palmergames.bukkit.towny.event.nation.NationListDisplayedNumResidentsCalculationEvent;
 import com.palmergames.bukkit.towny.event.nation.NationListDisplayedNumTownBlocksCalculationEvent;
@@ -117,8 +118,13 @@ public class ComparatorCaches {
 	private static List<TextComponent> gatherNationLines(ComparatorType compType) {
 		List<TextComponent> output = new ArrayList<>();
 		List<Nation> nations = TownyUniverse.getInstance().getDataSource().getNations();
+
+		//Sort nations
 		nations.sort((Comparator<? super Nation>) compType.getComparator());
-		
+		DisplayedNationsListSortEvent nationListSortEvent = new DisplayedNationsListSortEvent(nations, compType);
+		Bukkit.getPluginManager().callEvent(nationListSortEvent);
+		nations = nationListSortEvent.getNations();
+
 		for (Nation nation : nations) {
 			TextComponent nationName = Component.text(Colors.LightBlue + StringMgmt.remUnderscore(nation.getName()))
 					.clickEvent(ClickEvent.runCommand("/towny:nation spawn " + nation + " -ignore"));


### PR DESCRIPTION
#### Description: 
- This PR adds a new event, DisplayedNationsListSortEvent
- The event is called after "/n list" is run and the nation list is ordered
- This allows for custom ordering of the list by plugins
- This is needed as part of the fix for https://github.com/TownyAdvanced/SiegeWar/issues/310

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Towny Issue ticket:
N/A

____
- [N/A] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
