### PR TITLE
Let admins bypass nation capital checks

### DIFF
--- a/resources/lang/en-US.yml
+++ b/resources/lang/en-US.yml
@@ -1656,3 +1656,5 @@ msg_border_titles_toggled: 'Title messages shown when crossing borders is %s.'
 
 #Message shown confirming that an admin wants to reset their Towny config
 this_will_reset_your_config: 'Running this command resets your config.yml to the default file. Do you want to continue?'
+#Message shown when an admin is setting a new king or capital and would override the config by doing so
+msg_warn_overriding_server_config: 'By doing this you are overriding the resident limits set in the server configuration. Do you want to continue anyway?'

--- a/src/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -2231,6 +2231,11 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 	}
 
 	private static void nationSetCapital(CommandSender sender, Nation nation, String[] split, boolean admin) {
+		if (split.length < 2) {
+			TownyMessaging.sendErrorMsg(sender, "Eg: /nation set capital {town name}");
+			return;
+		}
+		
 		Town newCapital = TownyUniverse.getInstance().getTown(split[1]);
 		
 		if (newCapital == null) {
@@ -2238,57 +2243,45 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 			return;
 		}
 
-		if (TownySettings.getNumResidentsCreateNation() > 0 && newCapital.getNumResidents() < TownySettings.getNumResidentsCreateNation()) {
+		if (TownySettings.getNumResidentsCreateNation() > 0 && newCapital.getNumResidents() < TownySettings.getNumResidentsCreateNation() && !admin) {
 			TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_not_enough_residents_capital", newCapital.getName()));
 			return;
 		}
 		
-		if (TownySettings.getMaxResidentsPerTown() > 0 && nation.getCapital().getNumResidents() > TownySettings.getMaxResidentsPerTown()) {
+		if (TownySettings.getMaxResidentsPerTown() > 0 && nation.getCapital().getNumResidents() > TownySettings.getMaxResidentsPerTown() && !admin) {
 			TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_nation_capital_too_many_residents", newCapital.getName()));
 			return;
 		}
+		
+		Resident oldKing = nation.getKing();
+		Resident newKing = newCapital.getMayor();
 
-		if (split.length < 2)
-			TownyMessaging.sendErrorMsg(sender, "Eg: /nation set capital {town name}");
-		else {
-			Resident oldKing = nation.getKing();
-			Resident newKing = newCapital.getMayor();
+		NationKingChangeEvent nationKingChangeEvent = new NationKingChangeEvent(oldKing, newKing);
+		Bukkit.getPluginManager().callEvent(nationKingChangeEvent);
+		if (nationKingChangeEvent.isCancelled() && !admin) {
+			TownyMessaging.sendErrorMsg(sender, nationKingChangeEvent.getCancelMessage());
+			return;
+		}
 
-			NationKingChangeEvent nationKingChangeEvent = new NationKingChangeEvent(oldKing, newKing);
-			Bukkit.getPluginManager().callEvent(nationKingChangeEvent);
-			if (nationKingChangeEvent.isCancelled() && !admin) {
-				TownyMessaging.sendErrorMsg(sender, nationKingChangeEvent.getCancelMessage());
-				return;
-			}
-
-			// Do proximity tests.
-			if (TownySettings.getNationRequiresProximity() > 0 ) {
-				List<Town> removedTowns = nation.gatherOutOfRangeTowns(nation.getTowns(), newCapital);
-				
-				// There are going to be some towns removed from the nation, so we'll do a Confirmation.
-				if (!removedTowns.isEmpty()) {
-					final Nation finalNation = nation;
-					Confirmation.runOnAccept(() -> {
-						finalNation.setCapital(newCapital);										
-						finalNation.removeOutOfRangeTowns();
-						plugin.resetCache();
-						TownyMessaging.sendPrefixedNationMessage(finalNation, Translatable.of("msg_new_king", newCapital.getMayor().getName(), finalNation.getName()));
-						if (admin)
-							TownyMessaging.sendMsg(sender, Translatable.of("msg_new_king", newCapital.getMayor().getName(), finalNation.getName()));
-					})
-					.setTitle(Translatable.of("msg_warn_the_following_towns_will_be_removed_from_your_nation", StringMgmt.join(removedTowns, ", ")))
-					.sendTo(sender);
-					
-				// No towns will be removed, skip the Confirmation.
-				} else {
-					nation.setCapital(newCapital);
+		// Do proximity tests.
+		if (TownySettings.getNationRequiresProximity() > 0 ) {
+			List<Town> removedTowns = nation.gatherOutOfRangeTowns(nation.getTowns(), newCapital);
+			
+			// There are going to be some towns removed from the nation, so we'll do a Confirmation.
+			if (!removedTowns.isEmpty()) {
+				final Nation finalNation = nation;
+				Confirmation.runOnAccept(() -> {
+					finalNation.setCapital(newCapital);										
+					finalNation.removeOutOfRangeTowns();
 					plugin.resetCache();
-					TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_new_king", newCapital.getMayor().getName(), nation.getName()));
+					TownyMessaging.sendPrefixedNationMessage(finalNation, Translatable.of("msg_new_king", newCapital.getMayor().getName(), finalNation.getName()));
 					if (admin)
-						TownyMessaging.sendMsg(sender, Translatable.of("msg_new_king", newCapital.getMayor().getName(), nation.getName()));
-					nation.save();
-				}
-			// Proximity doesn't factor in.
+						TownyMessaging.sendMsg(sender, Translatable.of("msg_new_king", newCapital.getMayor().getName(), finalNation.getName()));
+				})
+				.setTitle(Translatable.of("msg_warn_the_following_towns_will_be_removed_from_your_nation", StringMgmt.join(removedTowns, ", ")))
+				.sendTo(sender);
+				
+			// No towns will be removed, skip the Confirmation.
 			} else {
 				nation.setCapital(newCapital);
 				plugin.resetCache();
@@ -2297,6 +2290,14 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 					TownyMessaging.sendMsg(sender, Translatable.of("msg_new_king", newCapital.getMayor().getName(), nation.getName()));
 				nation.save();
 			}
+		// Proximity doesn't factor in.
+		} else {
+			nation.setCapital(newCapital);
+			plugin.resetCache();
+			TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_new_king", newCapital.getMayor().getName(), nation.getName()));
+			if (admin)
+				TownyMessaging.sendMsg(sender, Translatable.of("msg_new_king", newCapital.getMayor().getName(), nation.getName()));
+			nation.save();
 		}
 	}
 
@@ -2310,12 +2311,12 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 				Resident oldKing = nation.getKing();
 				Town newCapital = newKing.getTown();
 
-				if (TownySettings.getNumResidentsCreateNation() > 0 && newCapital.getNumResidents() < TownySettings.getNumResidentsCreateNation()) {
+				if (TownySettings.getNumResidentsCreateNation() > 0 && newCapital.getNumResidents() < TownySettings.getNumResidentsCreateNation() && !admin) {
 					TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_not_enough_residents_capital", newCapital.getName()));
 					return;
 				}
 				
-				if (TownySettings.getMaxResidentsPerTown() > 0 && nation.getCapital().getNumResidents() > TownySettings.getMaxResidentsPerTown()) {
+				if (TownySettings.getMaxResidentsPerTown() > 0 && nation.getCapital().getNumResidents() > TownySettings.getMaxResidentsPerTown() && !admin) {
 					TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_nation_capital_too_many_residents", newCapital.getName()));
 					return;
 				}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Replaces #5824

Admins using /ta nation <nation> set <capital|king> now bypass checks for resident limits for the new and old capital. This makes it easier to transfer the nation to a new king without impacting the old capital or its residents.


____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
