### PR TITLE
Adds spawn protection for players who've just died.

### DIFF
--- a/resources/lang/en-US.yml
+++ b/resources/lang/en-US.yml
@@ -1521,3 +1521,6 @@ msg_setup_town_cost: 'How much should the cost to create a new town be? The defa
 msg_setup_nation_cost: 'How much should the cost to create a new nation be? The default is 1000.'
 msg_setup_townblock_cost: 'How much should it cost to claim a townblock? The default is 25. A townblock is the same size as a chunk (default settings)'
 msg_setup_success: 'Successfully changed config values to your new values.'
+
+msg_err_player_cannot_be_harmed: '%s spawned recently and cannot be harmed.'
+msg_you_have_lost_your_invulnerability: 'You have lost your invulnerability.'

--- a/resources/lang/en-US.yml
+++ b/resources/lang/en-US.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.124
+version: 0.125
 language: english
 author: ElgarL
 website: 'http://townyadvanced.github.io/'
@@ -1522,5 +1522,8 @@ msg_setup_nation_cost: 'How much should the cost to create a new nation be? The 
 msg_setup_townblock_cost: 'How much should it cost to claim a townblock? The default is 25. A townblock is the same size as a chunk (default settings)'
 msg_setup_success: 'Successfully changed config values to your new values.'
 
+#Added in 0.125
+#Player has recently died and respawned and is invulnerable.
 msg_err_player_cannot_be_harmed: '%s spawned recently and cannot be harmed.'
+#Player was invulnerable after respawning and has lost their invulnerability.
 msg_you_have_lost_your_invulnerability: 'You have lost your invulnerability.'

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -575,7 +575,7 @@ public enum ConfigNodes {
 			"10s",
 			"",
 			"# When greater than 0s, the amount of time a player who has respawned is considered invulnerable.",
-			"# Invulnerable players who attacker other players will lose their invulnerability.",
+			"# Invulnerable players who attack other players will lose their invulnerability.",
 			"# Invulnerable players who teleport after respawn will also lose their invulnerability."),
 	GTOWN_SETTINGS_TOWN_RESPAWN_SAME_WORLD_ONLY(
 			"global_town_settings.town_respawn_same_world_only",

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -569,7 +569,14 @@ public enum ConfigNodes {
 			"global_town_settings.town_respawn",
 			"false",
 			"",
-			"# Respawn the player at his town spawn point when he/she dies"),
+			"# When true Towny will handle respawning, with town or resident spawns."),
+	GTOWN_SETTINGS_RESPAWN_PROTECTION(
+			"global_town_settings.respawn_protection",
+			"10s",
+			"",
+			"# When greater than 0s, the amount of time a player who has respawned is considered invulnerable.",
+			"# Invulnerable players who attacker other players will lose their invulnerability.",
+			"# Invulnerable players who teleport after respawn will also lose their invulnerability."),
 	GTOWN_SETTINGS_TOWN_RESPAWN_SAME_WORLD_ONLY(
 			"global_town_settings.town_respawn_same_world_only",
 			"false",

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -3165,5 +3165,9 @@ public class TownySettings {
 	public static void saveConfig() {
 		config.save();
 	}
+
+	public static long getSpawnProtection() {
+		return TimeTools.getTicks(getString(ConfigNodes.GTOWN_SETTINGS_RESPAWN_PROTECTION));
+	}
 }
 

--- a/src/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
@@ -14,6 +14,7 @@ import com.palmergames.bukkit.towny.command.TownyCommand;
 import com.palmergames.bukkit.towny.event.BedExplodeEvent;
 import com.palmergames.bukkit.towny.event.NewTownEvent;
 import com.palmergames.bukkit.towny.event.PlayerChangePlotEvent;
+import com.palmergames.bukkit.towny.event.damage.TownyPlayerDamagePlayerEvent;
 import com.palmergames.bukkit.towny.event.nation.NationPreTownLeaveEvent;
 import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
 import com.palmergames.bukkit.towny.object.CellBorder;
@@ -190,6 +191,20 @@ public class TownyCustomListener implements Listener {
 		if (event.getTown().isConquered()) {
 			event.setCancelMessage(Translation.of("msg_err_your_conquered_town_cannot_leave_the_nation_yet"));
 			event.setCancelled(true);
+		}
+	}
+	
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true) 
+	public void onPlayerDamagePlayerEvent(TownyPlayerDamagePlayerEvent event) {
+		Resident victim = event.getVictimResident();
+		Resident attacker = event.getAttackingResident();
+		if (victim.getSpawnProtectionTaskID() != 0) {			
+			event.setCancelled(true);
+			event.setMessage(Translatable.of("msg_err_player_cannot_be_harmed", victim.getName()).forLocale(attacker));
+		}
+		if (attacker.getSpawnProtectionTaskID() != 0) {
+			event.setCancelled(true);
+			attacker.removeSpawnProtection();
 		}
 	}
 }

