### PR TITLE
Fix typo in /n set capital node.

### DIFF
--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -290,7 +290,7 @@ permissions:
         default: false
         children:
             towny.command.nation.set.board: true
-            towny.command.nation.set.capitol: true
+            towny.command.nation.set.capital: true
             towny.command.nation.set.king: true
             towny.command.nation.set.name: true
             towny.command.nation.set.spawn: true

--- a/src/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
+++ b/src/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
@@ -48,7 +48,7 @@ public enum PermissionNodes {
 	
 	TOWNY_COMMAND_NATION_SET("towny.command.nation.set.*"),
 		TOWNY_COMMAND_NATION_SET_KING("towny.command.nation.set.king"),
-		TOWNY_COMMAND_NATION_SET_CAPITOL("towny.command.nation.set.capitol"),
+		TOWNY_COMMAND_NATION_SET_CAPITAL("towny.command.nation.set.capital"),
 		TOWNY_COMMAND_NATION_SET_TAXES("towny.command.nation.set.taxes"),
 		TOWNY_COMMAND_NATION_SET_NAME("towny.command.nation.set.name"),
 		TOWNY_COMMAND_NATION_SET_TITLE("towny.command.nation.set.title"),


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Currently, in the plugin.yml and PermissionNodes, capital is called capitol, even though the perm node being tested for in NationCommand uses capital because of the catch-all permissions check.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [N/A] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
