### PR TITLE
Add option to disable pickups while under respawn protection

### DIFF
--- a/resources/config-migration.json
+++ b/resources/config-migration.json
@@ -273,5 +273,15 @@
         "worldAction": "UPDATE_WILDERNESS_IGNORE_MATS"
       }
     ]
+  },
+  {
+    "version": "0.98.1.12",
+    "changes": [
+      {
+        "type": "MOVE",
+        "path": "global_town_settings.respawn_protection",
+        "value": "global_town_settings.respawn_protection.time"
+      }
+    ]
   }
 ]

--- a/resources/lang/en-US.yml
+++ b/resources/lang/en-US.yml
@@ -1440,7 +1440,7 @@ msg_setup_success: 'Successfully changed config values to your new values.'
 #Player has recently died and respawned and is invulnerable.
 msg_err_player_cannot_be_harmed: '%s spawned recently and cannot be harmed.'
 #Player was invulnerable after respawning and has lost their invulnerability.
-msg_you_have_lost_your_invulnerability: 'You have lost your invulnerability.'
+msg_you_have_lost_your_respawn_protection: 'You have lost your respawn protection.'
 msg_err_cannot_pickup_respawn_protection: 'You cannot pick up items while under respawn protection.'
 
 #Added in 0.126

--- a/resources/lang/en-US.yml
+++ b/resources/lang/en-US.yml
@@ -1441,6 +1441,7 @@ msg_setup_success: 'Successfully changed config values to your new values.'
 msg_err_player_cannot_be_harmed: '%s spawned recently and cannot be harmed.'
 #Player was invulnerable after respawning and has lost their invulnerability.
 msg_you_have_lost_your_invulnerability: 'You have lost your invulnerability.'
+msg_err_cannot_pickup_respawn_protection: 'You cannot pick up items while under respawn protection.'
 
 #Added in 0.126
 

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -611,13 +611,18 @@ public enum ConfigNodes {
 			"false",
 			"",
 			"# When true Towny will handle respawning, with town or resident spawns."),