--- a/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -38,7 +38,6 @@ import com.palmergames.bukkit.util.ItemLists;
 import com.palmergames.util.StringMgmt;
 
 import com.palmergames.util.TimeMgmt;
-
 import net.citizensnpcs.api.CitizensAPI;
 
 import org.bukkit.Bukkit;
@@ -190,6 +189,14 @@ public class TownyPlayerListener implements Listener {
 			event.setRespawnLocation(player.getBedSpawnLocation());
 		} else {
 			event.setRespawnLocation(respawn);
+		}
+
+		// Handle Spawn protection
+		long protectionTime = TownySettings.getSpawnProtection();
+		if (protectionTime > 0l) {
+			Resident res = TownyAPI.getInstance().getResident(player);
+			int taskID = Bukkit.getScheduler().runTaskLater(plugin, ()-> res.removeSpawnProtection(), protectionTime).getTaskId();
+			res.setSpawnProtectionTaskID(taskID);
 		}
 	}
 	
@@ -713,6 +720,13 @@ public class TownyPlayerListener implements Listener {
 				return;
 			}
 		}
+		
+		/*
+		 * Remove spawn protection if the player is teleporting since spawning.
+		 */
+		if (resident.getSpawnProtectionTaskID() != 0)
+			resident.removeSpawnProtection();
+		
 		onPlayerMove(event);
 	}
 

--- a/src/com/palmergames/bukkit/towny/object/Resident.java
+++ b/src/com/palmergames/bukkit/towny/object/Resident.java
@@ -26,6 +26,8 @@ import com.palmergames.bukkit.towny.tasks.SetDefaultModes;
 import com.palmergames.bukkit.util.BukkitTools;
 import com.palmergames.bukkit.util.Colors;
 import com.palmergames.util.StringMgmt;
+
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
@@ -71,6 +73,7 @@ public class Resident extends TownyObject implements InviteReceiver, EconomyHand
 
 	private ArrayList<Inventory> guiPages;
 	private int guiPageNum = 0;
+	private int spawnProtectionTaskID = 0;
 
 	public Resident(String name) {
 		super(name);
@@ -839,6 +842,21 @@ public class Resident extends TownyObject implements InviteReceiver, EconomyHand
 	public boolean isOnline() {
 		return BukkitTools.isOnline(getName());
 	}
+
+	public int getSpawnProtectionTaskID() {
+		return spawnProtectionTaskID;
+	}
+
+	public void setSpawnProtectionTaskID(int spawnProtectionTaskID) {
+		this.spawnProtectionTaskID = spawnProtectionTaskID;
+	}
+	
+	public void removeSpawnProtection() {
+		Bukkit.getScheduler().cancelTask(getSpawnProtectionTaskID());
+		setSpawnProtectionTaskID(0);
+		TownyMessaging.sendMsg(this, Translatable.of("msg_you_have_lost_your_invulnerability").forLocale(this));
+	}
+
 
 	/**
 	 * @deprecated As of 0.96.0.0+ please use {@link EconomyAccount#getWorld()} instead.


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Players who have died and are being respawned in a location set by Towny (town_respawn: true in the config) will be granted a period of invulnerability. This is taken away early if the player attacks another player, or if they teleport.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->

- New Config Node: global_town_settings.respawn_protection
  - Default; 10s
  - When greater than 0s, the amount of time a player who has respawned
is considered invulnerable.
  - Invulnerable players who attacker other players will lose their
invulnerability.
  - Invulnerable players who teleport after respawn will also lose their
invulnerability.
____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
