### PR TITLE
Add a block whitelist to wilderness explosion regeneration

### DIFF
--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -443,6 +443,10 @@ public enum ConfigNodes {
 			"new_world_settings.plot_management.wild_revert_on_block_explosion.blocks",
 			"WHITE_BED,ORANGE_BED,MAGENTA_BED,LIGHT_BLUE_BED,YELLOW_BED,LIME_BED,PINK_BED,GRAY_BED,LIGHT_GRAY_BED,CYAN_BED,PURPLE_BED,BLUE_BED,BROWN_BED,GREEN_BED,RED_BED,BLACK_BED",
 			"# The list of blocks whose explosions should be reverted."),
+	NWS_PLOT_MANAGEMENT_WILD_REVERT_BLOCK_WHITELIST(
+		"new_world_settings.plot_management.wild_revert_on_explosion_block_whitelist",
+		"",
+		"# The list of blocks to regenerate. (if empty all blocks will regenerate)"),
 		
 
 	GTOWN_SETTINGS(

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -1243,6 +1243,13 @@ public class TownySettings {
 			System.out.println("[Towny] Debug: Wilderness explosion protection entities. ");
 		return getStrArr(ConfigNodes.NWS_PLOT_MANAGEMENT_WILD_ENTITY_REVERT_LIST);
 	}
+
+	public static List<String> getWildExplosionRevertBlockWhitelist() {
+
+		if (getDebug())
+			System.out.println("[Towny] Debug: Wilderness explosion protection block whitelist. ");
+		return getStrArr(ConfigNodes.NWS_PLOT_MANAGEMENT_WILD_REVERT_BLOCK_WHITELIST);
+	}
 	
 	public static List<String> getWildExplosionProtectionBlocks() {
 

--- a/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
+++ b/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
@@ -57,6 +57,7 @@ public class SQL_Schema {
 		columns.add("`plotManagementIgnoreIds` mediumtext NOT NULL");
 		columns.add("`usingPlotManagementWildRegen` bool NOT NULL DEFAULT '0'");
 		columns.add("`plotManagementWildRegenEntities` mediumtext NOT NULL");
+		columns.add("`plotManagementWildRegenBlockWhitelist` mediumtext NOT NULL");
 		columns.add("`plotManagementWildRegenSpeed` long NOT NULL");
 		columns.add("`usingPlotManagementWildRegenBlocks` bool NOT NULL DEFAULT '0'");
 		columns.add("`plotManagementWildRegenBlocks` mediumtext NOT NULL");		

--- a/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -1319,6 +1319,21 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 					} catch (Exception ignored) {
 					}
 				
+				line = keys.get("PlotManagementWildRegenBlockWhitelist");
+				if (line != null)
+					try {
+						List<String> mats = new ArrayList<>();
+						for (String s : line.split(","))
+							if (!s.isEmpty())
+								try {
+									mats.add(s.trim());
+								} catch (NumberFormatException ignored) {
+								}
+						world.setPlotManagementWildRevertBlockWhitelist(mats);
+						System.out.println(mats.toString());
+					} catch (Exception ignored) {
+					}
+				
 				line = keys.get("usingPlotManagementWildRegenDelay");
 				if (line != null)
 					try {
@@ -2061,6 +2076,11 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 		// Wilderness Explosion Protection blocks
 		if (world.getPlotManagementWildRevertBlocks() != null)
 			list.add("PlotManagementWildRegenBlocks=" + StringMgmt.join(world.getPlotManagementWildRevertBlocks(), ","));
+
+		list.add("# The list of blocks to regenerate. (if empty all blocks will regenerate)");
+		// Wilderness Explosion Protection entities
+		if (world.getPlotManagementWildRevertBlockWhitelist() != null)
+			list.add("PlotManagementWildRegenBlockWhitelist=" + StringMgmt.join(world.getPlotManagementWildRevertBlockWhitelist(), ","));
 
 		list.add("# The delay after which the explosion reverts will begin.");
 		// Using PlotManagement Wild Regen Delay

--- a/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -1330,7 +1330,6 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 								} catch (NumberFormatException ignored) {
 								}
 						world.setPlotManagementWildRevertBlockWhitelist(mats);
-						System.out.println(mats.toString());
 					} catch (Exception ignored) {
 					}
 				

--- a/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -1581,6 +1581,21 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 				} catch (Exception ignored) {
 				}
 
