### PR TITLE
Add TownPreClaimEvent to initial TownBlock claimed during new Town code.

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -2952,11 +2952,19 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		if (town == null)
 			throw new TownyException(String.format("Error fetching new town from name '%s'", name));
 
+		TownBlock townBlock = new TownBlock(key.getX(), key.getZ(), world);
+		TownPreClaimEvent preClaimEvent = new TownPreClaimEvent(town, townBlock, player, false, true);
+		BukkitTools.getPluginManager().callEvent(preClaimEvent);
+		if(preClaimEvent.isCancelled()) {
+			TownyUniverse.getInstance().unregisterTown(town);
+			town = null;
+			throw new TownyException(preClaimEvent.getCancelMessage());
+		}
+
 		town.setRegistered(System.currentTimeMillis());
 		town.setMapColorHexCode(MapUtil.generateRandomTownColourAsHexCode());
 		resident.setTown(town);
 		town.setMayor(resident);
-		TownBlock townBlock = new TownBlock(key.getX(), key.getZ(), world);
 		townBlock.setTown(town);
 
 		// Set the plot permissions to mirror the towns.

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -2953,11 +2953,14 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 			throw new TownyException(String.format("Error fetching new town from name '%s'", name));
 
 		TownBlock townBlock = new TownBlock(key.getX(), key.getZ(), world);
+		townBlock.setTown(town);
 		TownPreClaimEvent preClaimEvent = new TownPreClaimEvent(town, townBlock, player, false, true);
 		BukkitTools.getPluginManager().callEvent(preClaimEvent);
 		if(preClaimEvent.isCancelled()) {
+			TownyUniverse.getInstance().removeTownBlock(townBlock);
 			TownyUniverse.getInstance().unregisterTown(town);
 			town = null;
+			townBlock = null;
 			throw new TownyException(preClaimEvent.getCancelMessage());
 		}
 
@@ -2965,7 +2968,6 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		town.setMapColorHexCode(MapUtil.generateRandomTownColourAsHexCode());
 		resident.setTown(town);
 		town.setMayor(resident);
-		townBlock.setTown(town);
 
 		// Set the plot permissions to mirror the towns.
 		townBlock.setType(townBlock.getType());

--- a/src/com/palmergames/bukkit/towny/event/TownPreClaimEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/TownPreClaimEvent.java
@@ -69,9 +69,14 @@ public class TownPreClaimEvent extends Event implements Cancellable{
     
     /**
      * Whether the townblock being claimed will be a homeblock.
+     * 
+     * If this is being thrown because a town is about to be made, the Town object
+     * will be unfinished. Many parts of the Town object will throw errors if accessed.
+     * 
      * If there are multiple blocks being claimed using the larger selection commands,
      * this will return true for every block in the selection, only the first would become a homeblock. 
      * Cancelling the event will cause all claims to be cancelled.
+     * 
      * @return true if the townblock will become a homeblock, or if many townblocks are being claimed at once. 
      */
     public boolean isHomeBlock() {
@@ -87,6 +92,12 @@ public class TownPreClaimEvent extends Event implements Cancellable{
     }
 
     /**
+     * The town which is claiming this TownBlock
+     * 
+     * If {@link #isHomeblock} is true, then this could be the first TownBlock claimed by
+     * a town upon Town-creation. In this scenario the Town object has not finished 
+     * initializing and many methods in the Town object could return errors when used.
+     * 
      * @return the town
      * */
     public Town getTown() {

--- a/src/com/palmergames/bukkit/towny/event/TownPreClaimEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/TownPreClaimEvent.java
@@ -84,7 +84,12 @@ public class TownPreClaimEvent extends Event implements Cancellable{
     }
     
     /**
-     *
+     * The TownBlock which is being claimed.
+     * 
+     * If {@link #isHomeblock} is true, then this could be the first TownBlock claimed by
+     * a town upon Town-creation. In this scenario the Town object has not finished 
+     * initializing and many methods in the TownBlock object could return errors when used.
+     * 
      * @return the new TownBlock.
      */
     public TownBlock getTownBlock() {


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

If the claim is cancelled, then the Town is not claimed, and is immediately unregistered from TownyUniverse.

Shortfalls:

- The TownPreClaimEvent#getTown() is fairly unsafe to use, so there's warnings added to the javadocs.
- Someone listening for uncancelled PreNewTownEvents as a sure-fire sign that a town will be created will have a bad day (although I don't think anyone is going to use that over the NewTownEvent.)

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

Closes #3620 
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
