### PR TITLE
Fix /ta checkperm having incorrect tab completions

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -70,6 +70,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.conversations.ConversationContext;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
+import org.bukkit.permissions.Permission;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
@@ -352,6 +353,16 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 				}
 				break;
 			case "checkperm":
+				if (args.length == 2)
+					return NameUtil.filterByStart(BukkitTools.getOnlinePlayers()
+						.stream()
+						.map(Player::getName)
+						.collect(Collectors.toList()), args[1]);
+				if (args.length == 3)
+					return NameUtil.filterByStart(BukkitTools.getPluginManager().getPermissions()
+						.stream()
+						.map(Permission::getName)
+						.collect(Collectors.toList()), args[2]);
 			case "database":
 				if (args.length == 2)
 					return NameUtil.filterByStart(adminDatabaseTabCompletes, args[1]);


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This PR fixes a small issue with the `/ta checkperm` command having the tab completion of `/ta database`. I tested it for functionality and it works fine, but I am unsure as to how efficient it is (Especially on servers with lots of permissions. I have 16 plugins on my test server and did not notice any lag). I am also still very new to Git/PRs so if I messed anything up let me know.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
N/A

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
N/A

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.

Old behavior
![image](https://user-images.githubusercontent.com/71913030/160256535-abe2416e-6038-41f5-9f92-0617255f0ca6.png)


New behavior
![image](https://user-images.githubusercontent.com/71913030/160256429-ab2d76c4-1f86-4bd5-aaaa-18e1d6926d59.png)
![image](https://user-images.githubusercontent.com/71913030/160256382-34bd5d2a-0dac-4236-898e-c1f3300b9a1d.png)
![image](https://user-images.githubusercontent.com/71913030/160256396-573ddc29-4826-4468-9775-c8edb2cee61e.png)

