### PR TITLE
Change language in unallied nation spawning error.

### DIFF
--- a/resources/lang/en-US.yml
+++ b/resources/lang/en-US.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.150
+version: 0.151
 language: english
 author: ElgarL
 website: 'http://townyadvanced.github.io/'
@@ -1680,6 +1680,10 @@ msg_err_could_not_find_any_towns_to_rtp: 'Could not find any open, public towns 
 msg_cost_spawn_rtp: '&bYou were charged %s to teleport to a random town plot that is for sale.'
 #Message shown to a player when they use the town rtp command.
 msg_you_are_about_to_be_teleported_to_a_plot: 'You are about to be teleported to a plot which is forsale in %s which will let you join. Use ''/plot claim'' to claim your plot when you arrive.'
+
+#Added in 0.151
+msg_err_nation_unaffiliated: '&cThat nation is not affiliated with you.'
+
 
 #
 #Used in the town's status screen to display plots

--- a/src/com/palmergames/bukkit/towny/utils/SpawnUtil.java
+++ b/src/com/palmergames/bukkit/towny/utils/SpawnUtil.java
@@ -311,7 +311,7 @@ public class SpawnUtil {
 			}
 
 			if (nationSpawnLevel == NationSpawnLevel.UNAFFILIATED && !nation.isPublic())
-				throw new TownyException(Translatable.of("msg_err_nation_not_public"));
+				throw new TownyException(Translatable.of("msg_err_nation_unaffiliated"));
 		}
 
 		// Check if the player has the permission/config allows for this type of spawning.


### PR DESCRIPTION
#### Description: 
Currently, when a player tries to use `/n spawn` to a nation that is not allied with them, it simple says "That nation is not public" when it should suggest that nation is not affiliated with their nation, giving a hint at the problem lies with their relationship and not if the nation has enabled/disabled public.

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Towny Issue ticket:
https://github.com/EarthMC/Issue-Tracker/issues/1524


____
- [X] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
