### PR TITLE
Correctly fall back to the en_US when a server is using not-en_US

### DIFF
--- a/src/com/palmergames/bukkit/towny/object/Translation.java
+++ b/src/com/palmergames/bukkit/towny/object/Translation.java
@@ -28,6 +28,7 @@ public final class Translation {
 	
 	private static Map<String, Map<String, String>> translations = new HashMap<>();
 	private static Locale defaultLocale = new Locale("en", "US"); // en-US here by default, in case of safe mode happening before translations are loaded.
+	private static Locale englishLocale = new Locale("en", "US"); // Our last-ditch fall back locale.
 	
 	public static void loadTranslationRegistry() {
 		translations.clear();
@@ -85,8 +86,15 @@ public final class Translation {
 		String data = translations.get(defaultLocale.toString()).get(key.toLowerCase(Locale.ROOT));
 
 		if (data == null) {
-			TownySettings.sendError(key.toLowerCase() + " from " + TownySettings.getString(ConfigNodes.LANGUAGE));
-			return key;
+			// The default locale in the config is missing the language string, they are probably using a non-en_US locale.
+			data = of(key, englishLocale);
+			
+			if (data == null) {
+				// Even the en_US is missing this string, we're probably dealing with a typo.
+				// Log the error and return the un-translated key.
+				TownySettings.sendError(key.toLowerCase() + " from en_US");
+				return key;
+			}
 		}
 		return Colors.translateColorCodes(data);
 	}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
... and a plugin is calling for a string which was not translated to that locale.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
