### PR TITLE
Fix empty strings always being blacklisted

### DIFF
--- a/src/com/palmergames/bukkit/util/NameValidation.java
+++ b/src/com/palmergames/bukkit/util/NameValidation.java
@@ -113,7 +113,10 @@ public class NameValidation {
 	 * @param name String name to check.
 	 * @return true if this is something that isn't allowed in the config's name blacklist.
 	 */
-	public static boolean isConfigBlacklistedName(String name ) {
+	public static boolean isConfigBlacklistedName(String name) {
+		if (name.isEmpty())
+			return false;
+		
 		return TownySettings.getBlacklistedNames().stream().anyMatch(name::equalsIgnoreCase);
 	}
 	


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
The blacklisted names array in the config is empty by default, the change I made to it in my last PR caused empty strings to always be considered blacklisted.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
