### PR TITLE
Fix regen queue blocking up with unloaded chunks.

### DIFF
--- a/src/com/palmergames/bukkit/towny/object/WorldCoord.java
+++ b/src/com/palmergames/bukkit/towny/object/WorldCoord.java
@@ -153,7 +153,7 @@ public class WorldCoord extends Coord {
 	}
 
 	/**
-	 * Is the WorldCoord's blocks currently loaded.
+	 * Are the WorldCoord's blocks currently loaded.
 	 * 
 	 * @return true if the server has this WorldCoord loaded.
 	 */

--- a/src/com/palmergames/bukkit/towny/object/WorldCoord.java
+++ b/src/com/palmergames/bukkit/towny/object/WorldCoord.java
@@ -3,6 +3,8 @@ package com.palmergames.bukkit.towny.object;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
+import com.palmergames.bukkit.util.BukkitTools;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -148,6 +150,16 @@ public class WorldCoord extends Coord {
 	 */
 	public boolean isWilderness() {
 		return !hasTownBlock();
+	}
+
+	/**
+	 * Is the WorldCoord's blocks currently loaded.
+	 * 
+	 * @return true if the server has this WorldCoord loaded.
+	 */
+	public boolean isLoaded() {
+
+		return getBukkitWorld().isChunkLoaded(BukkitTools.calcChunk(getX()), BukkitTools.calcChunk(getZ()));
 	}
 
 	/**

--- a/src/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
+++ b/src/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
@@ -215,13 +215,15 @@ public class TownyRegenAPI {
 			// We have already got this worldcoord regenerating.
 			if (hasActiveRegeneration(wc))
 				continue;
-			// This worldcood is not loaded.
-			if (!wc.getBukkitWorld().isChunkLoaded(BukkitTools.calcChunk(wc.getX()), BukkitTools.calcChunk(wc.getZ())))
-				continue;
 			
 			// This worldCoord isn't actively regenerating, start the regeneration.
-			PlotBlockData plotData = getPlotChunkSnapshot(new TownBlock(wc.getX(), wc.getZ(), wc.getTownyWorldOrNull()));  
-			if (plotData != null && plotData.getWorldCoord().isLoaded()) {
+			PlotBlockData plotData = getPlotChunkSnapshot(new TownBlock(wc.getX(), wc.getZ(), wc.getTownyWorldOrNull()));
+			if (plotData != null) {
+				// Load the chunks if they are unloaded.
+				plotData.getWorldCoord().getChunks().stream()
+					.filter(chunk -> !chunk.isLoaded())
+					.forEach(chunk -> chunk.load());
+
 				addToActiveRegeneration(plotData);
 				TownyMessaging.sendDebugMsg("Revert on unclaim beginning for " + plotData.getWorldName() + " " + plotData.getX() +"," + plotData.getZ());
 			} else {

--- a/src/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
+++ b/src/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
@@ -207,6 +207,29 @@ public class TownyRegenAPI {
 			TownyUniverse.getInstance().getDataSource().saveRegenList();
 	}
 
+	public static  void getWorldCoordFromQueueForRegeneration() {
+		for (WorldCoord wc : new ArrayList<>(TownyRegenAPI.getRegenQueueList())) {
+			// We have enough plot chunks regenerating, break out of the loop.
+			if (getPlotChunks().size() >= 20)
+				break;
+			// We have already got this worldcoord regenerating.
+			if (hasActiveRegeneration(wc))
+				continue;
+			// This worldcood is not loaded.
+			if (!wc.getBukkitWorld().isChunkLoaded(BukkitTools.calcChunk(wc.getX()), BukkitTools.calcChunk(wc.getZ())))
+				continue;
+			
+			// This worldCoord isn't actively regenerating, start the regeneration.
+			PlotBlockData plotData = getPlotChunkSnapshot(new TownBlock(wc.getX(), wc.getZ(), wc.getTownyWorldOrNull()));  
+			if (plotData != null && plotData.getWorldCoord().isLoaded()) {
+				addToActiveRegeneration(plotData);
+				TownyMessaging.sendDebugMsg("Revert on unclaim beginning for " + plotData.getWorldName() + " " + plotData.getX() +"," + plotData.getZ());
+			} else {
+				removeFromRegenQueueList(wc);
+			}
+		}
+	}
+	
 	/*
 	 * Active Revert-On-Unclaims.
 	 */

--- a/src/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
+++ b/src/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
@@ -184,7 +184,7 @@ public class TownyRegenAPI {
 	}
 
 	/**
-	 * Adds a WorldCoord to the queue of the revert on unclaim feature.
+	 * Removes a WorldCoord from the queue of the revert on unclaim feature.
 	 * @param wc WorldCoord to add to the queue.
 	 */
 	public static void removeFromRegenQueueList(WorldCoord wc) {
@@ -195,7 +195,7 @@ public class TownyRegenAPI {
 	}
 
 	/**
-	 * Removes a WorldCoord to the queue of the revert on unclaim feature.
+	 * Adds a WorldCoord to the queue of the revert on unclaim feature.
 	 * @param wc WorldCoord to remove from thequeue.
 	 * @param save true to save the regenlist.
 	 */

--- a/src/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
+++ b/src/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
@@ -68,6 +68,7 @@ public class TownyRegenAPI {
 		removeFromRegenQueueList(plotChunk.getWorldCoord()); // Remove the WorldCoord from the queue.
 		removeFromActiveRegeneration(plotChunk); // Remove from the active HashTable.
 		deletePlotChunkSnapshot(plotChunk); // Remove from the database.
+		plotChunk.getWorldCoord().unloadChunks(); // Remove the PluginChunkTickets keeping the plotChunk loaded.
 	}
 	
 	/*
@@ -219,11 +220,8 @@ public class TownyRegenAPI {
 			// This worldCoord isn't actively regenerating, start the regeneration.
 			PlotBlockData plotData = getPlotChunkSnapshot(new TownBlock(wc.getX(), wc.getZ(), wc.getTownyWorldOrNull()));
 			if (plotData != null) {
-				// Load the chunks if they are unloaded.
-				plotData.getWorldCoord().getChunks().stream()
-					.filter(chunk -> !chunk.isLoaded())
-					.forEach(chunk -> chunk.load());
-
+				// Load the chunks.
+				plotData.getWorldCoord().loadChunks();
 				addToActiveRegeneration(plotData);
 				TownyMessaging.sendDebugMsg("Revert on unclaim beginning for " + plotData.getWorldName() + " " + plotData.getX() +"," + plotData.getZ());
 			} else {

--- a/src/com/palmergames/bukkit/towny/tasks/RepeatingTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/RepeatingTimerTask.java
@@ -45,18 +45,10 @@ public class RepeatingTimerTask extends TownyTimerTask {
 		if (Math.max(1L, TownySettings.getPlotManagementSpeed()) > ++timerCounter)
 			return;
 
-		for (PlotBlockData plotBlockData : TownyRegenAPI.getActivePlotBlockDatas()) {
-			if (plotBlockData != null) {
-				if (!plotBlockData.getWorldCoord().isLoaded()) {
-					TownyRegenAPI.removeFromActiveRegeneration(plotBlockData);
-					TownyMessaging.sendDebugMsg(plotBlockData.getWorldName() + " " + plotBlockData.getX() +"," + plotBlockData.getZ() + " appears to be in an unloaded part of the server, removing from active regeneration.");
-					continue;
-				}
-				if (!plotBlockData.restoreNextBlock()) {
-					TownyRegenAPI.finishPlotBlockData(plotBlockData);
-				}
-			}
-		}
+		for (PlotBlockData plotBlockData : TownyRegenAPI.getActivePlotBlockDatas())
+			if (plotBlockData != null && !plotBlockData.restoreNextBlock())
+				TownyRegenAPI.finishPlotBlockData(plotBlockData);
+
 		timerCounter = 0L;
 	}
 

--- a/src/com/palmergames/bukkit/towny/tasks/RepeatingTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/RepeatingTimerTask.java
@@ -7,9 +7,6 @@ import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.WorldCoord;
 import com.palmergames.bukkit.towny.regen.PlotBlockData;
 import com.palmergames.bukkit.towny.regen.TownyRegenAPI;
-import com.palmergames.bukkit.util.BukkitTools;
-
-import java.util.ArrayList;
 
 public class RepeatingTimerTask extends TownyTimerTask {
 
@@ -31,11 +28,6 @@ public class RepeatingTimerTask extends TownyTimerTask {
 		/*
 		  The following actions should be performed every second.
 		 */
-
-		// Check and see if we have any room in the PlotChunks regeneration, and more in the queue. 
-		if (TownyRegenAPI.getPlotChunks().size() < 20 && TownyRegenAPI.regenQueueHasAvailable()) {
-			getWorldCoordFromQueueForRegeneration();
-		}
 
 		// Take a snapshot of the next townBlock and save.
 		if (TownyRegenAPI.hasWorldCoords()) {
@@ -66,29 +58,6 @@ public class RepeatingTimerTask extends TownyTimerTask {
 			}
 		}
 		timerCounter = 0L;
-	}
-
-	private void getWorldCoordFromQueueForRegeneration() {
-		for (WorldCoord wc : new ArrayList<>(TownyRegenAPI.getRegenQueueList())) {
-			// We have enough plot chunks regenerating, break out of the loop.
-			if (TownyRegenAPI.getPlotChunks().size() >= 20)
-				break;
-			// We have already got this worldcoord regenerating.
-			if (TownyRegenAPI.hasActiveRegeneration(wc))
-				continue;
-			// This worldcood is not loaded.
-			if (!wc.getBukkitWorld().isChunkLoaded(BukkitTools.calcChunk(wc.getX()), BukkitTools.calcChunk(wc.getZ())))
-				continue;
-			
-			// This worldCoord isn't actively regenerating, start the regeneration.
-			PlotBlockData plotData = TownyRegenAPI.getPlotChunkSnapshot(new TownBlock(wc.getX(), wc.getZ(), wc.getTownyWorldOrNull()));  
-			if (plotData != null && plotData.getWorldCoord().isLoaded()) {
-				TownyRegenAPI.addToActiveRegeneration(plotData);
-				TownyMessaging.sendDebugMsg("Revert on unclaim beginning for " + plotData.getWorldName() + " " + plotData.getX() +"," + plotData.getZ());
-			} else {
-				TownyRegenAPI.removeFromRegenQueueList(wc);
-			}
-		}
 	}
 
 	private void makeNextPlotSnapshot() {

--- a/src/com/palmergames/bukkit/towny/tasks/ShortTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/ShortTimerTask.java
@@ -4,6 +4,7 @@ import org.bukkit.Bukkit;
 
 import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.event.time.NewShortTimeEvent;
+import com.palmergames.bukkit.towny.regen.TownyRegenAPI;
 
 /**
  * This class represents the short timer task
@@ -21,6 +22,11 @@ public class ShortTimerTask extends TownyTimerTask {
 
 	@Override
 	public void run() {
+		
+		// Check and see if we have any room in the PlotChunks regeneration, and more in the queue.
+		if (TownyRegenAPI.getPlotChunks().size() < 20 && TownyRegenAPI.regenQueueHasAvailable()) {
+			TownyRegenAPI.getWorldCoordFromQueueForRegeneration();
+		}
 		
 		/*
 		 * Fire an event other plugins can use.


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Slows down the attempted adding of PlotBlockData to the active regenerations, from every second to every 20 seconds.

Loads unloaded chunks so that PlotBlockDatas will revert land where players aren't actively logged in.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
