### PR TITLE
Remove one-way alliances

### DIFF
--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -2395,12 +2395,6 @@ public enum ConfigNodes {
 			"true",
 			"",
 			"#This setting allows you disable the ability for a nation to pay to remain neutral during a war."),
-	WAR_DISALLOW_ONE_WAY_ALLIANCE(
-			"war.disallow_one_way_alliance",
-			"true",
-			"",
-			"#By setting this to true, nations will receive a prompt for alliances and alliances will show on both nations."
-	),
 	WAR_EVENT(
 			"war.event",
 			"",

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -2709,11 +2709,6 @@ public class TownySettings {
 		setProperty(ConfigNodes.ECO_BANK_NATION_ALLOW_WITHDRAWALS.getRoot(), newSetting);
 	}
 
-	public static boolean isDisallowOneWayAlliance() {
-		
-		return getBoolean(ConfigNodes.WAR_DISALLOW_ONE_WAY_ALLIANCE);
-	}
-	
 	public static int getMaxNumResidentsWithoutNation() {
 		return getInt(ConfigNodes.GTOWN_SETTINGS_MAX_NUMBER_RESIDENTS_WITHOUT_NATION);
 	}

--- a/src/com/palmergames/bukkit/towny/command/HelpMenu.java
+++ b/src/com/palmergames/bukkit/towny/command/HelpMenu.java
@@ -765,20 +765,14 @@ public enum HelpMenu {
 	ALLIES_STRING {
 		@Override
 		protected MenuBuilder load() {
-			MenuBuilder builder = new MenuBuilder("nation ally")
-				.add("add [nation]", Translation.of("nation_ally_help_1"));
-
-			if (TownySettings.isDisallowOneWayAlliance()) {
-				builder.add("add -[nation]", Translation.of("nation_ally_help_7"));
-			}
-			builder.add("remove [nation]", Translation.of("nation_ally_help_2"));
-			if (TownySettings.isDisallowOneWayAlliance()) {
-				builder.add("sent", Translation.of("nation_ally_help_3"))
-					.add("received", Translation.of("nation_ally_help_4"))
-					.add("accept [nation]", Translation.of("nation_ally_help_5"))
-					.add("deny [nation]", Translation.of("nation_ally_help_6"));
-			}
-			return builder;
+			return new MenuBuilder("nation ally")
+				.add("add [nation]", Translation.of("nation_ally_help_1"))
+				.add("add -[nation]", Translation.of("nation_ally_help_7"))
+				.add("remove [nation]", Translation.of("nation_ally_help_2"))
+				.add("sent", Translation.of("nation_ally_help_3"))
+				.add("received", Translation.of("nation_ally_help_4"))
+				.add("accept [nation]", Translation.of("nation_ally_help_5"))
+				.add("deny [nation]", Translation.of("nation_ally_help_6"));
 		}
 	},
 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
One-way alliances became a legacy thing when invites were first added by
ArticDive years ago.

This commit removes one-way alliances, removing the option for a nation
to ally another ally, without it being a reciprocal relationship.

With the EventWar revamp, one-way alliances is one of the features that
will not carry forward. Someone could still use the API to make one-way
alliances happen if they really wanted it.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
Removed config node: war.disallow_one_way_alliance

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