-	GTOWN_SETTINGS_RESPAWN_PROTECTION(
-			"global_town_settings.respawn_protection",
+	GTOWN_SETTINGS_RESPAWN_PROTECTION_TIME(
+			"global_town_settings.respawn_protection.time",
 			"10s",
 			"",
 			"# When greater than 0s, the amount of time a player who has respawned is considered invulnerable.",
 			"# Invulnerable players who attack other players will lose their invulnerability.",
 			"# Invulnerable players who teleport after respawn will also lose their invulnerability."),
+	GTOWN_SETTINGS_RESPAWN_PROTECTION_ALLOW_PICKUP(
+			"global_town_settings.respawn_protection.allow_pickup",
+			"true",
+			"",
+			"# If disabled, players will not be able to pickup items while under respawn protection."),
 	GTOWN_SETTINGS_TOWN_RESPAWN_SAME_WORLD_ONLY(
 			"global_town_settings.town_respawn_same_world_only",
 			"false",

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -611,6 +611,7 @@ public enum ConfigNodes {
 			"false",
 			"",
 			"# When true Towny will handle respawning, with town or resident spawns."),
+	GTOWN_SETTINGS_RESPAWN_PROTECTION_ROOT("global_town_settings.respawn_protection", "", ""),
 	GTOWN_SETTINGS_RESPAWN_PROTECTION_TIME(
 			"global_town_settings.respawn_protection.time",
 			"10s",

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -3107,7 +3107,7 @@ public class TownySettings {
 	}
 
 	public static long getSpawnProtection() {
-		return TimeTools.getTicks(getString(ConfigNodes.GTOWN_SETTINGS_RESPAWN_PROTECTION));
+		return TimeTools.getTicks(getString(ConfigNodes.GTOWN_SETTINGS_RESPAWN_PROTECTION_TIME));
 	}
 	
 	public static boolean isUsingWebMapStatusScreens() {
@@ -3150,6 +3150,10 @@ public class TownySettings {
 			return true;
 		
 		return getStrArr(ConfigNodes.PLUGIN_ENABLED_CONTEXTS).contains(id);
+	}
+	
+	public static boolean getRespawnProtectionAllowPickup() {
+		return getBoolean(ConfigNodes.GTOWN_SETTINGS_RESPAWN_PROTECTION_ALLOW_PICKUP);
 	}
 }
 

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -3106,7 +3106,7 @@ public class TownySettings {
 		config.save();
 	}
 
-	public static long getSpawnProtection() {
+	public static long getSpawnProtectionDuration() {
 		return TimeTools.getTicks(getString(ConfigNodes.GTOWN_SETTINGS_RESPAWN_PROTECTION_TIME));
 	}
 	

--- a/src/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
@@ -201,13 +201,13 @@ public class TownyCustomListener implements Listener {
 	public void onPlayerDamagePlayerEvent(TownyPlayerDamagePlayerEvent event) {
 		Resident victim = event.getVictimResident();
 		Resident attacker = event.getAttackingResident();
-		if (victim != null && victim.hasSpawnProtection()) {
+		if (victim != null && victim.hasRespawnProtection()) {
 			event.setCancelled(true);
 			event.setMessage(Translatable.of("msg_err_player_cannot_be_harmed", victim.getName()).forLocale(attacker));
 		}
-		if (attacker != null && attacker.hasSpawnProtection()) {
+		if (attacker != null && attacker.hasRespawnProtection()) {
 			event.setCancelled(true);
-			attacker.removeSpawnProtection();
+			attacker.removeRespawnProtection();
 		}
 	}
 }

--- a/src/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
@@ -201,11 +201,11 @@ public class TownyCustomListener implements Listener {
 	public void onPlayerDamagePlayerEvent(TownyPlayerDamagePlayerEvent event) {
 		Resident victim = event.getVictimResident();
 		Resident attacker = event.getAttackingResident();
-		if (victim != null && victim.getSpawnProtectionTaskID() != 0) {
+		if (victim != null && victim.hasSpawnProtection()) {
 			event.setCancelled(true);
 			event.setMessage(Translatable.of("msg_err_player_cannot_be_harmed", victim.getName()).forLocale(attacker));
 		}
-		if (attacker != null && attacker.getSpawnProtectionTaskID() != 0) {
+		if (attacker != null && attacker.hasSpawnProtection()) {
 			event.setCancelled(true);
 			attacker.removeSpawnProtection();
 		}

--- a/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -203,14 +203,14 @@ public class TownyPlayerListener implements Listener {
 		event.setRespawnLocation(respawn);
 		
 		// Handle Spawn protection
-		long protectionTime = TownySettings.getSpawnProtection();
+		long protectionTime = TownySettings.getSpawnProtectionDuration();
 		if (protectionTime > 0L) {
 			Resident res = TownyAPI.getInstance().getResident(player);
 			if (res == null)
 				return;
 			
-			int taskID = Bukkit.getScheduler().runTaskLater(plugin, ()-> res.removeSpawnProtection(), protectionTime).getTaskId();
-			res.setSpawnProtectionTaskID(taskID);
+			int taskID = Bukkit.getScheduler().runTaskLater(plugin, res::removeRespawnProtection, protectionTime).getTaskId();
+			res.setRespawnProtectionTaskID(taskID);
 		}
 	}
 	
@@ -771,8 +771,8 @@ public class TownyPlayerListener implements Listener {
 		/*
 		 * Remove spawn protection if the player is teleporting since spawning.
 		 */
-		if (resident != null && resident.getSpawnProtectionTaskID() != -1) {
-			resident.removeSpawnProtection();
+		if (resident != null && resident.getRespawnProtectionTaskID() != -1) {
+			resident.removeRespawnProtection();
 		}
 		
 		onPlayerMove(event);
@@ -1305,6 +1305,13 @@ public class TownyPlayerListener implements Listener {
 		if (resident == null)
 			return;
 		
-		event.setCancelled(resident.hasSpawnProtection());
+		if (resident.hasRespawnProtection()) {
+			event.setCancelled(true);
+
+			if (!resident.isRespawnPickupWarningShown()) {
+				resident.setRespawnPickupWarningShown(true);
+				TownyMessaging.sendErrorMsg(player, Translatable.of("msg_err_cannot_pickup_respawn_protection"));
+			}
+		}
 	}
 }

--- a/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -209,8 +209,7 @@ public class TownyPlayerListener implements Listener {
 			if (res == null)
 				return;
 			
-			int taskID = Bukkit.getScheduler().runTaskLater(plugin, res::removeRespawnProtection, protectionTime).getTaskId();
-			res.setRespawnProtectionTaskID(taskID);
+			res.addRespawnProtection(protectionTime);
 		}
 	}
 	
@@ -771,7 +770,7 @@ public class TownyPlayerListener implements Listener {
 		/*
 		 * Remove spawn protection if the player is teleporting since spawning.
 		 */
-		if (resident != null && resident.getRespawnProtectionTaskID() != -1) {
+		if (resident != null && resident.hasRespawnProtection()) {
 			resident.removeRespawnProtection();
 		}
 		

--- a/src/com/palmergames/bukkit/towny/object/Resident.java
+++ b/src/com/palmergames/bukkit/towny/object/Resident.java
@@ -76,7 +76,7 @@ public class Resident extends TownyObject implements InviteReceiver, EconomyHand
 
 	private ArrayList<Inventory> guiPages;
 	private int guiPageNum = 0;
-	private int spawnProtectionTaskID = 0;
+	private int spawnProtectionTaskID = -1;
 
 	public Resident(String name) {
 		super(name);
@@ -866,9 +866,13 @@ public class Resident extends TownyObject implements InviteReceiver, EconomyHand
 		this.spawnProtectionTaskID = spawnProtectionTaskID;
 	}
 	
+	public boolean hasSpawnProtection() {
+		return spawnProtectionTaskID != -1 && Bukkit.getScheduler().isQueued(spawnProtectionTaskID);
+	}
+	
 	public void removeSpawnProtection() {
 		Bukkit.getScheduler().cancelTask(getSpawnProtectionTaskID());
-		setSpawnProtectionTaskID(0);
+		setSpawnProtectionTaskID(-1);
 		TownyMessaging.sendMsg(this, Translatable.of("msg_you_have_lost_your_invulnerability"));
 	}
 

--- a/src/com/palmergames/bukkit/towny/object/Resident.java
+++ b/src/com/palmergames/bukkit/towny/object/Resident.java
@@ -35,6 +35,7 @@ import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -859,23 +860,35 @@ public class Resident extends TownyObject implements InviteReceiver, EconomyHand
 		return BukkitTools.isOnline(getName());
 	}
 
+	@Deprecated
+	@ApiStatus.ScheduledForRemoval
 	public int getRespawnProtectionTaskID() {
-		return respawnProtectionTaskID;
+		return -1;
 	}
 
+	@Deprecated
+	@ApiStatus.ScheduledForRemoval
 	public void setRespawnProtectionTaskID(int respawnProtectionTaskID) {
-		this.respawnProtectionTaskID = respawnProtectionTaskID;
+		
 	}
 	
 	public boolean hasRespawnProtection() {
 		return respawnProtectionTaskID != -1;
 	}
 	
-	public void removeRespawnProtection() {
-		Bukkit.getScheduler().cancelTask(getRespawnProtectionTaskID());
-		setRespawnProtectionTaskID(-1);
-		TownyMessaging.sendMsg(this, Translatable.of("msg_you_have_lost_your_respawn_protection"));
+	public void addRespawnProtection(long protectionTime) {
+		// Cancel existing respawn protection task without message
+		if (respawnProtectionTaskID != -1)
+			Bukkit.getScheduler().cancelTask(respawnProtectionTaskID);
+
 		respawnPickupWarningShown = false;
+		this.respawnProtectionTaskID = Bukkit.getScheduler().runTaskLater(Towny.getPlugin(), this::removeRespawnProtection, protectionTime).getTaskId();
+	}
+	
+	public void removeRespawnProtection() {
+		Bukkit.getScheduler().cancelTask(respawnProtectionTaskID);
+		respawnProtectionTaskID = -1;
+		TownyMessaging.sendMsg(this, Translatable.of("msg_you_have_lost_your_respawn_protection"));
 	}
 	
 	public boolean isRespawnPickupWarningShown() {

--- a/src/com/palmergames/bukkit/towny/object/Resident.java
+++ b/src/com/palmergames/bukkit/towny/object/Resident.java
@@ -76,7 +76,8 @@ public class Resident extends TownyObject implements InviteReceiver, EconomyHand
 
 	private ArrayList<Inventory> guiPages;
 	private int guiPageNum = 0;
-	private int spawnProtectionTaskID = -1;
+	private int respawnProtectionTaskID = -1;
+	private boolean respawnPickupWarningShown = false; // Prevents chat spam when a player attempts to pick up an item while under respawn protection.
 
 	public Resident(String name) {
 		super(name);
@@ -858,22 +859,31 @@ public class Resident extends TownyObject implements InviteReceiver, EconomyHand
 		return BukkitTools.isOnline(getName());
 	}
 
-	public int getSpawnProtectionTaskID() {
-		return spawnProtectionTaskID;
+	public int getRespawnProtectionTaskID() {
+		return respawnProtectionTaskID;
 	}
 
-	public void setSpawnProtectionTaskID(int spawnProtectionTaskID) {
-		this.spawnProtectionTaskID = spawnProtectionTaskID;
+	public void setRespawnProtectionTaskID(int respawnProtectionTaskID) {
+		this.respawnProtectionTaskID = respawnProtectionTaskID;
 	}
 	
-	public boolean hasSpawnProtection() {
-		return spawnProtectionTaskID != -1 && Bukkit.getScheduler().isQueued(spawnProtectionTaskID);
+	public boolean hasRespawnProtection() {
+		return respawnProtectionTaskID != -1;
 	}
 	
-	public void removeSpawnProtection() {
-		Bukkit.getScheduler().cancelTask(getSpawnProtectionTaskID());
-		setSpawnProtectionTaskID(-1);
-		TownyMessaging.sendMsg(this, Translatable.of("msg_you_have_lost_your_invulnerability"));
+	public void removeRespawnProtection() {
+		Bukkit.getScheduler().cancelTask(getRespawnProtectionTaskID());
+		setRespawnProtectionTaskID(-1);
+		TownyMessaging.sendMsg(this, Translatable.of("msg_you_have_lost_your_respawn_protection"));
+		respawnPickupWarningShown = false;
+	}
+	
+	public boolean isRespawnPickupWarningShown() {
+		return this.respawnPickupWarningShown;
+	}
+
+	public void setRespawnPickupWarningShown(boolean respawnPickupWarningShown) {
+		this.respawnPickupWarningShown = respawnPickupWarningShown;
 	}
 
 	@NotNull

--- a/src/com/palmergames/bukkit/towny/object/Resident.java
+++ b/src/com/palmergames/bukkit/towny/object/Resident.java
@@ -877,6 +877,9 @@ public class Resident extends TownyObject implements InviteReceiver, EconomyHand
 	}
 	
 	public void addRespawnProtection(long protectionTime) {
+		if (protectionTime <= 0)
+			return;
+		
 		// Cancel existing respawn protection task without message
 		if (respawnProtectionTaskID != -1)
 			Bukkit.getScheduler().cancelTask(respawnProtectionTaskID);


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Adds an option to disable the ability for players to pickup items while under respawn protection.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
New config option: global_town_settings.respawn_protection.allow_pickup
If disabled, players will not be able to pickup items while under respawn protection.

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
