### PR TITLE
Move legacy releases from the README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ ___
 <tr align=center><td> MC 1.14.* </td>
 <tr align=center><td> MC 1.13.2 </td><td> <a href=https://github.com/TownyAdvanced/Towny/releases/tag/0.96.2.0for1.13.2>0.96.2.0 for 1.13.2</a> </td>
 <tr align=center><td> MC 1.12.2 </td><td> <a href=https://github.com/TownyAdvanced/Towny/releases/tag/0.97.0.0for1.12.2>0.97.0.0 for 1.12.2</a> </td>
-<tr align=center><td>Looking for older releases?</td><td><a href="https://github.com/TownyAdvanced/Towny/blob/master/RELEASES.md">Go to RELEASES.md</a></td>
+<tr align=center><td>Looking for older releases?</td><td><a href="RELEASES.md#legacy">Go to RELEASES.md</a></td>
 </table>
 <!--<tr align=center><td> MC 1.11.2 </td><td> <a href=https://www.dropbox.com/s/cfpm4iy0sbzmti4/Towny_Advanced%200.93.1.0%20for%20MC%201.11.2.zip?dl=0>0.93.1.0 for 1.11.2</a> </td>
 <tr align=center><td> MC 1.10.2 </td><td> <a href=https://www.dropbox.com/s/x2i3wqaj8n6gdh1/Towny_Advanced%200.93.1.0%20for%20MC%201.10.2.rar?dl=0>0.93.1.0 for 1.10.2</a> </td>

--- a/README.md
+++ b/README.md
@@ -30,15 +30,6 @@ ___
 <tr align=center><td> MC 1.12.2 </td><td> <a href=https://github.com/TownyAdvanced/Towny/releases/tag/0.97.0.0for1.12.2>0.97.0.0 for 1.12.2</a> </td>
 <tr align=center><td>Looking for older releases?</td><td><a href="RELEASES.md#legacy">Go to RELEASES.md</a></td>
 </table>
-<!--<tr align=center><td> MC 1.11.2 </td><td> <a href=https://www.dropbox.com/s/cfpm4iy0sbzmti4/Towny_Advanced%200.93.1.0%20for%20MC%201.11.2.zip?dl=0>0.93.1.0 for 1.11.2</a> </td>
-<tr align=center><td> MC 1.10.2 </td><td> <a href=https://www.dropbox.com/s/x2i3wqaj8n6gdh1/Towny_Advanced%200.93.1.0%20for%20MC%201.10.2.rar?dl=0>0.93.1.0 for 1.10.2</a> </td>
-<tr align=center><td> MC 1.9.4 </td><td> <a href=https://www.dropbox.com/s/eh81i4618bfmvjm/Towny_Advanced%200.93.1.0%20for%20MC%201.9.4.zip?dl=0>0.93.1.0 for 1.9.4</a> </td>
-<tr align=center><td> MC 1.8.9 </td><td> <a href=https://www.dropbox.com/s/e83206cfed61hsw/Towny_Advanced%200.93.1.0a%20for%20MC%201.8.9.zip?dl=0>0.93.1.0a for 1.8.9</a> </td>
-<tr align=center><td> MC 1.7.10 </td><td> <a href=https://www.dropbox.com/s/vmf2g5bj7ab4coo/Towny_Advanced%200.92.0.0%20-%20MC%201.7.10.zip?dl=0>0.92.0.0 for 1.7.10</a> </td>
-<tr align=center><td> MC 1.6.4 </td><td> <a href=https://www.dropbox.com/s/5n9r60ivldh5i8f/Towny_Advanced%200.88.0.0%20%281.6.4%29.zip?dl=0>0.88.0.0 for 1.6.4</a> </td>
-<tr align=center><td> MC 1.5.2 </td><td> <a href=https://www.dropbox.com/s/euydq4qsljheoms/Towny_Advanced%200.88.0.0%20%281.5.2%29.zip?dl=0>0.88.0.0 for 1.5.2</a> </td>
-<tr align=center><td> MC 1.2.5 </td><td> <a href=https://www.dropbox.com/s/xstn1vdexxc1k5q/Towny_Advanced%200.82.0.0%20for%201.2.5.zip?dl=0>0.82.0.0</a> </td>-->
-</table>
 
 ___
 
