### PR TITLE
Add admin town command upkeep toggle

### DIFF
--- a/resources/lang/en-US.yml
+++ b/resources/lang/en-US.yml
@@ -1,5 +1,5 @@
 name: Towny
-version: 0.154
+version: 0.155
 language: english
 author: ElgarL
 website: 'http://townyadvanced.github.io/'
@@ -1752,3 +1752,9 @@ msg_purchased_blocks_changed: 'The town %s has been given %s bought townblocks, 
 
 #Added in 0.154
 msg_comptype_upkeep: 'Upkeep'
+
+# Added in 0.155
+# Message shown when toggling town upkeep admin setting
+msg_town_upkeep_setting_set_to: 'The town %s has had their upkeep setting set to %s.'
+# Message shown when toggling nation upkeep admin setting
+msg_nation_upkeep_setting_set_to: 'The nation %s has had their upkeep setting set to %s.'

--- a/resources/lang/en-US.yml
+++ b/resources/lang/en-US.yml
@@ -1756,5 +1756,3 @@ msg_comptype_upkeep: 'Upkeep'
 # Added in 0.155
 # Message shown when toggling town upkeep admin setting
 msg_town_upkeep_setting_set_to: 'The town %s has had their upkeep setting set to %s.'
-# Message shown when toggling nation upkeep admin setting
-msg_nation_upkeep_setting_set_to: 'The nation %s has had their upkeep setting set to %s.'

--- a/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -152,7 +152,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		"forcemerge"
 	);
 	private static final List<String> adminTownToggleTabCompletes = Stream.concat(TownCommand.townToggleTabCompletes.stream(),
-			Arrays.asList("forcepvp", "unlimitedclaims").stream()).collect(Collectors.toList()); 
+			Arrays.asList("forcepvp", "unlimitedclaims", "upkeep").stream()).collect(Collectors.toList()); 
 
 	private static final List<String> adminNationTabCompletes = Arrays.asList(
 		"add",
@@ -1333,6 +1333,11 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 					town.setHasUnlimitedClaims(choice.orElse(!town.hasUnlimitedClaims()));
 					town.save();
 					TownyMessaging.sendMsg(sender, Translatable.of("msg_town_unlimitedclaims_setting_set_to", town.getName(), town.hasUnlimitedClaims()));
+				} else if (split[2].equalsIgnoreCase("upkeep")) {
+					
+					town.setHasUpkeep(!town.hasUpkeep());
+					town.save();
+					TownyMessaging.sendMsg(sender, Translatable.of("msg_town_upkeep_setting_set_to", town.getName(), town.hasUpkeep()));
 				} else
 					TownCommand.townToggle(sender, StringMgmt.remArgs(split, 2), true, town);
 				

--- a/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -1335,7 +1335,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 					TownyMessaging.sendMsg(sender, Translatable.of("msg_town_unlimitedclaims_setting_set_to", town.getName(), town.hasUnlimitedClaims()));
 				} else if (split[2].equalsIgnoreCase("upkeep")) {
 					
-					town.setHasUpkeep(!town.hasUpkeep());
+					town.setHasUpkeep(choice.orElse(!town.hasUpkeep()));
 					town.save();
 					TownyMessaging.sendMsg(sender, Translatable.of("msg_town_upkeep_setting_set_to", town.getName(), town.hasUpkeep()));
 				} else


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Towns can overwrite the upkeep setting of the config, but this setting wasn't modifyable per town by admins. This pull request adds a new admin town command toggle for upkeep.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
`/ta town <town> toggle upkeep`

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
