### PR TITLE
Allow spaces to be used in town/nation rename commands

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -2154,7 +2154,11 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 			TownyMessaging.sendErrorMsg(sender, "Eg: /nation set name Plutoria");				
 		else {
 			
-			String name = split[1];
+			String name;
+			if (split.length == 2)
+				name = split[1];
+			else
+				name = String.join("_", Arrays.copyOfRange(split, 1, split.length));
 			
 			if (NameValidation.isBlacklistName(name) || TownyUniverse.getInstance().hasNation(name) || (!TownySettings.areNumbersAllowedInNationNames() && NameValidation.containsNumbers(name)))
 				throw new TownyException(Translatable.of("msg_invalid_name"));

--- a/src/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -2154,11 +2154,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 			TownyMessaging.sendErrorMsg(sender, "Eg: /nation set name Plutoria");				
 		else {
 			
-			String name;
-			if (split.length == 2)
-				name = split[1];
-			else
-				name = String.join("_", Arrays.copyOfRange(split, 1, split.length));
+			String name = String.join("_", StringMgmt.remFirstArg(split));
 			
 			if (NameValidation.isBlacklistName(name) || TownyUniverse.getInstance().hasNation(name) || (!TownySettings.areNumbersAllowedInNationNames() && NameValidation.containsNumbers(name)))
 				throw new TownyException(Translatable.of("msg_invalid_name"));

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -2388,11 +2388,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 						return;
 					}
 
-					String name;
-					if (split.length == 2)
-						name = split[1];
-					else
-						name = String.join("_", Arrays.copyOfRange(split, 1, split.length));
+					String name = String.join("_", StringMgmt.remFirstArg(split));
 					
 					if (NameValidation.isBlacklistName(name) || TownyUniverse.getInstance().hasTown(name) || (!TownySettings.areNumbersAllowedInTownNames() && NameValidation.containsNumbers(name)))
 						throw new TownyException(Translatable.of("msg_invalid_name"));

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -2388,7 +2388,11 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 						return;
 					}
 
-					String name = split[1];
+					String name;
+					if (split.length == 2)
+						name = split[1];
+					else
+						name = String.join("_", Arrays.copyOfRange(split, 1, split.length));
 					
 					if (NameValidation.isBlacklistName(name) || TownyUniverse.getInstance().hasTown(name) || (!TownySettings.areNumbersAllowedInTownNames() && NameValidation.containsNumbers(name)))
 						throw new TownyException(Translatable.of("msg_invalid_name"));

--- a/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -1284,11 +1284,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 
 			} else if (split[1].equalsIgnoreCase("rename")) {
 				
-				String name;
-				if (split.length == 3)
-					name = split[2];
-				else
-					name = String.join("_", Arrays.copyOfRange(split, 2, split.length));
+				String name = String.join("_", StringMgmt.remArgs(split, 2));
 				
 				TownPreRenameEvent event = new TownPreRenameEvent(town, name);
 				Bukkit.getServer().getPluginManager().callEvent(event);
@@ -1627,11 +1623,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 
 			} else if (split[1].equalsIgnoreCase("rename")) {
 
-				String name;
-				if (split.length == 3)
-					name = split[2];
-				else
-					name = String.join("_", Arrays.copyOfRange(split, 2, split.length));
+				String name = String.join("_", StringMgmt.remArgs(split, 2));
 
 				NationPreRenameEvent event = new NationPreRenameEvent(nation, name);
 				Bukkit.getServer().getPluginManager().callEvent(event);

--- a/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -1284,15 +1284,21 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 
 			} else if (split[1].equalsIgnoreCase("rename")) {
 				
-				TownPreRenameEvent event = new TownPreRenameEvent(town, split[2]);
+				String name;
+				if (split.length == 3)
+					name = split[2];
+				else
+					name = String.join("_", Arrays.copyOfRange(split, 2, split.length));
+				
+				TownPreRenameEvent event = new TownPreRenameEvent(town, name);
 				Bukkit.getServer().getPluginManager().callEvent(event);
 				if (event.isCancelled()) {
 					TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_rename_cancelled"));
 					return;
 				}
 
-				if (!NameValidation.isBlacklistName(split[2]) && (TownySettings.areNumbersAllowedInTownNames() || !NameValidation.containsNumbers(split[2]))) {
-					townyUniverse.getDataSource().renameTown(town, split[2]);
+				if (!NameValidation.isBlacklistName(name) && (TownySettings.areNumbersAllowedInTownNames() || !NameValidation.containsNumbers(name))) {
+					townyUniverse.getDataSource().renameTown(town, name);
 					TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_town_set_name", ((getSender() instanceof Player) ? player.getName() : "CONSOLE"), town.getName()));
 					TownyMessaging.sendMsg(getSender(), Translatable.of("msg_town_set_name", ((getSender() instanceof Player) ? player.getName() : "CONSOLE"), town.getName()));
 				} else {
@@ -1621,16 +1627,23 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 
 			} else if (split[1].equalsIgnoreCase("rename")) {
 
-				NationPreRenameEvent event = new NationPreRenameEvent(nation, split[2]);
+				String name;
+				if (split.length == 3)
+					name = split[2];
+				else
+					name = String.join("_", Arrays.copyOfRange(split, 2, split.length));
+
+				NationPreRenameEvent event = new NationPreRenameEvent(nation, name);
 				Bukkit.getServer().getPluginManager().callEvent(event);
 				if (event.isCancelled()) {
 					TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_rename_cancelled"));
 					return;
 				}
 				
-				if (!NameValidation.isBlacklistName(split[2]) && (TownySettings.areNumbersAllowedInNationNames() || !NameValidation.containsNumbers(split[2]))) {
-					townyUniverse.getDataSource().renameNation(nation, split[2]);
+				if (!NameValidation.isBlacklistName(name) && (TownySettings.areNumbersAllowedInNationNames() || !NameValidation.containsNumbers(name))) {
+					townyUniverse.getDataSource().renameNation(nation, name);
 					TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_nation_set_name", ((getSender() instanceof Player) ? player.getName() : "CONSOLE"), nation.getName()));
+					TownyMessaging.sendMsg(getSender(), Translatable.of("msg_nation_set_name", ((getSender() instanceof Player) ? player.getName() : "CONSOLE"), nation.getName()));
 				} else
 					TownyMessaging.sendErrorMsg(getSender(), Translatable.of("msg_invalid_name"));
 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Allows spaces to be used in the town/nation rename commands, similar to how spaces are parsed in town/nation new commands.

Previous:
/t set name My Town -> town renamed to My
New:
/t set name My Town -> town renamed to My_Town
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