@@ -113,4 +104,4 @@ For building, open your terminal / command prompt and navigate to the Towny Dire
 
 - **Ant** ![](https://img.shields.io/badge/deprecated-red)
     - For older branches using the Ant build system, the main command to use would be: `ant clean jar`. This command will _exit_ the Towny directory, creating a lib folder alongside it. A `Towny.jar` file will be generated and placed within there.
-    - _Note: As Ant is being deprecated, older branches may eventually not be able to be built against without modification of the `build.xml` file. We leave no guarantee that the file repo providing the dependencies will stay up._
+    - Since Ant is being deprecated, you may need to modify the `build.xml` file. We leave no guarantee that the file repositories are still maintained, it is also possible they're no longer available.

--- a/README.md
+++ b/README.md
@@ -28,14 +28,16 @@ ___
 <tr align=center><td> MC 1.14.* </td>
 <tr align=center><td> MC 1.13.2 </td><td> <a href=https://github.com/TownyAdvanced/Towny/releases/tag/0.96.2.0for1.13.2>0.96.2.0 for 1.13.2</a> </td>
 <tr align=center><td> MC 1.12.2 </td><td> <a href=https://github.com/TownyAdvanced/Towny/releases/tag/0.97.0.0for1.12.2>0.97.0.0 for 1.12.2</a> </td>
-<tr align=center><td> MC 1.11.2 </td><td> <a href=https://www.dropbox.com/s/cfpm4iy0sbzmti4/Towny_Advanced%200.93.1.0%20for%20MC%201.11.2.zip?dl=0>0.93.1.0 for 1.11.2</a> </td>
+<tr align=center><td>Looking for older releases?</td><td><a href="https://github.com/TownyAdvanced/Towny/blob/master/RELEASES.md">Go to RELEASES.md</a></td>
+</table>
+<!--<tr align=center><td> MC 1.11.2 </td><td> <a href=https://www.dropbox.com/s/cfpm4iy0sbzmti4/Towny_Advanced%200.93.1.0%20for%20MC%201.11.2.zip?dl=0>0.93.1.0 for 1.11.2</a> </td>
 <tr align=center><td> MC 1.10.2 </td><td> <a href=https://www.dropbox.com/s/x2i3wqaj8n6gdh1/Towny_Advanced%200.93.1.0%20for%20MC%201.10.2.rar?dl=0>0.93.1.0 for 1.10.2</a> </td>
 <tr align=center><td> MC 1.9.4 </td><td> <a href=https://www.dropbox.com/s/eh81i4618bfmvjm/Towny_Advanced%200.93.1.0%20for%20MC%201.9.4.zip?dl=0>0.93.1.0 for 1.9.4</a> </td>
 <tr align=center><td> MC 1.8.9 </td><td> <a href=https://www.dropbox.com/s/e83206cfed61hsw/Towny_Advanced%200.93.1.0a%20for%20MC%201.8.9.zip?dl=0>0.93.1.0a for 1.8.9</a> </td>
 <tr align=center><td> MC 1.7.10 </td><td> <a href=https://www.dropbox.com/s/vmf2g5bj7ab4coo/Towny_Advanced%200.92.0.0%20-%20MC%201.7.10.zip?dl=0>0.92.0.0 for 1.7.10</a> </td>
 <tr align=center><td> MC 1.6.4 </td><td> <a href=https://www.dropbox.com/s/5n9r60ivldh5i8f/Towny_Advanced%200.88.0.0%20%281.6.4%29.zip?dl=0>0.88.0.0 for 1.6.4</a> </td>
 <tr align=center><td> MC 1.5.2 </td><td> <a href=https://www.dropbox.com/s/euydq4qsljheoms/Towny_Advanced%200.88.0.0%20%281.5.2%29.zip?dl=0>0.88.0.0 for 1.5.2</a> </td>
-<tr align=center><td> MC 1.2.5 </td><td> <a href=https://www.dropbox.com/s/xstn1vdexxc1k5q/Towny_Advanced%200.82.0.0%20for%201.2.5.zip?dl=0>0.82.0.0</a> </td>
+<tr align=center><td> MC 1.2.5 </td><td> <a href=https://www.dropbox.com/s/xstn1vdexxc1k5q/Towny_Advanced%200.82.0.0%20for%201.2.5.zip?dl=0>0.82.0.0</a> </td>-->
 </table>
 
 ___
@@ -109,7 +111,6 @@ For building, open your terminal / command prompt and navigate to the Towny Dire
     - Run `mvn clean package` to generate the plugin in the `target` directory, within the Towny folder. 
 
 
-- **Ant** (_Deprecated_)
-
-    - For older branches using the Ant build system, the main command to use would be: `ant clean jar`. This command will _exit_ the Towny directory, creating a lib folder alongside it. A Towny.jar file will be generated and placed within there.
+- **Ant** ![](https://img.shields.io/badge/deprecated-red)
+    - For older branches using the Ant build system, the main command to use would be: `ant clean jar`. This command will _exit_ the Towny directory, creating a lib folder alongside it. A `Towny.jar` file will be generated and placed within there.
     - _Note: As Ant is being deprecated, older branches may eventually not be able to be built against without modification of the `build.xml` file. We leave no guarantee that the file repo providing the dependencies will stay up._

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -17,7 +17,7 @@ Get the latest pre-release [here](https://github.com/TownyAdvanced/Towny/release
     <tr>
         <th> Minecraft Version</th><th>Towny Version</th>
     </tr>
-    <tr align=center><td> MC 1.18.* </td><td rowspan=5> Use <a href="#release">latest release</a> or <a href="#pre-release">latest Pre-Release</a>.</td>
+    <tr align=center><td> MC 1.18.* </td><td rowspan=5> Use <a href="#release-">latest release</a> or <a href="#pre-release-">latest Pre-Release</a>.</td>
     <tr align=center><td> MC 1.17.* </td>
     <tr align=center><td> MC 1.16.* </td>
     <tr align=center><td> MC 1.15.* </td>

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,7 @@
+# Releases
+
+## Recommended
+<table>
+</table>
+
+## Legacy

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,7 +1,43 @@
 # Releases
 
+## Latest
+
+### Release <img src="https://img.shields.io/github/v/release/TownyAdvanced/Towny">
+Latest release is **0.97.5.0**.
+Get it [here](https://github.com/TownyAdvanced/Towny/releases/tag/0.97.5.0).
+
+### Pre-Release <img src="https://img.shields.io/github/v/release/TownyAdvanced/Towny?include_prereleases&label=prerelease">
+> ⚠ Pre-releases are experimental builds of Towny, and as such, aren't meant for production servers.
+These releases contain in-development features, which you can give feedback on!
+
+Get the latest pre-release [here](https://github.com/TownyAdvanced/Towny/releases/latest/).
+
 ## Recommended
 <table>
+    <tr>
+        <th> Minecraft Version</th><th>Towny Version</th>
+    </tr>
+    <tr align=center><td> MC 1.18.* </td><td rowspan=5> Use <a href="#release">latest release</a> or <a href="#pre-release">latest Pre-Release</a>.</td>
+    <tr align=center><td> MC 1.17.* </td>
+    <tr align=center><td> MC 1.16.* </td>
+    <tr align=center><td> MC 1.15.* </td>
+    <tr align=center><td> MC 1.14.* </td>
+    <tr align=center><td> MC 1.13.2 <strong>(compatibility backport)</strong></td><td> <a href=https://github.com/TownyAdvanced/Towny/releases/tag/0.96.2.0for1.13.2>0.96.2.0 for 1.13.2</a> </td>
+    <tr align=center><td> MC 1.12.2 <strong>(compatibility backport)</strong></td><td> <a href=https://github.com/TownyAdvanced/Towny/releases/tag/0.97.0.0for1.12.2>0.97.0.0 for 1.12.2</a> </td>
 </table>
 
 ## Legacy
+> ⚠ Note these versions are not supported anymore and may have unexpected bugs, if you can, you should consider updating to an newer release.
+<table>
+    <tr>
+        <th> Minecraft Version</th><th>Towny Version</th>
+    </tr>
+    <tr align=center><td> MC 1.11.2 </td><td> <a href=https://www.dropbox.com/s/cfpm4iy0sbzmti4/Towny_Advanced%200.93.1.0%20for%20MC%201.11.2.zip?dl=0>0.93.1.0 for 1.11.2</a> </td>
+    <tr align=center><td> MC 1.10.2 </td><td> <a href=https://www.dropbox.com/s/x2i3wqaj8n6gdh1/Towny_Advanced%200.93.1.0%20for%20MC%201.10.2.rar?dl=0>0.93.1.0 for 1.10.2</a> </td>
+    <tr align=center><td> MC 1.9.4 </td><td> <a href=https://www.dropbox.com/s/eh81i4618bfmvjm/Towny_Advanced%200.93.1.0%20for%20MC%201.9.4.zip?dl=0>0.93.1.0 for 1.9.4</a> </td>
+    <tr align=center><td> MC 1.8.9 </td><td> <a href=https://www.dropbox.com/s/e83206cfed61hsw/Towny_Advanced%200.93.1.0a%20for%20MC%201.8.9.zip?dl=0>0.93.1.0a for 1.8.9</a> </td>
+    <tr align=center><td> MC 1.7.10 </td><td> <a href=https://www.dropbox.com/s/vmf2g5bj7ab4coo/Towny_Advanced%200.92.0.0%20-%20MC%201.7.10.zip?dl=0>0.92.0.0 for 1.7.10</a> </td>
+    <tr align=center><td> MC 1.6.4 </td><td> <a href=https://www.dropbox.com/s/5n9r60ivldh5i8f/Towny_Advanced%200.88.0.0%20%281.6.4%29.zip?dl=0>0.88.0.0 for 1.6.4</a> </td>
+    <tr align=center><td> MC 1.5.2 </td><td> <a href=https://www.dropbox.com/s/euydq4qsljheoms/Towny_Advanced%200.88.0.0%20%281.5.2%29.zip?dl=0>0.88.0.0 for 1.5.2</a> </td>
+    <tr align=center><td> MC 1.2.5 </td><td> <a href=https://www.dropbox.com/s/xstn1vdexxc1k5q/Towny_Advanced%200.82.0.0%20for%201.2.5.zip?dl=0>0.82.0.0</a> </td>
+</table>


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This pull request moves legacy requests from the README into its own file (RELEASES.md).

#### Why?
First of all, these releases aren't used anymore, and simply clutter up the README.
Oldest release used by servers that have allowed metrics is `0.96.1.0` (representing the 1.1% of servers), makes no sense to keep releases 0.93.1.0 and below in the readme.

Second of all, it's extremely hard to find server softwares for these MC versions (considering what happened with Bukkit's DMCA some time ago).

For instance, MC 1.7.10 was released in 2014 (https://howoldisminecraft1710.today/).

Instead of removing these releases completely, I felt it was an better idea to simply move them to another file, which is mentioned (and linked to) in the README.

This PR also contains minor changes to the Ant build system note.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
