### PR TITLE
Add a command to manually override a town's TownLevel.

### DIFF
--- a/resources/lang/en-US.yml
+++ b/resources/lang/en-US.yml
@@ -1737,3 +1737,9 @@ msg_perm_hud_nation: 'nation'
 msg_perm_hud_outsider: 'outsider'
 #Seen in /plot perm hud:
 msg_perm_hud_plot_name: 'Plot: '
+
+#Added in 0.153
+#Message shown confirming /ta town NAME settownlevel # command.
+msg_town_level_overridden_with: 'The town %s has had their townlevel set to %s.'
+#Message shown when unsetting a manual town level.
+msg_town_level_unset: 'The town %s has had their manually-set townlevel unset. Current townlevel is %s.'

--- a/src/com/palmergames/bukkit/towny/command/BaseCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/BaseCommand.java
@@ -74,6 +74,18 @@ public class BaseCommand implements TabCompleter{
 		"off"
 	);
 	
+	public static final List<String> numbers = Arrays.asList(
+		"1",
+		"2",
+		"3",
+		"4",
+		"5",
+		"6",
+		"7",
+		"8",
+		"9"
+	);
+	
 	@Override
 	public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
 		return getTownyStartingWith(args[args.length - 1], "rtn");

--- a/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
+++ b/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
@@ -195,6 +195,7 @@ public class SQL_Schema {
 		columns.add("`allies` mediumtext NOT NULL");
 		columns.add("`enemies` mediumtext NOT NULL");
 		columns.add("`hasUnlimitedClaims` bool NOT NULL DEFAULT '0'");
+		columns.add("`manualTownLevel` BIGINT DEFAULT '-1'");
 		return columns;
 	}
 

--- a/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -906,6 +906,10 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 				if (line != null && !line.isEmpty())
 					MetadataLoader.getInstance().deserializeMetadata(town, line.trim());
 				
+				line = keys.get("manualTownLevel");
+				if (line != null)
+					town.setManualTownLevel(Integer.parseInt(line));
+				
 				line = keys.get("nation");
 				if (line != null && !line.isEmpty()) {
 					Nation nation = null;
@@ -1967,6 +1971,9 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 
 		// Metadata
 		list.add("metadata=" + serializeMetadata(town));
+		
+		// ManualTownLevel
+		list.add("manualTownLevel=" + town.getManualTownLevel());
 		
 		list.add("ruined=" + town.isRuined());
 		list.add("ruinedTime=" + town.getRuinedTime());

--- a/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -956,6 +956,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 				town.setTag(line);
 			town.setPermissions(rs.getString("protectionStatus").replaceAll("#", ","));
 			town.setBonusBlocks(rs.getInt("bonus"));
+			town.setManualTownLevel(rs.getInt("manualTownLevel"));
 			town.setTaxPercentage(rs.getBoolean("taxpercent"));
 			town.setTaxes(rs.getFloat("taxes"));
 			town.setMaxPercentTaxAmount(rs.getFloat("maxPercentTaxAmount"));
@@ -2117,6 +2118,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			twn_hm.put("tag", town.getTag());
 			twn_hm.put("protectionStatus", town.getPermissions().toString().replaceAll(",", "#"));
 			twn_hm.put("bonus", town.getBonusBlocks());
+			twn_hm.put("manualTownLevel", town.getManualTownLevel());
 			twn_hm.put("purchased", town.getPurchasedBlocks());
 			twn_hm.put("nationZoneOverride", town.getNationZoneOverride());
 			twn_hm.put("nationZoneEnabled", town.isNationZoneEnabled());

--- a/src/com/palmergames/bukkit/towny/object/Town.java
+++ b/src/com/palmergames/bukkit/towny/object/Town.java
@@ -95,6 +95,7 @@ public class Town extends Government implements TownBlockOwner {
 	private long joinedNationAt;
 	private long movedHomeBlockAt;
 	private Jail primaryJail;
+	private int manualTownLevel = -1;
 
 	public Town(String name) {
 		super(name);
@@ -1641,9 +1642,17 @@ public class Town extends Government implements TownBlockOwner {
 	public int getLevel(int populationSize) {
 		if (this.isRuined())
 			return 0;
-		for (int level : TownySettings.getConfigTownLevel().keySet())
-			if (populationSize >= level)
+
+		int key = 0;
+		for (int level : TownySettings.getConfigTownLevel().keySet()) {
+			key++;
+			// Some towns might have their townlevel overridden.
+			if (getManualTownLevel() > -1 && key == getMaxLevel() - getManualTownLevel())
 				return level;
+			// No overridden townlevel, use population instead.
+			if (getManualTownLevel() == -1 && populationSize >= level)
+				return level;
+		}
 		return 0;
 	}
 
@@ -1684,6 +1693,20 @@ public class Town extends Government implements TownBlockOwner {
 		return townLevelId;
 	}
 
+	/**
+	 * @return the manualTownLevel
+	 */
+	public int getManualTownLevel() {
+		return manualTownLevel;
+	}
+
+	/**
+	 * @param manualTownLevel the manualTownLevel to set
+	 */
+	public void setManualTownLevel(int manualTownLevel) {
+		this.manualTownLevel = manualTownLevel;
+	}
+	
 	@Override
 	public @NotNull Iterable<? extends Audience> audiences() {
 		return TownyAPI.getInstance().getOnlinePlayers(this).stream().map(player -> Towny.getAdventure().player(player)).collect(Collectors.toSet());

--- a/src/com/palmergames/util/StringMgmt.java
+++ b/src/com/palmergames/util/StringMgmt.java
@@ -4,6 +4,7 @@ import com.palmergames.bukkit.towny.object.Translation;
 
 import net.md_5.bungee.api.ChatColor;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -238,5 +239,11 @@ public class StringMgmt {
 				return false;
 		
 		return true;
+	}
+	
+	public static List<String> addToList(List<String> list, String addition) {
+		List<String> out = new ArrayList<>(list);
+		out.add(addition);
+		return out;
 	}
 }


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

- /ta town NAME settownlevel #|unset.
- Changes a town's level from being population-based to something that
is overridden at townlevel calculation.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->

/ta town NAME settownlevel # or unset.
  - Automatically will not set higher than there are levels.

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
