### PR TITLE
Fix translation loader loading global from the wrong location.

### DIFF
--- a/src/com/palmergames/bukkit/towny/object/TranslationLoader.java
+++ b/src/com/palmergames/bukkit/towny/object/TranslationLoader.java
@@ -276,22 +276,22 @@ public class TranslationLoader {
 	 * Creates and loads a global.yml if one is present in the plugin's jar.
 	 */
 	void loadGlobalFile() {
-		InputStream resourceAsStream = clazz.getResourceAsStream("/global.yml");
-		// A plugin might be using this without also making use of the global.yml.
-		if (resourceAsStream == null)
-			return;
+		try (InputStream resourceAsStream = clazz.getResourceAsStream("/global.yml")) {
+			// A plugin might be using this without also making use of the global.yml.
+			if (resourceAsStream == null)
+				return;
 
-		// Create the global.yml file if it doesn't exist.
-		Path globalYMLPath = langFolderPath.resolve("global.yml");
-		if (!globalYMLPath.toFile().exists())
-			createGlobalYML(globalYMLPath, resourceAsStream);
+			// Create the global.yml file if it doesn't exist.
+			Path globalYMLPath = langFolderPath.resolve("override").resolve("global.yml");
+			if (!globalYMLPath.toFile().exists())
+				createGlobalYML(globalYMLPath, resourceAsStream);
 
-		// Load global override file into memory.
-		Map<String, Object> globalOverrides = loadGlobalFile(globalYMLPath);
-		// Can be null if no overrides have been added
-		if (globalOverrides != null)
-			overwriteKeysWithGlobalOverrides(globalOverrides);
-		
+			// Load global override file into memory.
+			Map<String, Object> globalOverrides = loadGlobalFile(globalYMLPath);
+			// Can be null if no overrides have been added
+			if (globalOverrides != null)
+				overwriteKeysWithGlobalOverrides(globalOverrides);
+		} catch (IOException ignored) {}
 	}
 	
 	/**

--- a/src/com/palmergames/bukkit/towny/object/TranslationLoader.java
+++ b/src/com/palmergames/bukkit/towny/object/TranslationLoader.java
@@ -281,9 +281,15 @@ public class TranslationLoader {
 			if (resourceAsStream == null)
 				return;
 
-			// Create the global.yml file if it doesn't exist.
 			Path globalYMLPath = langFolderPath.resolve("override").resolve("global.yml");
-			if (!globalYMLPath.toFile().exists())
+			Path glitchedGlobalPath = langFolderPath.resolve("global.yml");
+
+			// Move any old global.yml files that are in the wrong location.
+			if (Files.exists(glitchedGlobalPath))
+				Files.move(glitchedGlobalPath, globalYMLPath, StandardCopyOption.REPLACE_EXISTING);
+
+			// Create the global.yml file if it doesn't exist.
+			if (!Files.exists(globalYMLPath))
 				createGlobalYML(globalYMLPath, resourceAsStream);
 
 			// Load global override file into memory.


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Fixes the translation loader loading lang/global.yml instead of the correct lang/override/global.yml.
Also closes the InputStream used in that method correctly.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
