### PR TITLE
Fix AlreadyRegisteredException when accepting two invites or more

### DIFF
--- a/src/com/palmergames/bukkit/towny/object/inviteobjects/PlayerJoinTownInvite.java
+++ b/src/com/palmergames/bukkit/towny/object/inviteobjects/PlayerJoinTownInvite.java
@@ -19,9 +19,12 @@ public class PlayerJoinTownInvite extends AbstractInvite<Town, Resident> {
 		Resident resident = getReceiver();
 		Town town = getSender();
 		
-		TownCommand.townAddResident(town, resident);
-		TownyMessaging.sendPrefixedTownMessage(town, Translation.of("msg_join_town", resident.getName()));
-		
+		if(!resident.hasTown()){
+			TownCommand.townAddResident(town, resident);
+			TownyMessaging.sendPrefixedTownMessage(town, Translation.of("msg_join_town", resident.getName()));
+		} else {
+			TownyMessaging.sendMsg(resident, Translation.of("msg_err_already_res"));
+		}
 		resident.deleteReceivedInvite(this);
 		town.deleteSentInvite(this);
 	}

--- a/src/com/palmergames/bukkit/towny/object/inviteobjects/TownJoinNationInvite.java
+++ b/src/com/palmergames/bukkit/towny/object/inviteobjects/TownJoinNationInvite.java
@@ -23,7 +23,11 @@ public class TownJoinNationInvite extends AbstractInvite<Nation, Town> {
 		List<Town> towns = new ArrayList<>();
 		towns.add(town);
 		Nation nation = getSender();
-		NationCommand.nationAdd(nation, towns);
+		if(!town.hasNation()){
+			NationCommand.nationAdd(nation, towns);
+		} else {
+			TownyMessaging.sendPrefixedTownMessage(town, Translation.of("msg_err_already_nation", town.getName()));
+		}
 		// Message handled in nationAdd()
 		town.deleteReceivedInvite(this);
 		nation.deleteSentInvite(this);


### PR DESCRIPTION
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
An AlreadyRegisteredException spawns when a user accepts two more invites without leaving a town prior. This check will warn the player they are already in a town and not add them but remove the invite. 
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Didn't make an issue.

____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [x] if you have tested this code on a server. --->
Tested on 1.17.1.

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.