### PR TITLE
Fix potential NPE in towny:insidetown luckperms context.

### DIFF
--- a/src/com/palmergames/bukkit/towny/Towny.java
+++ b/src/com/palmergames/bukkit/towny/Towny.java
@@ -35,7 +35,6 @@ import com.palmergames.bukkit.towny.listeners.TownyPlayerListener;
 import com.palmergames.bukkit.towny.listeners.TownyServerListener;
 import com.palmergames.bukkit.towny.listeners.TownyVehicleListener;
 import com.palmergames.bukkit.towny.listeners.TownyWorldListener;
-import com.palmergames.bukkit.towny.object.Coord;
 import com.palmergames.bukkit.towny.object.PlayerCache;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.TownBlockTypeHandler;
@@ -879,7 +878,7 @@ public class Towny extends JavaPlugin {
 
 		for (Player player : BukkitTools.getOnlinePlayers())
 			if (player != null)
-				if (Coord.parseCoord(player).equals(worldCoord))
+				if (WorldCoord.parseWorldCoord(player).equals(worldCoord))
 					getCache(player).resetAndUpdate(worldCoord); // Automatically resets permissions.
 	}
 

--- a/src/com/palmergames/bukkit/towny/hooks/LuckPermsContexts.java
+++ b/src/com/palmergames/bukkit/towny/hooks/LuckPermsContexts.java
@@ -42,7 +42,7 @@ public class LuckPermsContexts implements ContextCalculator<Player> {
 			if (cache == null)
 				return Collections.emptyList();
 			
-			return Collections.singleton(String.valueOf(cache.getLastTownBlock().hasTownBlock()));
+			return Optional.ofNullable(cache.getLastTownBlock()).map(wc -> Collections.singleton(String.valueOf(wc.hasTownBlock()))).orElse(Collections.emptySet());
 		}, () -> Arrays.asList("true", "false"));
 		registerContext("towny:insideowntown", resident -> {
 			PlayerCache cache = plugin.getCacheOrNull(resident.getUUID());

--- a/src/com/palmergames/bukkit/towny/object/PlayerCache.java
+++ b/src/com/palmergames/bukkit/towny/object/PlayerCache.java
@@ -50,8 +50,7 @@ public class PlayerCache {
 	 */
 	public void resetAndUpdate(@NotNull WorldCoord worldCoord) {
 		
-		reset();
-		setLastTownBlock(worldCoord);
+		reset(worldCoord);
 	}
 
 	/**
@@ -74,8 +73,7 @@ public class PlayerCache {
 	public boolean updateCoord(@NotNull WorldCoord pos) {
 
 		if (!getLastTownBlock().equals(pos)) {
-			reset();
-			setLastTownBlock(pos);
+			reset(pos);
 			return true;
 		} else
 			return false;
@@ -177,9 +175,9 @@ public class PlayerCache {
 		
 	}
 
-	private void reset() {
+	private void reset(WorldCoord wc) {
 
-		lastWorldCoord = null;
+		lastWorldCoord = wc;
 		townBlockStatus = null;
 		blockErrMsg = null;
 		


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Fixes:
```
[02:21:24] [pool-66-thread-1/WARN]: [LuckPerms] An exception was thrown by com.palmergames.bukkit.towny.hooks.LuckPermsContexts whilst calculating the context of subject CraftPlayer{name=Eurykles}
java.lang.NullPointerException: Cannot invoke "com.palmergames.bukkit.towny.object.WorldCoord.hasTownBlock()" because the return value of "com.palmergames.bukkit.towny.object.PlayerCache.getLastTownBlock()" is null
    at com.palmergames.bukkit.towny.hooks.LuckPermsContexts.lambda$new$6(LuckPermsContexts.java:45) ~[Towny-0.98.2.0.jar:?]
    at com.palmergames.bukkit.towny.hooks.LuckPermsContexts.calculate(LuckPermsContexts.java:95) ~[Towny-0.98.2.0.jar:?]
    at com.palmergames.bukkit.towny.hooks.LuckPermsContexts.calculate(LuckPermsContexts.java:32) ~[Towny-0.98.2.0.jar:?]
    at me.lucko.luckperms.common.context.manager.ContextManager.callContextCalculator(ContextManager.java:140) ~[?:?]
    at me.lucko.luckperms.common.context.manager.ContextManager.calculate(ContextManager.java:159) ~[?:?]
    at me.lucko.luckperms.common.context.manager.QueryOptionsCache.supply(QueryOptionsCache.java:54) ~[?:?]
    at me.lucko.luckperms.common.context.manager.QueryOptionsCache.supply(QueryOptionsCache.java:42) ~[?:?]
    at me.lucko.luckperms.common.cache.ExpiringCache.get(ExpiringCache.java:64) ~[?:?]
    at me.lucko.luckperms.common.context.manager.QueryOptionsCache.getQueryOptions(QueryOptionsCache.java:59) ~[?:?]
    at me.lucko.luckperms.bukkit.inject.permissible.LuckPermsPermissible.hasPermission(LuckPermsPermissible.java:175) ~[?:?]
    at org.bukkit.craftbukkit.v1_18_R2.entity.CraftHumanEntity.hasPermission(CraftHumanEntity.java:212) ~[purpur-1.18.2.jar:git-Purpur-1627]
    at me.frep.vulcan.spigot.Vulcan_nR.Vulcan_u(Vulcan_nR.java:149) ~[Vulcan-2.6.6-HOTFIX.jar:?]
    at me.frep.vulcan.spigot.Vulcan_nR.Vulcan_y(Vulcan_nR.java:54) ~[Vulcan-2.6.6-HOTFIX.jar:?]
    at me.frep.vulcan.spigot.Vulcan_NR.Vulcan_e(Vulcan_NR.java:38) ~[Vulcan-2.6.6-HOTFIX.jar:?]
    at me.frep.vulcan.spigot.Vulcan_lU.lambda$onPacketPlayReceive$0(Vulcan_lU.java:58) ~[Vulcan-2.6.6-HOTFIX.jar:?]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
    at java.lang.Thread.run(Thread.java:833) ~[?:?]
```
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
