### PR TITLE
Nation name in titles & town leave title improvements

### DIFF
--- a/resources/lang/en-US.yml
+++ b/resources/lang/en-US.yml
@@ -1589,3 +1589,5 @@ msg_view_on_web: 'Click to view on the web.'
 town1_has_merged_with_town2: '&6The town %s has agreed to merge together with the prevailing town of %s.'
 #Shown in the town and nation status screens to inform about neutrality costs.
 status_neutrality_cost: 'Neutrality Cost:'
+
+titles_nationname_placeholder_if_town_has_no_nation: '-'

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1506,7 +1506,7 @@ public enum ConfigNodes {
 			"# {town_motd} - Shows the townboard message.",
 			"# {town_residents} - Shows the number of residents in the town.",
 			"# {town_residents_online} - Shows the number of residents online currently.",
-			"# {nationname} - Shows the name of the nation the town is in. If the town is not in a nation, it will show '-' instead.",
+			"# {nationname} - Shows the name of the nation the town is in. If the town is not in a nation, it will show '-' instead (or whatever is defined in language string 'titles_nationname_placeholder_if_town_has_no_nation').",
 			"# The notification.town_names_are_verbose setting will affect the {townname} placeholder."),
 	NOTIFICATION_TITLES_TOWN_TITLE(
 			"notification.titles.town_title",

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1506,6 +1506,7 @@ public enum ConfigNodes {
 			"# {town_motd} - Shows the townboard message.",
 			"# {town_residents} - Shows the number of residents in the town.",
 			"# {town_residents_online} - Shows the number of residents online currently.",
+			"# {nationname} - Shows the name of the nation the town is in. If the town is not in a nation, it will show '-' instead.",
 			"# The notification.town_names_are_verbose setting will affect the {townname} placeholder."),
 	NOTIFICATION_TITLES_TOWN_TITLE(
 			"notification.titles.town_title",

--- a/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -963,6 +963,7 @@ public class TownyPlayerListener implements Listener {
 			placeholders.put("{town_motd}", town.getBoard());
 			placeholders.put("{town_residents}", town.getNumResidents());
 			placeholders.put("{town_residents_online}", TownyAPI.getInstance().getOnlinePlayers(town).size());
+			placeholders.put("{nationname}", town.getNationOrNull() != null ? town.getNationOrNull().getName() : "-");
 
 			for(Map.Entry<String, Object> placeholder: placeholders.entrySet()) {
 				title = title.replace(placeholder.getKey(), placeholder.getValue().toString());

--- a/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -963,7 +963,7 @@ public class TownyPlayerListener implements Listener {
 			placeholders.put("{town_motd}", town.getBoard());
 			placeholders.put("{town_residents}", town.getNumResidents());
 			placeholders.put("{town_residents_online}", TownyAPI.getInstance().getOnlinePlayers(town).size());
-			placeholders.put("{nationname}", town.getNationOrNull() != null ? town.getNationOrNull().getName() : "-");
+			placeholders.put("{nationname}", town.getNationOrNull() != null ? town.getNationOrNull().getName() : Translatable.of("titles_nationname_placeholder_if_town_has_no_nation"));
 
 			for(Map.Entry<String, Object> placeholder: placeholders.entrySet()) {
 				title = title.replace(placeholder.getKey(), placeholder.getValue().toString());

--- a/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -963,7 +963,7 @@ public class TownyPlayerListener implements Listener {
 			placeholders.put("{town_motd}", town.getBoard());
 			placeholders.put("{town_residents}", town.getNumResidents());
 			placeholders.put("{town_residents_online}", TownyAPI.getInstance().getOnlinePlayers(town).size());
-			placeholders.put("{nationname}", town.getNationOrNull() != null ? town.getNationOrNull().getName() : Translatable.of("titles_nationname_placeholder_if_town_has_no_nation"));
+			placeholders.put("{nationname}", town.getNationOrNull() != null ? StringMgmt.remUnderscore(town.getNationOrNull().getName()) : Translatable.of("titles_nationname_placeholder_if_town_has_no_nation"));
 
 			for(Map.Entry<String, Object> placeholder: placeholders.entrySet()) {
 				title = title.replace(placeholder.getKey(), placeholder.getValue().toString());
@@ -985,7 +985,6 @@ public class TownyPlayerListener implements Listener {
 	public void onPlayerLeaveTown(PlayerLeaveTownEvent event) {
 		Resident resident = TownyAPI.getInstance().getResident(event.getPlayer().getUniqueId());
 		String worldName = TownyAPI.getInstance().getTownyWorld(event.getPlayer().getWorld().getName()).getUnclaimedZoneName();
-
 		// Likely a Citizens NPC.
 		if (resident == null || worldName == null)
 			return;
@@ -993,18 +992,23 @@ public class TownyPlayerListener implements Listener {
 		if (TownySettings.isNotificationUsingTitles() && event.getTo().getTownBlockOrNull() == null) {
 			String title = ChatColor.translateAlternateColorCodes('&', TownySettings.getNotificationTitlesWildTitle());
 			String subtitle = ChatColor.translateAlternateColorCodes('&', TownySettings.getNotificationTitlesWildSubtitle());
-			if (title.contains("{wilderness}")) {
-				title = title.replace("{wilderness}", StringMgmt.remUnderscore(worldName));
+
+			HashMap<String, Object> placeholders = new HashMap<>();
+			placeholders.put("{wilderness}", StringMgmt.remUnderscore(worldName));
+			Town town = event.getLefttown();
+			if(town != null){
+				placeholders.put("{townname}", StringMgmt.remUnderscore(TownySettings.isNotificationsTownNamesVerbose() ? town.getFormattedName() : town.getName()));
+				placeholders.put("{town_motd}", town.getBoard());
+				placeholders.put("{town_residents}", town.getNumResidents());
+				placeholders.put("{town_residents_online}", TownyAPI.getInstance().getOnlinePlayers(town).size());
+				placeholders.put("{nationname}", town.getNationOrNull() != null ? StringMgmt.remUnderscore(town.getNationOrNull().getName()) : Translatable.of("titles_nationname_placeholder_if_town_has_no_nation"));
 			}
-			if (subtitle.contains("{wilderness}")) {
-				subtitle = subtitle.replace("{wilderness}", StringMgmt.remUnderscore(worldName));
+		
+			for(Map.Entry<String, Object> placeholder: placeholders.entrySet()) {
+				title = title.replace(placeholder.getKey(), placeholder.getValue().toString());
+				subtitle = subtitle.replace(placeholder.getKey(), placeholder.getValue().toString());
 			}
-			if (title.contains("{townname}")) {
-				subtitle = subtitle.replace("{townname}", StringMgmt.remUnderscore(event.getFrom().getTownOrNull().getName()));
-			}
-			if (subtitle.contains("{townname}")) {
-				subtitle = subtitle.replace("{townname}", StringMgmt.remUnderscore(event.getFrom().getTownOrNull().getName()));
-			}
+			
 			TownyMessaging.sendTitleMessageToResident(resident, title, subtitle);		
 		}
 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
See https://github.com/TownyAdvanced/Towny/issues/5524
This adds the {nationname} placeholder to entering and leaving titles. If the town has no nation, the symbol in titles_nationname_placeholder_if_town_has_no_nation will be used. I think it's a good idea to make this translatable, so people could use something like "No Nation" instead of the default "-" there.

I have also re-done how placeholders are handled in the Town Leave event. It's now identical to how it's done in the town enter event.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
Translation: titles_nationname_placeholder_if_town_has_no_nation: '-'

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
https://github.com/TownyAdvanced/Towny/issues/5524

____
- [X] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
