### PR TITLE
Move permissions check down in onPlayerMove

### DIFF
--- a/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -603,11 +603,11 @@ public class TownyPlayerListener implements Listener {
 		Resident resident = townyUniverse.getResident(player.getUniqueId());
 		
 		if (resident != null
-				&& TownyTimerHandler.isTeleportWarmupRunning()				 
-				&& TownySettings.getTeleportWarmupTime() > 0 
-				&& TownySettings.isMovementCancellingSpawnWarmup() 
-				&& !townyUniverse.getPermissionSource().isTownyAdmin(player) 
-				&& resident.getTeleportRequestTime() > 0) {
+				&& TownyTimerHandler.isTeleportWarmupRunning()	 
+				&& TownySettings.getTeleportWarmupTime() > 0
+				&& TownySettings.isMovementCancellingSpawnWarmup()
+				&& resident.getTeleportRequestTime() > 0
+				&& !townyUniverse.getPermissionSource().isTownyAdmin(player)) {
 			TeleportWarmupTimerTask.abortTeleportRequest(resident);
 			TownyMessaging.sendMsg(resident, ChatColor.RED + Translation.of("msg_err_teleport_cancelled"));
 		}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Moves the isTownyAdmin permission check below the teleport request check, to avoid doing permissions checks for a player that does not have a teleport warmup.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
