### PR TITLE
Prevent safemode if the config/townyperms files couldn't be loaded during a reload.

### DIFF
--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -61,6 +61,7 @@ public class TownySettings {
 		NAME_PREFIX, NAME_POSTFIX, CAPITAL_PREFIX, CAPITAL_POSTFIX, KING_PREFIX, KING_POSTFIX, TOWN_BLOCK_LIMIT_BONUS, UPKEEP_MULTIPLIER, NATION_TOWN_UPKEEP_MULTIPLIER, NATIONZONES_SIZE, NATION_BONUS_OUTPOST_LIMIT
 	}
 
+	private static CommentedConfiguration oldConfig;
 	private static CommentedConfiguration config;
 	private static CommentedConfiguration newConfig;
 	private static int uuidCount;
@@ -288,12 +289,22 @@ public class TownySettings {
 		if (!FileMgmt.checkOrCreateFile(configPath.toString())) {
 			throw new TownyInitException("Failed to touch '" + configPath + "'.", TownyInitException.TownyError.MAIN_CONFIG);
 		}
+		
+		if (config != null)
+			oldConfig = config;
 
 		// read the config.yml into memory
 		config = new CommentedConfiguration(configPath);
 		if (!config.load()) {
-			throw new TownyInitException("Failed to load Towny's config.yml.", TownyInitException.TownyError.MAIN_CONFIG);
+			if (oldConfig != null) {
+				config = oldConfig;
+				oldConfig = null;
+				throw new TownyInitException("An error occurred while reloading the config, the old config file will be used until the issue is fixed.", TownyInitException.TownyError.MAIN_CONFIG, false);
+			} else
+				throw new TownyInitException("Failed to load Towny's config.yml.", TownyInitException.TownyError.MAIN_CONFIG);
 		}
+
+		oldConfig = null;
 
 		setDefaults(version, configPath);
 

--- a/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -67,6 +67,7 @@ import org.bukkit.World;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.conversations.ConversationContext;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
@@ -2030,9 +2031,16 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			plugin.loadPermissions(true);
 		} catch (TownyInitException tie) {
 			TownyMessaging.sendErrorMsg(sender, "Error Loading townyperms.yml!");
-			TownyMessaging.sendErrorMsg(tie.getMessage());
+			TownyMessaging.sendErrorMsg(sender, tie.getMessage());
+
+			// Send a copy of the message to console
+			if (!(sender instanceof ConsoleCommandSender))
+				TownyMessaging.sendErrorMsg(tie.getMessage());
+
 			// Place Towny in Safe Mode while the townyperms.yml is unreadable.
-			plugin.addError(tie.getError());
+			if (tie.shouldSafeMode())
+				plugin.addError(tie.getError());
+
 			return;
 		}
 		TownyMessaging.sendMsg(sender, Translatable.of("msg_reloaded_perms"));
@@ -2057,7 +2065,18 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			TownySettings.loadNationLevelConfig(); // but later so the config-migrator can do it's work on them if needed.
 			Translation.loadTranslationRegistry();
 			TownBlockTypeHandler.initialize();
-		} catch (IOException e) {
+		} catch (TownyInitException tie) {
+			TownyMessaging.sendErrorMsg(sender, tie.getMessage());
+			
+			// Send a copy of the message to console
+			if (!(sender instanceof ConsoleCommandSender))
+				TownyMessaging.sendErrorMsg(tie.getMessage());
+
+			if (tie.shouldSafeMode())
+				plugin.addError(tie.getError());
+
+			return;
+		} catch (Exception e) {
 			TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_reload_error"));
 			e.printStackTrace();
 			return;

--- a/src/com/palmergames/bukkit/towny/exceptions/initialization/TownyInitException.java
+++ b/src/com/palmergames/bukkit/towny/exceptions/initialization/TownyInitException.java
@@ -8,6 +8,7 @@ import org.jetbrains.annotations.NotNull;
 public class TownyInitException extends RuntimeException {
 	private static final long serialVersionUID = -1943705202251722549L;
 	private final TownyError error;
+	private boolean safeMode = true;
 
 	public TownyInitException(@NotNull String message, @NotNull TownyError error) {
 		super(message);
@@ -19,8 +20,18 @@ public class TownyInitException extends RuntimeException {
 		this.error = error;
 	}
 
+	public TownyInitException(@NotNull String message, @NotNull TownyError error, boolean safeMode) {
+		super(message);
+		this.error = error;
+		this.safeMode = safeMode;
+	}
+
 	public TownyError getError() {
 		return error;
+	}
+	
+	public boolean shouldSafeMode() {
+		return safeMode;
 	}
 
 	public enum TownyError {

--- a/src/com/palmergames/bukkit/towny/permissions/TownyPerms.java
+++ b/src/com/palmergames/bukkit/towny/permissions/TownyPerms.java
@@ -44,6 +44,7 @@ public class TownyPerms {
 	protected static LinkedHashMap<String, Permission> registeredPermissions = new LinkedHashMap<>();
 	protected static HashMap<String, PermissionAttachment> attachments = new HashMap<>();
 	private static HashMap<String, List<String>> groupPermsMap = new HashMap<>();
+	private static CommentedConfiguration oldPerms;
 	private static CommentedConfiguration perms;
 	private static Towny plugin;
 	private static List<String> vitalGroups = new ArrayList<>(Arrays.asList("nomad","towns.default","towns.mayor","towns.ranks","nations.default","nations.king","nations.ranks"));
@@ -83,12 +84,22 @@ public class TownyPerms {
 		} catch (IOException e) {
 			throw new TownyInitException("Could not copy townyperms.yml from JAR to '" + permsYMLPath + "'.",TownyInitException.TownyError.PERMISSIONS, e);
 		}
+		
+		if (perms != null)
+			oldPerms = perms;
+		
 		// read the townyperms.yml into memory
 		perms = new CommentedConfiguration(permsYMLPath);
 		if (!perms.load()) {
-			throw new TownyInitException("Could not read townyperms.yml", TownyInitException.TownyError.PERMISSIONS);
+			if (oldPerms != null) {
+				perms = oldPerms;
+				oldPerms = null;
+				throw new TownyInitException("An error occurred while reloading townyperms.yml, the old townyperms file will be used until the issue is fixed.", TownyInitException.TownyError.PERMISSIONS, false);
+			} else
+				throw new TownyInitException("Could not read townyperms.yml", TownyInitException.TownyError.PERMISSIONS);
 		}
 
+		oldPerms = null;
 		groupPermsMap.clear();
 		buildGroupPermsMap();
 		checkForVitalGroups();


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Prevents yaml errors from instantly causing a safemode when using /ta reload config/townyperms by keeping the old config loaded. Does not work when booting up, unless we save the latest working file somewhere.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
