### PR TITLE
Adds ability to override a town's NationZone.

### DIFF
--- a/resources/lang/en-US.yml
+++ b/resources/lang/en-US.yml
@@ -1538,3 +1538,7 @@ status_joined_town: 'Joined town:'
 status_joined_nation: 'Joined nation:'
 #Shown in status screen elements where a value is not known.
 status_unknown: 'unknown'
+#Feedback given for the /ta set nationzoneoverride [townname] [size] command.
+msg_nationzone_override_set_to: '%s has had their nationzone override set to %s.'
+#Feedback given for the /ta set nationzoneoverride [townname] 0 command.
+msg_nationzone_override_removed: '%s has had their nationzone override removed.'

--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -613,6 +613,7 @@ permissions:
         children:
             towny.command.townyadmin.set.capital: true
             towny.command.townyadmin.set.mayor: true
+            towny.command.townyadmin.set.nationzoneoverride: true
             towny.command.townyadmin.set.plot: true
             towny.command.townyadmin.set.surname: true
             towny.command.townyadmin.set.title: true

--- a/src/com/palmergames/bukkit/towny/TownyAPI.java
+++ b/src/com/palmergames/bukkit/towny/TownyAPI.java
@@ -607,11 +607,13 @@ public class TownyAPI {
 		}
 
 		try {
-			int nationZoneRadius = Integer.parseInt(TownySettings.getNationLevel(TownyAPI.getInstance().getTownNationOrNull(nearestTown)).get(TownySettings.NationLevel.NATIONZONES_SIZE).toString());
+			int nationZoneRadius = Integer.parseInt(TownySettings.getNationLevel(nearestTown.getNationOrNull()).get(TownySettings.NationLevel.NATIONZONES_SIZE).toString());
 			
-			if (nearestTown.isCapital()) {
+			if (nearestTown.isCapital())
 				nationZoneRadius += TownySettings.getNationZonesCapitalBonusSize();
-			}
+
+			if (nearestTown.hasNationZoneOverride())
+				nationZoneRadius = nearestTown.getNationZoneOverride();
 
 			if (distance <= nationZoneRadius) {
 				NationZoneTownBlockStatusEvent event = new NationZoneTownBlockStatusEvent(nearestTown);

--- a/src/com/palmergames/bukkit/towny/command/HelpMenu.java
+++ b/src/com/palmergames/bukkit/towny/command/HelpMenu.java
@@ -224,6 +224,7 @@ public enum HelpMenu {
 				.add("mayor [town] " + Translation.of("town_help_2"), "")
 				.add("mayor [town] npc", "")
 				.add("capital [town] [nation]", "")
+				.add("nationzoneoverride [town name] [size]", "")
 				.add("title [resident] [title]", "")
 				.add("surname [resident] [surname]", "")
 				.add("plot [town]", "");
@@ -254,6 +255,15 @@ public enum HelpMenu {
 				.add("[town]",  Translation.of("msg_admin_set_plot_help_1"))
 				.add("[town name] {rect|circle} {radius}", Translation.of("msg_admin_set_plot_help_2"))
 				.add("[town name] {rect|circle} auto", Translation.of("msg_admin_set_plot_help_2"));
+		}
+	},
+	
+	TA_SET_NATIONZONE {
+		@Override
+		protected MenuBuilder load() {
+			return new MenuBuilder("townyadmin set nationzoneoverride")
+				.add("[town name] [size]", "")
+				.add("[town name] 0", "Removes the NationZone override.");
 		}
 	},
 	

--- a/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -200,6 +200,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		"capital",
 		"title",
 		"surname",
+		"nationzoneoverride",
 		"plot"
 	);
 	
@@ -264,6 +265,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 									return filterByStartOrGetTownyStartingWith(Collections.singletonList("npc"), args[3], "+r");
 							}
 						case "capital":
+						case "nationzoneoverride":
 						case "plot":
 							if (args.length == 3)
 								return getTownyStartingWith(args[2], "t");
@@ -1872,7 +1874,36 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 				TownyMessaging.sendMessage(sender, Translatable.of("msg_clear_title_surname", "Surname", resident.getName()));
 				TownyMessaging.sendMessage(resident, Translatable.of("msg_clear_title_surname", "Surname", resident.getName()));
 			}
