### PR TITLE
Allow moving of blocks between wilderness plot borders

### DIFF
--- a/src/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
@@ -238,7 +238,7 @@ public class TownyBlockListener implements Listener {
 		WorldCoord from = WorldCoord.parseWorldCoord(block);
 		WorldCoord to = WorldCoord.parseWorldCoord(blockTo);
 
-		if (from.equals(to) || (allowWild && TownyAPI.getInstance().isWilderness(to)))
+		if (from.equals(to) || (allowWild && to.isWilderness()) || (to.isWilderness() && from.isWilderness()))
 			return true;
 
 		try {

--- a/src/com/palmergames/bukkit/towny/object/WorldCoord.java
+++ b/src/com/palmergames/bukkit/towny/object/WorldCoord.java
@@ -143,6 +143,14 @@ public class WorldCoord extends Coord {
 	}
 
 	/**
+	 * Identical to !{@link WorldCoord#hasTownBlock()}, but is better readable.
+	 * @return Whether this townblock is not claimed.
+	 */
+	public boolean isWilderness() {
+		return !hasTownBlock();
+	}
+
+	/**
 	 * Relatively safe to use if {@link #hasTownBlock()} has already been used.
 	 * @return Town at this WorldCoord or null;
 	 */


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Fixes blocks not being pushable between 2 plot borders in the wilderness, and adds WorldCoord#isWilderness for better readability.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #5127


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
