### PR TITLE
Queue the revert on unclaim feature.

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -2960,7 +2960,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 				TownyRegenAPI.addPlotChunkSnapshot(plotChunk); // Save a snapshot.
 				plotChunk = null;
 				// Remove the WorldCoord from the regenqueue.
-				TownyRegenAPI.removeFromRegenList(townBlock.getWorldCoord());
+				TownyRegenAPI.removeFromRegenQueueList(townBlock.getWorldCoord());
 			}
 		}
 		if (TownyEconomyHandler.isActive()) {

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -2947,9 +2947,8 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 			PlotBlockData plotChunk = TownyRegenAPI.getPlotChunk(townBlock);
 			if (plotChunk != null && TownyRegenAPI.getRegenQueueList().contains(townBlock.getWorldCoord())) {
 				// This plot is in the regeneration queue.
-				TownyRegenAPI.deletePlotChunk(plotChunk); // just claimed so stop regeneration.
-				// Remove the WorldCoord from the regenqueue.
-				TownyRegenAPI.removeFromRegenQueueList(townBlock.getWorldCoord());
+				TownyRegenAPI.removeFromActiveRegeneration(plotChunk); // just claimed so stop regeneration.
+				TownyRegenAPI.removeFromRegenQueueList(townBlock.getWorldCoord()); // Remove the WorldCoord from the regenqueue.
 			} else {
 
 				plotChunk = new PlotBlockData(townBlock); // Not regenerating so create a new snapshot.

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -2944,19 +2944,24 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		town.setSpawn(spawn);
 
 		if (world.isUsingPlotManagementRevert()) {
-			PlotBlockData plotChunk = TownyRegenAPI.getPlotChunk(townBlock);
-			if (plotChunk != null) {
+			if (TownyRegenAPI.getRegenQueueList().contains(townBlock.getWorldCoord())) {
+				// This plot is in the regeneration queue.
+				PlotBlockData plotChunk = TownyRegenAPI.getPlotChunk(townBlock);
+				if (plotChunk != null) {
 
-				TownyRegenAPI.deletePlotChunk(plotChunk); // just claimed so stop regeneration.
-
-			} else {
-
-				plotChunk = new PlotBlockData(townBlock); // Not regenerating so create a new snapshot.
-				plotChunk.initialize();
-
+					TownyRegenAPI.deletePlotChunk(plotChunk); // just claimed so stop regeneration.
+	
+				} else {
+	
+					plotChunk = new PlotBlockData(townBlock); // Not regenerating so create a new snapshot.
+					plotChunk.initialize();
+	
+				}
+				TownyRegenAPI.addPlotChunkSnapshot(plotChunk); // Save a snapshot.
+				plotChunk = null;
+				// Remove the WorldCoord from the regenqueue.
+				TownyRegenAPI.removeFromRegenList(townBlock.getWorldCoord());
 			}
-			TownyRegenAPI.addPlotChunkSnapshot(plotChunk); // Save a snapshot.
-			plotChunk = null;
 		}
 		if (TownyEconomyHandler.isActive()) {
 			TownyMessaging.sendDebugMsg("Creating new Town account: " + TownySettings.getTownAccountPrefix() + name);

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -2944,24 +2944,20 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		town.setSpawn(spawn);
 
 		if (world.isUsingPlotManagementRevert()) {
-			if (TownyRegenAPI.getRegenQueueList().contains(townBlock.getWorldCoord())) {
+			PlotBlockData plotChunk = TownyRegenAPI.getPlotChunk(townBlock);
+			if (plotChunk != null && TownyRegenAPI.getRegenQueueList().contains(townBlock.getWorldCoord())) {
 				// This plot is in the regeneration queue.
-				PlotBlockData plotChunk = TownyRegenAPI.getPlotChunk(townBlock);
-				if (plotChunk != null) {
-
-					TownyRegenAPI.deletePlotChunk(plotChunk); // just claimed so stop regeneration.
-	
-				} else {
-	
-					plotChunk = new PlotBlockData(townBlock); // Not regenerating so create a new snapshot.
-					plotChunk.initialize();
-	
-				}
-				TownyRegenAPI.addPlotChunkSnapshot(plotChunk); // Save a snapshot.
-				plotChunk = null;
+				TownyRegenAPI.deletePlotChunk(plotChunk); // just claimed so stop regeneration.
 				// Remove the WorldCoord from the regenqueue.
 				TownyRegenAPI.removeFromRegenQueueList(townBlock.getWorldCoord());
+			} else {
+
+				plotChunk = new PlotBlockData(townBlock); // Not regenerating so create a new snapshot.
+				plotChunk.initialize();
+
 			}
+			TownyRegenAPI.addPlotChunkSnapshot(plotChunk); // Save a snapshot.
+			plotChunk = null;
 		}
 		if (TownyEconomyHandler.isActive()) {
 			TownyMessaging.sendDebugMsg("Creating new Town account: " + TownySettings.getTownAccountPrefix() + name);

--- a/src/com/palmergames/bukkit/towny/command/TownyWorldCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyWorldCommand.java
@@ -250,11 +250,8 @@ public class TownyWorldCommand extends BaseCommand implements CommandExecutor {
 				TownyMessaging.sendMsg(sender, globalWorld.isUsingTowny() ? Translatable.of("msg_set_use_towny_on") : Translatable.of("msg_set_use_towny_off"));
 				
 				// Towny might be getting shut off in a world in order to stop the revert-on-unclaim feature, here we stop any active reverts.
-				if (!globalWorld.isUsingTowny() && globalWorld.isUsingPlotManagementRevert()) {
-					TownyRegenAPI.removeRegenQueueListOfWorld(globalWorld, true); // Remove any inactive reverts sitting in the queue.
-					TownyRegenAPI.removeWorldCoords(globalWorld); // Stop any active snapshots being made.
-					TownyRegenAPI.removePlotChunksForWorld(globalWorld); // Stop any active reverts being done.
-				}
+				if (!globalWorld.isUsingTowny() && globalWorld.isUsingPlotManagementRevert())
+					TownyRegenAPI.turnOffRevertOnUnclaimForWorld(globalWorld);
 			
 			} else if (split[0].equalsIgnoreCase("warallowed")) {
 
@@ -316,11 +313,8 @@ public class TownyWorldCommand extends BaseCommand implements CommandExecutor {
 
 				globalWorld.setUsingPlotManagementRevert(choice.orElse(!globalWorld.isUsingPlotManagementRevert()));
 
-				if (!globalWorld.isUsingPlotManagementRevert()) {
-					TownyRegenAPI.removeRegenQueueListOfWorld(globalWorld, true); // Remove any queued regenerations.
-					TownyRegenAPI.removeWorldCoords(globalWorld); // Stop any active snapshots being made.
-					TownyRegenAPI.removePlotChunksForWorld(globalWorld); // Stop any active reverts being done.
-				}
+				if (!globalWorld.isUsingPlotManagementRevert()) 
+					TownyRegenAPI.turnOffRevertOnUnclaimForWorld(globalWorld);
 				
 				TownyMessaging.sendMsg(sender, Translatable.of("msg_changed_world_setting", "Unclaim Revert", globalWorld.getName(), formatBool(globalWorld.isUsingPlotManagementRevert())));
 

--- a/src/com/palmergames/bukkit/towny/command/TownyWorldCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyWorldCommand.java
@@ -251,7 +251,7 @@ public class TownyWorldCommand extends BaseCommand implements CommandExecutor {
 				
 				// Towny might be getting shut off in a world in order to stop the revert-on-unclaim feature, here we stop any active reverts.
 				if (!globalWorld.isUsingTowny() && globalWorld.isUsingPlotManagementRevert()) {
-					TownyRegenAPI.removeRegenListOfWorld(globalWorld, true); // Remove any inactive reverts sitting in the queue.
+					TownyRegenAPI.removeRegenQueueListOfWorld(globalWorld, true); // Remove any inactive reverts sitting in the queue.
 					TownyRegenAPI.removeWorldCoords(globalWorld); // Stop any active snapshots being made.
 					TownyRegenAPI.removePlotChunksForWorld(globalWorld); // Stop any active reverts being done.
 				}
@@ -317,7 +317,7 @@ public class TownyWorldCommand extends BaseCommand implements CommandExecutor {
 				globalWorld.setUsingPlotManagementRevert(choice.orElse(!globalWorld.isUsingPlotManagementRevert()));
 
 				if (!globalWorld.isUsingPlotManagementRevert()) {
-					TownyRegenAPI.removeRegenListOfWorld(globalWorld, true); // Remove any queued regenerations.
+					TownyRegenAPI.removeRegenQueueListOfWorld(globalWorld, true); // Remove any queued regenerations.
 					TownyRegenAPI.removeWorldCoords(globalWorld); // Stop any active snapshots being made.
 					TownyRegenAPI.removePlotChunksForWorld(globalWorld); // Stop any active reverts being done.
 				}

--- a/src/com/palmergames/bukkit/towny/command/TownyWorldCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyWorldCommand.java
@@ -251,8 +251,9 @@ public class TownyWorldCommand extends BaseCommand implements CommandExecutor {
 				
 				// Towny might be getting shut off in a world in order to stop the revert-on-unclaim feature, here we stop any active reverts.
 				if (!globalWorld.isUsingTowny() && globalWorld.isUsingPlotManagementRevert()) {
+					TownyRegenAPI.removeRegenListOfWorld(globalWorld, true); // Remove any inactive reverts sitting in the queue.
 					TownyRegenAPI.removeWorldCoords(globalWorld); // Stop any active snapshots being made.
-					TownyRegenAPI.removePlotChunksForWorld(globalWorld, true); // Stop any active reverts being done.
+					TownyRegenAPI.removePlotChunksForWorld(globalWorld); // Stop any active reverts being done.
 				}
 			
 			} else if (split[0].equalsIgnoreCase("warallowed")) {
@@ -316,8 +317,9 @@ public class TownyWorldCommand extends BaseCommand implements CommandExecutor {
 				globalWorld.setUsingPlotManagementRevert(choice.orElse(!globalWorld.isUsingPlotManagementRevert()));
 
 				if (!globalWorld.isUsingPlotManagementRevert()) {
+					TownyRegenAPI.removeRegenListOfWorld(globalWorld, true); // Remove any queued regenerations.
 					TownyRegenAPI.removeWorldCoords(globalWorld); // Stop any active snapshots being made.
-					TownyRegenAPI.removePlotChunksForWorld(globalWorld, true); // Stop any active reverts being done.
+					TownyRegenAPI.removePlotChunksForWorld(globalWorld); // Stop any active reverts being done.
 				}
 				
 				TownyMessaging.sendMsg(sender, Translatable.of("msg_changed_world_setting", "Unclaim Revert", globalWorld.getName(), formatBool(globalWorld.isUsingPlotManagementRevert())));

--- a/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
@@ -739,7 +739,7 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 
 		// Move the plot to be restored
 		if (townBlock.getWorld().isUsingPlotManagementRevert())
-			TownyRegenAPI.addToRegenList(townBlock.getWorldCoord());
+			TownyRegenAPI.addToRegenQueueList(townBlock.getWorldCoord(), true);
 
 		// Raise an event to signal the unclaim
 		BukkitTools.getPluginManager().callEvent(new TownUnclaimEvent(town, townBlock.getWorldCoord()));
@@ -1483,7 +1483,7 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 				if (!line.equals("")) {
 					split = line.split(",");
 					WorldCoord wc = new WorldCoord(split[0], Integer.parseInt(split[1]), Integer.parseInt(split[2]));
-					TownyRegenAPI.addToRegenList(wc);
+					TownyRegenAPI.addToRegenQueueList(wc, false);
 				}
 			
 			return true;
@@ -1532,11 +1532,9 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 	public boolean saveRegenList() {
         queryQueue.add(() -> {
         	File file = new File(dataFolderPath + File.separator + "regen.txt");
-
 			Collection<String> lines = TownyRegenAPI.getRegenQueueList().stream()
 				.map(wc -> wc.getWorldName() + "," + wc.getX() + "," + wc.getZ())
 				.collect(Collectors.toList());
-
 			FileMgmt.listToFile(lines, file.getPath());
 		});
 

--- a/src/com/palmergames/bukkit/towny/regen/PlotBlockData.java
+++ b/src/com/palmergames/bukkit/towny/regen/PlotBlockData.java
@@ -3,6 +3,7 @@ package com.palmergames.bukkit.towny.regen;
 import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.object.TownBlock;
+import com.palmergames.bukkit.towny.object.WorldCoord;
 import com.palmergames.bukkit.towny.regen.block.BlockObject;
 import com.palmergames.bukkit.util.BukkitTools;
 
@@ -275,6 +276,10 @@ public class PlotBlockData {
 	public void resetBlockListRestored() {
 
 		blockListRestored = 0;
+	}
+
+	public WorldCoord getWorldCoord() {
+		return new WorldCoord(getWorldName(), getX(), getZ());
 	}
 
 }

--- a/src/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
+++ b/src/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
@@ -142,7 +142,7 @@ public class TownyRegenAPI {
 	}
 	
 	public static boolean regenQueueHasAvailable() {
-		return !regenWorldCoordList.isEmpty() && regenWorldCoordList.size() >= 20;
+		return !regenWorldCoordList.isEmpty();
 	}
 	
 	private static void setRegenQueue(List<WorldCoord> list) {

--- a/src/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
+++ b/src/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
@@ -46,7 +46,6 @@ public class TownyRegenAPI {
 	
 	// List of protection blocks placed to prevent blockPhysics.
 	private static  Set<Block> protectionPlaceholders = new HashSet<>();
-	
 
 	/*
 	 * Snapshots used in Revert-On-Unclaim feature
@@ -142,15 +141,15 @@ public class TownyRegenAPI {
 		return regenWorldCoordList;
 	}
 	
-	public static boolean regenQueueIsNotEmpty() {
-		return !regenWorldCoordList.isEmpty();
+	public static boolean regenQueueHasAvailable() {
+		return !regenWorldCoordList.isEmpty() && regenWorldCoordList.size() >= 20;
 	}
 	
 	private static void setRegenQueue(List<WorldCoord> list) {
 		regenWorldCoordList = list;
 	}
 	
-	public static void removeRegenListOfWorld(TownyWorld world, boolean save) {
+	public static void removeRegenQueueListOfWorld(TownyWorld world, boolean save) {
 		List<WorldCoord> list = new ArrayList<>();
 		for (WorldCoord wc : getRegenQueueList()) {
 			if (!wc.getTownyWorldOrNull().equals(world))
@@ -163,17 +162,18 @@ public class TownyRegenAPI {
 			TownyUniverse.getInstance().getDataSource().saveRegenList();
 	}
 	
-	public static void removeFromRegenList(WorldCoord wc) {
+	public static void removeFromRegenQueueList(WorldCoord wc) {
 		if (regenWorldCoordList.contains(wc)) { 
 			regenWorldCoordList.remove(wc);
 			TownyUniverse.getInstance().getDataSource().saveRegenList();
 		}
 	}
 	
-	public static void addToRegenList(WorldCoord wc) {
+	public static void addToRegenQueueList(WorldCoord wc, boolean save) {
 		if (!regenWorldCoordList.contains(wc)) {
 			regenWorldCoordList.add(wc);
-			TownyUniverse.getInstance().getDataSource().saveRegenList();
+			if (save)
+				TownyUniverse.getInstance().getDataSource().saveRegenList();
 		}
 	}
 

--- a/src/com/palmergames/bukkit/towny/tasks/RepeatingTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/RepeatingTimerTask.java
@@ -33,7 +33,7 @@ public class RepeatingTimerTask extends TownyTimerTask {
 				for (PlotBlockData plotChunk : new ArrayList<PlotBlockData>(TownyRegenAPI.getPlotChunks().values())) {
 					if (plotChunk != null && !plotChunk.restoreNextBlock()) {
 						TownyMessaging.sendDebugMsg("Revert on unclaim complete for " + plotChunk.getWorldName() + " " + plotChunk.getX() +"," + plotChunk.getZ());
-						TownyRegenAPI.removeFromRegenList(plotChunk.getWorldCoord());
+						TownyRegenAPI.removeFromRegenQueueList(plotChunk.getWorldCoord());
 						TownyRegenAPI.deletePlotChunk(plotChunk);
 						TownyRegenAPI.deletePlotChunkSnapshot(plotChunk);
 					}
@@ -43,9 +43,7 @@ public class RepeatingTimerTask extends TownyTimerTask {
 		}
 
 		// Check and see if we have any room in the PlotChunks regeneration, and more in the queue. 
-		if (TownyRegenAPI.getPlotChunks().size() < 20 
-			&& TownyRegenAPI.regenQueueIsNotEmpty() 
-			&& TownyRegenAPI.getRegenQueueList().size() >= 20) {
+		if (TownyRegenAPI.getPlotChunks().size() < 20 && TownyRegenAPI.regenQueueHasAvailable()) {
 			for (WorldCoord wc : new ArrayList<>(TownyRegenAPI.getRegenQueueList())) {
 				// We have enough plot chunks regenerating, break out of the loop.
 				if (TownyRegenAPI.getPlotChunks().size() >= 20)
@@ -58,7 +56,7 @@ public class RepeatingTimerTask extends TownyTimerTask {
 				if (plotData != null) {
 					TownyRegenAPI.addPlotChunk(plotData);
 				} else {
-					TownyRegenAPI.removeFromRegenList(wc);
+					TownyRegenAPI.removeFromRegenQueueList(wc);
 				}
 			}
 		}

--- a/src/com/palmergames/bukkit/towny/tasks/RepeatingTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/RepeatingTimerTask.java
@@ -74,6 +74,7 @@ public class RepeatingTimerTask extends TownyTimerTask {
 				if (!plotChunk.getBlockList().isEmpty() && !(plotChunk.getBlockList() == null)) {
 					TownyRegenAPI.addPlotChunkSnapshot(plotChunk); // Save the snapshot.
 				}
+				plotChunk = null;
 				
 				townBlock.setLocked(false);
 				townBlock.save();

--- a/src/com/palmergames/bukkit/towny/tasks/TownClaim.java
+++ b/src/com/palmergames/bukkit/towny/tasks/TownClaim.java
@@ -196,7 +196,7 @@ public class TownClaim extends Thread {
 						TownyRegenAPI.addWorldCoord(townBlock.getWorldCoord());
 						townBlock.setLocked(true);
 					}
-					TownyRegenAPI.removeFromRegenList(worldCoord);
+					TownyRegenAPI.removeFromRegenQueueList(worldCoord);
 				}
 			}
 			

--- a/src/com/palmergames/bukkit/towny/tasks/TownClaim.java
+++ b/src/com/palmergames/bukkit/towny/tasks/TownClaim.java
@@ -186,14 +186,17 @@ public class TownClaim extends Thread {
 			}
 
 			if (worldCoord.getTownyWorld().isUsingPlotManagementRevert() && (TownySettings.getPlotManagementSpeed() > 0)) {
-				PlotBlockData plotChunk = TownyRegenAPI.getPlotChunk(townBlock);
-				if (plotChunk != null) {
-					TownyRegenAPI.deletePlotChunk(plotChunk); // just claimed so stop regeneration.
-					townBlock.setLocked(false);
-				} else {
-
-					TownyRegenAPI.addWorldCoord(townBlock.getWorldCoord());
-					townBlock.setLocked(true);
+				if (TownyRegenAPI.getRegenQueueList().contains(townBlock.getWorldCoord())) {
+					PlotBlockData plotChunk = TownyRegenAPI.getPlotChunk(townBlock);
+					if (plotChunk != null) {
+						TownyRegenAPI.deletePlotChunk(plotChunk); // just claimed so stop regeneration.
+						townBlock.setLocked(false);
+					} else {
+						// Queue to have a snapshot made. 
+						TownyRegenAPI.addWorldCoord(townBlock.getWorldCoord());
+						townBlock.setLocked(true);
+					}
+					TownyRegenAPI.removeFromRegenList(worldCoord);
 				}
 			}
 			

--- a/src/com/palmergames/bukkit/towny/tasks/TownClaim.java
+++ b/src/com/palmergames/bukkit/towny/tasks/TownClaim.java
@@ -185,19 +185,18 @@ public class TownClaim extends Thread {
 				town.addOutpostSpawn(outpostLocation);
 			}
 
-			if (worldCoord.getTownyWorld().isUsingPlotManagementRevert() && (TownySettings.getPlotManagementSpeed() > 0)) {
+			if (worldCoord.getTownyWorld().isUsingPlotManagementRevert() && TownySettings.getPlotManagementSpeed() > 0) {
 				if (TownyRegenAPI.getRegenQueueList().contains(townBlock.getWorldCoord())) {
 					PlotBlockData plotChunk = TownyRegenAPI.getPlotChunk(townBlock);
 					if (plotChunk != null) {
 						TownyRegenAPI.deletePlotChunk(plotChunk); // just claimed so stop regeneration.
 						townBlock.setLocked(false);
-					} else {
-						// Queue to have a snapshot made. 
-						TownyRegenAPI.addWorldCoord(townBlock.getWorldCoord());
-						townBlock.setLocked(true);
 					}
 					TownyRegenAPI.removeFromRegenQueueList(worldCoord);
-				}
+				} 
+				// Queue to have a snapshot made. 
+				TownyRegenAPI.addWorldCoord(townBlock.getWorldCoord());
+				townBlock.setLocked(true);
 			}
 			
 			townBlock.save();

--- a/src/com/palmergames/bukkit/towny/tasks/TownClaim.java
+++ b/src/com/palmergames/bukkit/towny/tasks/TownClaim.java
@@ -189,7 +189,7 @@ public class TownClaim extends Thread {
 				if (TownyRegenAPI.getRegenQueueList().contains(townBlock.getWorldCoord())) {
 					PlotBlockData plotChunk = TownyRegenAPI.getPlotChunk(townBlock);
 					if (plotChunk != null) {
-						TownyRegenAPI.deletePlotChunk(plotChunk); // just claimed so stop regeneration.
+						TownyRegenAPI.removeFromActiveRegeneration(plotChunk); // just claimed so stop regeneration.
 						townBlock.setLocked(false);
 					}
 					TownyRegenAPI.removeFromRegenQueueList(worldCoord);


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Stops Towny from loading the entire regen queue into memory and
processing all the reverts at the same time.

Towny now loads the regen.txt into a list of WorldCoords which holds all
active and inactive revert-on-unclaims.

When there are less than 20 active reverts, Towny will look to see if
there are any available WorldCoords in the queue. If one is found only
then will the PlotBlockData object be created and loaded into memory.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

Closes #5473 
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