+		} else if (split[0].equalsIgnoreCase("nationzoneoverride")) {
+			if (!townyUniverse.getPermissionSource().testPermission(player, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_SET_NATIONZONE.getNode(split[0].toLowerCase())))
+				throw new TownyException(Translatable.of("msg_err_command_disable"));
+			
+			if (split.length < 2) {
+				HelpMenu.TA_SET_NATIONZONE.send(sender);
+				return;
+			}
+			
+			Town town = townyUniverse.getTown(split[1]);
+			if (town == null)
+				throw new TownyException(Translatable.of("msg_err_not_registered_1", split[1]));
 
+			int size;
+			try {
+				size = Integer.parseInt(split[2]);
+			} catch (NumberFormatException e) {
+				throw new TownyException(Translatable.of("msg_error_must_be_int"));
+			}
+			
+			if (size < 0)
+				throw new TownyException(Translatable.of("msg_err_negative"));
+			
+			town.setNationZoneOverride(size);
+			town.save();
+			if (size == 0)
+				TownyMessaging.sendMessage(sender, Translatable.of("msg_nationzone_override_removed", town.getName()));
+			else 
+				TownyMessaging.sendMessage(sender, Translatable.of("msg_nationzone_override_set_to", town.getName(), size));
+			
 		} else if (split[0].equalsIgnoreCase("plot")) {
 			if (!townyUniverse.getPermissionSource().testPermission(player, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_SET_PLOT.getNode(split[0].toLowerCase())))
 				throw new TownyException(Translatable.of("msg_err_command_disable"));

--- a/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
+++ b/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
@@ -191,6 +191,7 @@ public class SQL_Schema {
 		columns.add("`primaryJail` VARCHAR(36) DEFAULT NULL");
 		columns.add("`movedHomeBlockAt` BIGINT NOT NULL");
 		columns.add("`trustedResidents` mediumtext DEFAULT NULL");
+		columns.add("`nationZoneOverride` int(11) DEFAULT 0");
 		return columns;
 	}
 

--- a/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -980,6 +980,13 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 				} else {
 					town.setMapColorHexCode(MapUtil.generateRandomTownColourAsHexCode());
 				}
+				
+				line = keys.get("nationZoneOverride");
+				if (line != null)
+					try {
+						town.setNationZoneOverride(Integer.parseInt(line));
+					} catch (Exception ignored) {
+					}
 
 			} catch (Exception e) {
 				TownyMessaging.sendErrorMsg(Translation.of("flatfile_err_reading_town_file_at_line", town.getName(), line, town.getName()));
@@ -1974,7 +1981,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 		list.add("trustedResidents=" + StringMgmt.join(toUUIDList(town.getTrustedResidents()), ","));
 		
 		list.add("mapColorHexCode=" + town.getMapColorHexCode());
-
+		list.add("nationZoneOverride=" + town.getNationZoneOverride());
 		
 		/*
 		 *  Make sure we only save in async

--- a/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -996,6 +996,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			town.setMovedHomeBlockAt(rs.getLong("movedHomeBlockAt"));
 
 			town.setPurchasedBlocks(rs.getInt("purchased"));
+			town.setNationZoneOverride(rs.getInt("nationZoneOverride"));
 			
 			line = rs.getString("maxPercentTaxAmount");
 			if (line != null)
@@ -2123,6 +2124,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			twn_hm.put("protectionStatus", town.getPermissions().toString().replaceAll(",", "#"));
 			twn_hm.put("bonus", town.getBonusBlocks());
 			twn_hm.put("purchased", town.getPurchasedBlocks());
+			twn_hm.put("nationZoneOverride", town.getNationZoneOverride());
 			twn_hm.put("commercialPlotPrice", town.getCommercialPlotPrice());
 			twn_hm.put("commercialPlotTax", town.getCommercialPlotTax());
 			twn_hm.put("embassyPlotPrice", town.getEmbassyPlotPrice());

--- a/src/com/palmergames/bukkit/towny/object/Town.java
+++ b/src/com/palmergames/bukkit/towny/object/Town.java
@@ -71,6 +71,7 @@ public class Town extends Government implements TownBlockOwner {
 	private boolean adminEnabledPVP = false; // This is a special setting to make a town ignore All PVP settings and keep PVP enabled. Overrides the admin disabled too.
 	private boolean isConquered = false;
 	private int conqueredDays;
+	private int nationZoneOverride = 0;
 	private final ConcurrentHashMap<WorldCoord, TownBlock> townBlocks = new ConcurrentHashMap<>();
 	private final TownyPermission permissions = new TownyPermission();
 	private boolean ruined = false;
@@ -1374,6 +1375,18 @@ public class Town extends Government implements TownBlockOwner {
 	@Override
 	public void save() {
 		TownyUniverse.getInstance().getDataSource().saveTown(this);
+	}
+
+	public int getNationZoneOverride() {
+		return nationZoneOverride;
+	}
+	
+	public void setNationZoneOverride(int size) {
+		this.nationZoneOverride = size;
+	}
+	
+	public boolean hasNationZoneOverride() {
+		return nationZoneOverride > 0;
 	}
 	
 	/**

--- a/src/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
+++ b/src/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
@@ -264,6 +264,7 @@ public enum PermissionNodes {
 		TOWNY_COMMAND_TOWNYADMIN_SET_CAPITAL("towny.command.townyadmin.set.capital"),
 		TOWNY_COMMAND_TOWNYADMIN_SET_TITLE("towny.command.townyadmin.set.title"),
 		TOWNY_COMMAND_TOWNYADMIN_SET_SURNAME("towny.command.townyadmin.set.surname"),
+		TOWNY_COMMAND_TOWNYADMIN_SET_NATIONZONE("towny.command.townyadmin.set.nationzoneoverride"),
 		
     TOWNY_COMMAND_TOWNYADMIN_PLOT("towny.command.townyadmin.plot.*"),
     	TOWNY_COMMAND_TOWNYADMIN_PLOT_CLAIM("towny.command.townyadmin.plot.claim"),


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Admins can set an override on a nationzone size per-town.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
  - New Command: /ta set nationzoneoverride [town] [size]
    - Sets a town's nationzone override.

  - New Permission Node: towny.command.townyadmin.set.nationzoneoverride
    - Child node of towny.command.townyadmin.set.*

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

  - Closes #4915.
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
