### PR TITLE
Fix Citizens NPCs causing error on PlayerTeleportEvent.

### DIFF
--- a/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -598,6 +598,10 @@ public class TownyPlayerListener implements Listener {
 			event.setCancelled(true);
 			return;
 		}
+		// Let's ignore Citizens NPCs
+		if (plugin.isCitizens2() && CitizensAPI.getNPCRegistry().isNPC(event.getPlayer())) {
+			return;
+		}
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
 
 		/*
@@ -650,13 +654,17 @@ public class TownyPlayerListener implements Listener {
 
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onPlayerTeleport(PlayerTeleportEvent event) {
-
 		if (plugin.isError()) {
 			// Citizens stores their NPCs at the world spawn and when players load chunks the NPC is teleported there. 
 			// Towny was preventing them being teleported and causing NPCs to be at a world spawn, even after the Safe Mode was cleaned up. 
 			if (plugin.isCitizens2() && CitizensAPI.getNPCRegistry().isNPC(event.getPlayer()))
 				return;
 			event.setCancelled(true);
+			return;
+		}
+		
+		// Let's ignore Citizens NPCs
+		if (plugin.isCitizens2() && CitizensAPI.getNPCRegistry().isNPC(event.getPlayer())) {
 			return;
 		}
 
@@ -724,8 +732,9 @@ public class TownyPlayerListener implements Listener {
 		/*
 		 * Remove spawn protection if the player is teleporting since spawning.
 		 */
-		if (resident.getSpawnProtectionTaskID() != 0)
+		if (resident != null && resident.getSpawnProtectionTaskID() != 0) {
 			resident.removeSpawnProtection();
+		}
 		
 		onPlayerMove(event);
 	}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Fixes a towny issue and basically always ignores Citizens2 Player's in Towny events.

Mainly caused by a missing resident != null for the new resident spawn protection task.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
Nope

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
#5318 

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
