### PR TITLE
Add town&nation rank luckperms contexts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
                     <target>${java.version}</target>
                 </configuration>
             </plugin>
-            <plugin>
+<!--            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.2.0</version>
@@ -221,7 +221,7 @@
                 <configuration>
                     <source>${java.version}</source>
                 </configuration>
-            </plugin>
+            </plugin>-->
             <plugin>  <!-- Create sources.jar -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
                     <target>${java.version}</target>
                 </configuration>
             </plugin>
-<!--            <plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.2.0</version>
@@ -221,7 +221,7 @@
                 <configuration>
                     <source>${java.version}</source>
                 </configuration>
-            </plugin>-->
+            </plugin>
             <plugin>  <!-- Create sources.jar -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>

--- a/src/com/palmergames/bukkit/towny/hooks/LuckPermsContexts.java
+++ b/src/com/palmergames/bukkit/towny/hooks/LuckPermsContexts.java
@@ -3,6 +3,7 @@ package com.palmergames.bukkit.towny.hooks;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.WorldCoord;
+import com.palmergames.bukkit.towny.permissions.TownyPerms;
 import com.palmergames.bukkit.towny.utils.PlayerCacheUtil;
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.context.ContextCalculator;
@@ -25,8 +26,12 @@ public class LuckPermsContexts implements ContextCalculator<Player> {
 	private static final String INSIDETOWN_CONTEXT = "towny:insidetown";
 	private static final String INSIDEOWNTOWN_CONTEXT = "towny:insideowntown";
 	private static final String INSIDEOWNPLOT_CONTEXT = "towny:insideownplot";
+	private static final String TOWN_RANK_CONTEXT = "towny:townrank";
+	private static final String NATION_RANK_CONTEXT = "towny:nationrank";
 	
 	private static final List<String> booleanContexts = Arrays.asList(RESIDENT_CONTEXT, MAYOR_CONTEXT, KING_CONTEXT, INSIDETOWN_CONTEXT, INSIDEOWNTOWN_CONTEXT, INSIDEOWNPLOT_CONTEXT);
+	private static final String nationRankContext = NATION_RANK_CONTEXT;
+	private static final String TownRankContext = TOWN_RANK_CONTEXT;
 	
 	private static LuckPerms luckPerms;
 
@@ -43,6 +48,9 @@ public class LuckPermsContexts implements ContextCalculator<Player> {
 		Resident resident = TownyAPI.getInstance().getResident(player.getName());
 		if (resident == null)
 			return;
+			
+		for (String townrank : resident.getTownRanks()) contextConsumer.accept(TOWN_RANK_CONTEXT, townrank);
+		for (String nationrank : resident.getNationRanks()) contextConsumer.accept(NATION_RANK_CONTEXT, nationrank);
 		
 		contextConsumer.accept(RESIDENT_CONTEXT, Boolean.toString(resident.hasTown()));
 		contextConsumer.accept(MAYOR_CONTEXT, Boolean.toString(resident.isMayor()));
@@ -68,6 +76,9 @@ public class LuckPermsContexts implements ContextCalculator<Player> {
 			builder.add(context, "true");
 			builder.add(context, "false");
 		}
+		for (String nationrank : TownyPerms.getNationRanks()) builder.add(nationRankContext, nationrank);
+		for (String townrank : TownyPerms.getTownRanks()) builder.add(TownRankContext, townrank);
+		
 		return builder.build();
 	}
 }


### PR DESCRIPTION
#### Description: 
Adds even more Towny contexts to luckperms.

With this feature, you can setup permissions for players with ranks which are at the moment inside town, which i find very useful

![image](https://user-images.githubusercontent.com/51333325/126692318-22b73b5a-956c-4dea-bf97-9375c64e583e.png)

![image](https://user-images.githubusercontent.com/51333325/126692376-dea806b9-754f-4841-9dfe-9669526add18.png)

____
#### New Nodes/Commands/ConfigOptions: 
____
#### Relevant Towny Issue ticket:
____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
