### PR TITLE
Let plugins access to original lines via StatusScreenEvent

### DIFF
--- a/src/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/src/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -247,7 +247,7 @@ public class TownyFormatter {
 		
 		out.addAll(getExtraFields(resident));
 		
-		ResidentStatusScreenEvent event = new ResidentStatusScreenEvent(resident);
+		ResidentStatusScreenEvent event = new ResidentStatusScreenEvent(resident, out);
 		Bukkit.getPluginManager().callEvent(event);
 		if (event.hasAdditionalLines())
 			out.addAll(event.getAdditionalLines());
@@ -460,7 +460,7 @@ public class TownyFormatter {
 
 		out.addAll(getExtraFields(town));
 		
-		TownStatusScreenEvent event = new TownStatusScreenEvent(town);
+		TownStatusScreenEvent event = new TownStatusScreenEvent(town, out);
 		Bukkit.getPluginManager().callEvent(event);
 		if (event.hasAdditionalLines())
 			out.addAll(event.getAdditionalLines());
@@ -585,7 +585,7 @@ public class TownyFormatter {
 
 		out.addAll(getExtraFields(nation));
 		
-		NationStatusScreenEvent event = new NationStatusScreenEvent(nation);
+		NationStatusScreenEvent event = new NationStatusScreenEvent(nation, out);
 		Bukkit.getPluginManager().callEvent(event);
 		if (event.hasAdditionalLines())
 			out.addAll(event.getAdditionalLines());

--- a/src/com/palmergames/bukkit/towny/event/damage/TownyFriendlyFireTestEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/damage/TownyFriendlyFireTestEvent.java
@@ -1,0 +1,82 @@
+package com.palmergames.bukkit.towny.event.damage;
+
+import com.palmergames.bukkit.towny.object.TownyWorld;
+import com.palmergames.bukkit.towny.utils.CombatUtil;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class TownyFriendlyFireTestEvent extends Event {
+
+	private static final HandlerList handlers = new HandlerList();
+
+	private final Player attacker;
+	private final Player defender;
+	private final TownyWorld world;
+	private final Relationship relationship;
+
+	private boolean pvp;
+
+	public TownyFriendlyFireTestEvent(Player attacker, Player defender, TownyWorld world, Relationship relationship) {
+		this.attacker = attacker;
+		this.defender = defender;
+		this.world = world;
+		this.relationship = relationship;
+
+		if (world.isFriendlyFireEnabled() || CombatUtil.isArenaPlot(attacker, defender)) {
+			pvp = true;
+		} else {
+			switch (relationship) {
+				case TOWN:
+				case NATION:
+				case ALLY:
+					pvp = false;
+					break;
+				case NEUTRAL:
+				case ENEMY:
+					pvp = true;
+					break;
+			}
+		}
+	}
+
+	public Player getAttacker() {
+		return attacker;
+	}
+
+	public Player getDefender() {
+		return defender;
+	}
+
+	public TownyWorld getWorld() {
+		return world;
+	}
+
+	public Relationship getRelationship() {
+		return relationship;
+	}
+
+	public boolean isPvp() {
+		return pvp;
+	}
+
+	public void setPvp(boolean pvp) {
+		this.pvp = pvp;
+	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
+
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+
+	public enum Relationship {
+		TOWN,
+		NATION,
+		ALLY,
+		NEUTRAL,
+		ENEMY
+	}
+}

--- a/src/com/palmergames/bukkit/towny/event/statusscreen/NationStatusScreenEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/statusscreen/NationStatusScreenEvent.java
@@ -2,11 +2,14 @@ package com.palmergames.bukkit.towny.event.statusscreen;
 
 import com.palmergames.bukkit.towny.object.Nation;
 
+import java.util.List;
+
 public class NationStatusScreenEvent extends StatusScreenEvent {
 
 	private Nation nation;
 	
-	public NationStatusScreenEvent(Nation nation) {
+	public NationStatusScreenEvent(Nation nation, List<String> originalLines) {
+		super(originalLines);
 		this.nation = nation;
 	}
 	

--- a/src/com/palmergames/bukkit/towny/event/statusscreen/ResidentStatusScreenEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/statusscreen/ResidentStatusScreenEvent.java
@@ -2,11 +2,14 @@ package com.palmergames.bukkit.towny.event.statusscreen;
 
 import com.palmergames.bukkit.towny.object.Resident;
 
+import java.util.List;
+
 public class ResidentStatusScreenEvent extends StatusScreenEvent {
 
 	private Resident resident;
 	
-	public ResidentStatusScreenEvent(Resident resident) {
+	public ResidentStatusScreenEvent(Resident resident, List<String> originalLines) {
+		super(originalLines);
 		this.resident = resident;
 	}
 	

--- a/src/com/palmergames/bukkit/towny/event/statusscreen/StatusScreenEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/statusscreen/StatusScreenEvent.java
@@ -10,10 +10,13 @@ import org.bukkit.event.HandlerList;
 public class StatusScreenEvent extends Event {
 
 	private static final HandlerList handlers = new HandlerList();
+	private List<String> originalLines;
 	private List<String> addedLines = new ArrayList<>();
 	
-	public StatusScreenEvent() {
+	public StatusScreenEvent(List<String> originalLines) {
 		super(!Bukkit.getServer().isPrimaryThread());
+		
+		this.originalLines = originalLines;
 	}
 	
 	@Override
@@ -24,6 +27,8 @@ public class StatusScreenEvent extends Event {
 	public static HandlerList getHandlerList() {
 		return handlers;
 	}
+	
+	public List<String> getOriginalLines() { return originalLines; }
 
  	public boolean hasAdditionalLines() {
  		return !addedLines.isEmpty();

--- a/src/com/palmergames/bukkit/towny/event/statusscreen/TownStatusScreenEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/statusscreen/TownStatusScreenEvent.java
@@ -2,11 +2,14 @@ package com.palmergames.bukkit.towny.event.statusscreen;
 
 import com.palmergames.bukkit.towny.object.Town;
 
+import java.util.List;
+
 public class TownStatusScreenEvent extends StatusScreenEvent {
 
 	private Town town;
 	
-	public TownStatusScreenEvent(Town town) {
+	public TownStatusScreenEvent(Town town, List<String> originalLines) {
+		super(originalLines);
 		this.town = town;
 	}
 	

--- a/src/com/palmergames/bukkit/towny/utils/CombatUtil.java
+++ b/src/com/palmergames/bukkit/towny/utils/CombatUtil.java
@@ -406,10 +406,10 @@ public class CombatUtil {
 			TownyFriendlyFireTestEvent event = new TownyFriendlyFireTestEvent(attacker, defender, world, relationship);
 			Bukkit.getPluginManager().callEvent(event);
 			
-			if(event.isPvp())
+			if(!event.isPvp())
 				TownyMessaging.sendErrorMsg(attacker, Translation.of("msg_err_friendly_fire_disable"));
 			
-			return event.isPvp();
+			return !event.isPvp();
 		}
 		return false;
 	}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
I'm making a Towny Add-On plugin called "TownyKOTH" and I wanna show simplified town informations for specified towns but with current TownStatusScreenEvent I can't so made changes in API
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