+			line = rs.getString("plotManagementWildRegenBlockWhitelist");
+			if (line != null)
+				try {
+					List<String> materials = new ArrayList<>();
+					search = (line.contains("#")) ? "#" : ",";
+					for (String split : line.split(search))
+						if (!split.isEmpty())
+							try {
+								materials.add(split.trim());
+							} catch (NumberFormatException ignored) {
+							}
+					world.setPlotManagementWildRevertBlockWhitelist(materials);
+				} catch (Exception ignored) {
+				}
+
 			resultLong = rs.getLong("plotManagementWildRegenSpeed");
 			try {
 				world.setPlotManagementWildRevertDelay(resultLong);
@@ -2268,6 +2283,11 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			if (world.getPlotManagementWildRevertEntities() != null)
 				nat_hm.put("PlotManagementWildRegenEntities",
 						StringMgmt.join(world.getPlotManagementWildRevertEntities(), "#"));
+
+			// Wilderness Explosion Protection Block Whitelist
+			if (world.getPlotManagementWildRevertBlockWhitelist() != null)
+				nat_hm.put("PlotManagementWildRegenBlockWhitelist",
+						StringMgmt.join(world.getPlotManagementWildRevertBlockWhitelist(), "#"));
 
 			// Using PlotManagement Wild Regen Delay
 			nat_hm.put("plotManagementWildRegenSpeed", world.getPlotManagementWildRevertDelay());

--- a/src/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
@@ -10,6 +10,7 @@ import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.TownyWorld;
 import com.palmergames.bukkit.towny.object.WorldCoord;
 import com.palmergames.bukkit.towny.regen.TownyRegenAPI;
+import com.palmergames.bukkit.towny.regen.block.BlockLocation;
 import com.palmergames.bukkit.towny.utils.BorderUtil;
 import com.palmergames.bukkit.util.BlockUtil;
 import com.palmergames.bukkit.util.ItemLists;
@@ -256,11 +257,7 @@ public class TownyBlockListener implements Listener {
 		if (!TownyAPI.getInstance().isTownyWorld(event.getBlock().getWorld()))
 			return;
 		
-		TownyWorld townyWorld = null;
-		try {
-			townyWorld = TownyUniverse.getInstance().getDataSource().getWorld(event.getBlock().getLocation().getWorld().getName());			
-		} catch (NotRegisteredException ignored) {}
-
+		TownyWorld townyWorld = TownyAPI.getInstance().getTownyWorld(event.getBlock().getWorld().getName());
 		Material material = event.getBlock().getType();
 		/*
 		 * event.getBlock() doesn't return the bed when a bed or respawn anchor is the cause of the explosion, so we use this workaround.
@@ -287,9 +284,11 @@ public class TownyBlockListener implements Listener {
 				// Check the white/blacklist
 				if (!townyWorld.isBlockAllowedToRevert(block.getType()))
 					continue;
+				// Don't start a revert on a block that is going to be reverted.
+				if (TownyRegenAPI.hasProtectionRegenTask(new BlockLocation(block.getLocation())))
+					continue;
 				count++;
-				// Cancel the event outright if this will cause a revert to start on an already operating revert.
-				event.setCancelled(!event.isCancelled() && !TownyRegenAPI.beginProtectionRegenTask(block, count, townyWorld, event));
+				TownyRegenAPI.beginProtectionRegenTask(block, count, townyWorld, event);
 			}
 		}
 	}

--- a/src/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
@@ -284,6 +284,9 @@ public class TownyBlockListener implements Listener {
 				// Only regenerate in the wilderness.
 				if (!TownyAPI.getInstance().isWilderness(block))
 					continue;
+				// Check the white/blacklist
+				if (!townyWorld.isBlockAllowedToRevert(block.getType()))
+					continue;
 				count++;
 				// Cancel the event outright if this will cause a revert to start on an already operating revert.
 				event.setCancelled(!event.isCancelled() && !TownyRegenAPI.beginProtectionRegenTask(block, count, townyWorld, event));

--- a/src/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
@@ -284,6 +284,8 @@ public class TownyBlockListener implements Listener {
 				// Only regenerate in the wilderness.
 				if (!TownyAPI.getInstance().isWilderness(block))
 					continue;
+				if(!townyWorld.isPlotManagementWildRevertProtectingBlock(block.getBlockData().getMaterial()))
+					continue;
 				count++;
 				// Cancel the event outright if this will cause a revert to start on an already operating revert.
 				event.setCancelled(!TownyRegenAPI.beginProtectionRegenTask(block, count, townyWorld, event));

--- a/src/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
@@ -284,11 +284,9 @@ public class TownyBlockListener implements Listener {
 				// Only regenerate in the wilderness.
 				if (!TownyAPI.getInstance().isWilderness(block))
 					continue;
-				if(!townyWorld.isPlotManagementWildRevertProtectingBlock(block.getBlockData().getMaterial()))
-					continue;
 				count++;
 				// Cancel the event outright if this will cause a revert to start on an already operating revert.
-				event.setCancelled(!TownyRegenAPI.beginProtectionRegenTask(block, count, townyWorld, event));
+				event.setCancelled(!event.isCancelled() && !TownyRegenAPI.beginProtectionRegenTask(block, count, townyWorld, event));
 			}
 		}
 	}

--- a/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
@@ -621,6 +621,8 @@ public class TownyEntityListener implements Listener {
 				// Only regenerate in the wilderness.
 				if (!TownyAPI.getInstance().isWilderness(block))
 					continue;
+				if(!townyWorld.isPlotManagementWildRevertProtectingBlock(block.getBlockData().getMaterial()))
+					continue;
 				count++;
 				// Cancel the event outright if this will cause a revert to start on an already operating revert.
 				event.setCancelled(!TownyRegenAPI.beginProtectionRegenTask(block, count, townyWorld, event));

--- a/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
@@ -621,11 +621,9 @@ public class TownyEntityListener implements Listener {
 				// Only regenerate in the wilderness.
 				if (!TownyAPI.getInstance().isWilderness(block))
 					continue;
-				if(!townyWorld.isPlotManagementWildRevertProtectingBlock(block.getBlockData().getMaterial()))
-					continue;
 				count++;
 				// Cancel the event outright if this will cause a revert to start on an already operating revert.
-				event.setCancelled(!TownyRegenAPI.beginProtectionRegenTask(block, count, townyWorld, event));
+				event.setCancelled(!event.isCancelled() && !TownyRegenAPI.beginProtectionRegenTask(block, count, townyWorld, event));
 			}
 		}
 	}

--- a/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
@@ -11,6 +11,7 @@ import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.TownBlockType;
 import com.palmergames.bukkit.towny.object.TownyWorld;
 import com.palmergames.bukkit.towny.regen.TownyRegenAPI;
+import com.palmergames.bukkit.towny.regen.block.BlockLocation;
 import com.palmergames.bukkit.towny.tasks.MobRemovalTimerTask;
 import com.palmergames.bukkit.towny.utils.CombatUtil;
 import com.palmergames.bukkit.towny.utils.EntityTypeUtil;
@@ -602,11 +603,7 @@ public class TownyEntityListener implements Listener {
 		if (!TownyAPI.getInstance().isTownyWorld(event.getEntity().getWorld()))
 			return;
 
-		TownyWorld townyWorld = null;
-		try {
-			townyWorld = TownyUniverse.getInstance().getDataSource().getWorld(event.getLocation().getWorld().getName());
-		} catch (NotRegisteredException ignored) {}
-
+		TownyWorld townyWorld = TownyAPI.getInstance().getTownyWorld(event.getEntity().getWorld().getName());
 		List<Block> blocks = TownyActionEventExecutor.filterExplodableBlocks(event.blockList(), null, event.getEntity(), event);
 		event.blockList().clear();
 		event.blockList().addAll(blocks);
@@ -624,9 +621,11 @@ public class TownyEntityListener implements Listener {
 				// Check the white/blacklist
 				if (!townyWorld.isBlockAllowedToRevert(block.getType()))
 					continue;
+				// Don't start a revert on a block that is going to be reverted.
+				if (TownyRegenAPI.hasProtectionRegenTask(new BlockLocation(block.getLocation())))
+					continue;
 				count++;
-				// Cancel the event outright if this will cause a revert to start on an already operating revert.
-				event.setCancelled(!event.isCancelled() && !TownyRegenAPI.beginProtectionRegenTask(block, count, townyWorld, event));
+				TownyRegenAPI.beginProtectionRegenTask(block, count, townyWorld, event);
 			}
 		}
 	}

--- a/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
@@ -621,6 +621,9 @@ public class TownyEntityListener implements Listener {
 				// Only regenerate in the wilderness.
 				if (!TownyAPI.getInstance().isWilderness(block))
 					continue;
+				// Check the white/blacklist
+				if (!townyWorld.isBlockAllowedToRevert(block.getType()))
+					continue;
 				count++;
 				// Cancel the event outright if this will cause a revert to start on an already operating revert.
 				event.setCancelled(!event.isCancelled() && !TownyRegenAPI.beginProtectionRegenTask(block, count, townyWorld, event));

--- a/src/com/palmergames/bukkit/towny/object/TownyWorld.java
+++ b/src/com/palmergames/bukkit/towny/object/TownyWorld.java
@@ -499,7 +499,7 @@ public class TownyWorld extends TownyObject {
 		return plotManagementWildRevertBlockWhitelist;
 	}
 
-	public boolean isPlotManagementWildRevertProtectingBlock(Material mat) {
+	public boolean isPlotManagementWildRevertWhitelistedBlock(Material mat) {
 
 		if (plotManagementWildRevertBlockWhitelist == null)
 			setPlotManagementWildRevertBlockWhitelist(TownySettings.getWildExplosionRevertBlockWhitelist());

--- a/src/com/palmergames/bukkit/towny/object/TownyWorld.java
+++ b/src/com/palmergames/bukkit/towny/object/TownyWorld.java
@@ -507,6 +507,13 @@ public class TownyWorld extends TownyObject {
 		return plotManagementWildRevertBlockWhitelist.isEmpty() || plotManagementWildRevertBlockWhitelist.contains(mat.name());
 	}
 
+	public boolean isBlockAllowedToRevert(Material mat) {
+		if (getPlotManagementWildRevertBlockWhitelist().isEmpty())
+			return !isPlotManagementIgnoreIds(mat);
+		else
+			return isPlotManagementWildRevertWhitelistedBlock(mat);
+	}
+
 	public void setPlotManagementWildRevertMaterials(List<String> mats) {
 
 		blockExplosionProtection = new ArrayList<>();

--- a/src/com/palmergames/bukkit/towny/object/TownyWorld.java
+++ b/src/com/palmergames/bukkit/towny/object/TownyWorld.java
@@ -36,6 +36,7 @@ public class TownyWorld extends TownyObject {
 	private boolean isUsingPlotManagementWildEntityRevert = TownySettings.isUsingPlotManagementWildEntityRegen();	
 	private long plotManagementWildRevertDelay = TownySettings.getPlotManagementWildRegenDelay();
 	private List<String> entityExplosionProtection = null;
+	private List<String> plotManagementWildRevertBlockWhitelist = null;
 	
 	private boolean isUsingPlotManagementWildBlockRevert = TownySettings.isUsingPlotManagementWildBlockRegen();
 	private List<String> blockExplosionProtection = null;
@@ -477,6 +478,33 @@ public class TownyWorld extends TownyObject {
 
 		return (entityExplosionProtection.contains(entity.getType().getEntityClass().getSimpleName().toLowerCase()));
 
+	}
+
+	public void setPlotManagementWildRevertBlockWhitelist(List<String> mats) {
+
+		plotManagementWildRevertBlockWhitelist = new ArrayList<>();
+
+		for (String mat : mats)
+			if (!mat.equals("")) {
+				plotManagementWildRevertBlockWhitelist.add(mat);
+			}
+
+	}
+
+	public List<String> getPlotManagementWildRevertBlockWhitelist() {
+
+		if (plotManagementWildRevertBlockWhitelist == null)
+			setPlotManagementWildRevertBlockWhitelist(TownySettings.getWildExplosionRevertBlockWhitelist());
+
+		return plotManagementWildRevertBlockWhitelist;
+	}
+
+	public boolean isPlotManagementWildRevertProtectingBlock(Material mat) {
+
+		if (plotManagementWildRevertBlockWhitelist == null)
+			setPlotManagementWildRevertBlockWhitelist(TownySettings.getWildExplosionRevertBlockWhitelist());
+
+		return plotManagementWildRevertBlockWhitelist.isEmpty() || plotManagementWildRevertBlockWhitelist.contains(mat.name());
 	}
 
 	public void setPlotManagementWildRevertMaterials(List<String> mats) {

--- a/src/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
+++ b/src/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
@@ -498,10 +498,8 @@ public class TownyRegenAPI {
 	 * @return true if the protectiontask was begun successfully. 
 	 */
 	public static boolean beginProtectionRegenTask(Block block, int count, TownyWorld world, Event event) {
-		// Cancel the event so it doesn't affect another revert
-		if (hasProtectionRegenTask(new BlockLocation(block.getLocation())))
-			return false;
-		if (!isBlacklistedBlock(world, block.getType())) {
+		// Don't interfere with an existing regen task
+		if (!hasProtectionRegenTask(new BlockLocation(block.getLocation()))) {
 			// Piston extensions which are broken by explosions ahead of the base block
 			// cause baseblocks to drop as items and no base block to be regenerated.
 			if (block.getType().equals(Material.PISTON_HEAD)) {
@@ -525,15 +523,7 @@ public class TownyRegenAPI {
 
 			return true;
 		}
-		// Do not schedule a revert on this block but do not cancel the event
-		return true;
-	}
-	
-	private static boolean isBlacklistedBlock(TownyWorld world, Material type) {
-		if (world.getPlotManagementWildRevertBlockWhitelist().isEmpty())
-			return world.isPlotManagementIgnoreIds(type);
-		else
-			return !world.isPlotManagementWildRevertWhitelistedBlock(type);
+		return false;
 	}
 
 	/**

--- a/src/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
+++ b/src/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
@@ -498,7 +498,10 @@ public class TownyRegenAPI {
 	 * @return true if the protectiontask was begun successfully. 
 	 */
 	public static boolean beginProtectionRegenTask(Block block, int count, TownyWorld world, Event event) {
-		if (!hasProtectionRegenTask(new BlockLocation(block.getLocation())) && !isBlacklistedBlock(world, block.getType())) {
+		// Cancel the event so it doesn't affect another revert
+		if (hasProtectionRegenTask(new BlockLocation(block.getLocation())))
+			return false;
+		if (!isBlacklistedBlock(world, block.getType())) {
 			// Piston extensions which are broken by explosions ahead of the base block
 			// cause baseblocks to drop as items and no base block to be regenerated.
 			if (block.getType().equals(Material.PISTON_HEAD)) {
@@ -522,11 +525,15 @@ public class TownyRegenAPI {
 
 			return true;
 		}
-		return false;
+		// Do not schedule a revert on this block but do not cancel the event
+		return true;
 	}
 	
 	private static boolean isBlacklistedBlock(TownyWorld world, Material type) {
-		return world.isPlotManagementIgnoreIds(type);
+		if(world.getPlotManagementWildRevertBlockWhitelist().isEmpty())
+			return world.isPlotManagementIgnoreIds(type);
+		else
+			return !world.isPlotManagementWildRevertWhitelistedBlock(type);
 	}
 
 	/**

--- a/src/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
+++ b/src/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
@@ -530,7 +530,7 @@ public class TownyRegenAPI {
 	}
 	
 	private static boolean isBlacklistedBlock(TownyWorld world, Material type) {
-		if(world.getPlotManagementWildRevertBlockWhitelist().isEmpty())
+		if (world.getPlotManagementWildRevertBlockWhitelist().isEmpty())
 			return world.isPlotManagementIgnoreIds(type);
 		else
 			return !world.isPlotManagementWildRevertWhitelistedBlock(type);

--- a/src/com/palmergames/bukkit/towny/regen/block/BlockLocation.java
+++ b/src/com/palmergames/bukkit/towny/regen/block/BlockLocation.java
@@ -4,6 +4,8 @@ import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.World;
 
+import java.util.Objects;
+
 /**
  * A class to hold basic block location data
  * 
@@ -60,6 +62,25 @@ public class BlockLocation {
 			return true;
 
 		return false;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		BlockLocation that = (BlockLocation) o;
+		return x == that.x && z == that.z && y == that.y && Objects.equals(chunk, that.chunk) && Objects.equals(world, that.world);
+	}
+
+	@Override
+	public int hashCode() {
+		int hash = 7;
+		hash = 31 * hash + x;
+		hash = 31 * hash + y;
+		hash = 31 * hash + z;
+		hash = hash * 31 + (chunk != null ? chunk.hashCode() : 0);
+		hash = hash * 31 + (world != null ? world.hashCode() : 0);
+		return hash;
 	}
 
 //	public boolean isLocation(BlockLocation blockLocation) {


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This adds a block whitelist to the behavior that regenerates the wilderness after an explosion. Since it is a whitelist, if the config option is empty or not present, all blocks will be considered protected.

I have tested this in every configuration (configured with values, configured empty, and key not present) with the flatfile database, but I have not tested it with the SQL database as I don't have one set up.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
Nodes:
wild_revert_on_explosion_block_whitelist: ''
New world settings:
PlotManagementWildRegenBlockWhitelist=

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
