### PR TITLE
Put town into ruined state when last resident is deleted.

### DIFF
--- a/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
@@ -668,21 +668,16 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 		for (Resident toCheck : toSave)
 			saveResident(toCheck);
 		
-		Town town = null;
+		if (resident.hasTown()) {
+			Town town = resident.getTownOrNull();
 
-		if (resident.hasTown())
-			try {
-				town = resident.getTown();
-			} catch (NotRegisteredException e1) {
-				e1.printStackTrace();
-			}
+			if (town != null) {
+				// Delete the town if there are no more residents
+				if (town.getNumResidents() <= 1) {
+					TownyUniverse.getInstance().getDataSource().removeTown(town);
+				}
 
-		if (town != null) {
-			resident.removeTown();
-			
-			// Delete the town if there are no more residents
-			if (town.getNumResidents() == 0) {
-				TownyUniverse.getInstance().getDataSource().removeTown(town);
+				resident.removeTown();
 			}
 		}
 
@@ -768,7 +763,7 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 			/*
 			 * When Town ruining is active, send the Town into a ruined state, prior to real removal.
 			 */
-			TownRuinUtil.putTownIntoRuinedState(town, plugin);
+			TownRuinUtil.putTownIntoRuinedState(town);
 			return;
 		}
 

--- a/src/com/palmergames/bukkit/towny/utils/TownRuinUtil.java
+++ b/src/com/palmergames/bukkit/towny/utils/TownRuinUtil.java
@@ -65,10 +65,9 @@ public class TownRuinUtil {
 	 * 3. Enable all perms
 	 * 4. Now, the residents cannot run /plot commands, and some /t commands
 	 * 5. Town will later be deleted full, unless it is reclaimed
-	 * @param plugin Instance of {@link Towny}
 	 * @param town The town to put into a "ruined" state.
 	 */
-	public static void putTownIntoRuinedState(Town town, Towny plugin) {
+	public static void putTownIntoRuinedState(Town town) {
 
 		//Town already ruined.
 		if (town.isRuined())
@@ -120,7 +119,7 @@ public class TownRuinUtil {
 			ResidentUtil.reduceResidentCountToFitTownMaxPop(town);
 		
 		town.save();
-		plugin.resetCache();
+		Towny.getPlugin().resetCache();
 		
 		TownyMessaging.sendGlobalMessage(Translatable.of("msg_ruin_town", town.getName()));
 	}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Currently, the delayFullRemoval boolean in TownyDatabaseHandler#removeTown will always be false, because the resident is removed before that code is called. This pr switches that around, so that the town can properly ruin.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
