### PR TITLE
Remove "/t list"`s root permission granting access to all listing options.

### DIFF
--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -345,6 +345,8 @@ permissions:
     towny.command.town.list:
         description: Users are able to use the default method of sorting the town list.
         default: false
+        children:
+            towny.command.town.list.residents: true
 
     towny.command.town.list.*:
         description: Users are able to use all the various methods of sorting the nation list.

--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -343,10 +343,8 @@ permissions:
             towny.command.town.trust: true
 
     towny.command.town.list:
-        description: Users are able to use all the various methods of sorting the town list.
+        description: Users are able to use all the default method of sorting the town list.
         default: false
-        children:
-            towny.command.town.list.*: true
 
     towny.command.town.list.*:
         description: Users are able to use all the various methods of sorting the nation list.

--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -343,7 +343,7 @@ permissions:
             towny.command.town.trust: true
 
     towny.command.town.list:
-        description: Users are able to use all the default method of sorting the town list.
+        description: Users are able to use the default method of sorting the town list.
         default: false
 
     towny.command.town.list.*:


### PR DESCRIPTION
#### Description: 
The purpose of this pull-request is to reinforce adding all listing options as `towny.command.town.list.*`.

As it currently stands, the admin has the option to allow users to do `/t list by <option>` which have corresponding permissions such as `towny.command.town.list.balance`. But if an admin wants to remove the option to use a certain `list by <option>`, they have to remove `towny.command.town.list`, which currently grants access to `towny.command.town.list.*` but the down side is the user is no longer able to use `/t list`, which is the most popular usage.

____
#### New Nodes/Commands/ConfigOptions: 
Changes `towny.command.town.list` to allow access to the root `/t list` command but not grant access to all listing options & their permissions.

____
#### Relevant Towny Issue ticket:
N/A

___
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
