### PR TITLE
Add option to disallow numbers in town/nation names

### DIFF
--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -941,6 +941,13 @@ public enum ConfigNodes {
 			"# When enabled, town (and nation) names will automatically be capitalised upon creation."
 	),
 	
+	GTOWN_SETTINGS_ALLOW_NUMBERS_IN_TOWN_NAME(
+			"global_town_settings.allow_numbers_in_town_name",
+			"true",
+			"",
+			"# When disabled, towns will not be able to be created with or renamed to a name that contains numbers.",
+			"# Disabling this option does not affect already created towns."),
+	
 	GTOWN_SETTINGS_ALLOWED_TOWN_COLORS(
 			"global_town_settings.allowed_map_colors",
 			"aqua:00ffff, azure:f0ffff, beige:f5f5dc, black:000000, blue:0000ff, brown:a52a2a, cyan:00ffff, darkblue:00008b, darkcyan:008b8b, darkgrey:a9a9a9, darkgreen:006400, darkkhaki:bdb76b, darkmagenta:8b008b, darkolivegreen:556b2f, darkorange:ff8c00, darkorchid:9932cc, darkred:8b0000, darksalmon:e9967a, darkviolet:9400d3, fuchsia:ff00ff, gold:ffd700, green:008000, indigo:4b0082, khaki:f0e68c, lightblue:add8e6, lightcyan:e0ffff, lightgreen:90ee90, lightgrey:d3d3d3, lightpink:ffb6c1, lightyellow:ffffe0, lime:00ff00, magenta:ff00ff, maroon:800000, navy:000080, olive:808000, orange:ffa500, pink:ffc0cb, purple:800080, violet:800080, red:ff0000, silver:c0c0c0, white:ffffff, yellow:ffff00",
@@ -1055,6 +1062,13 @@ public enum ConfigNodes {
 			"-1",
 			"",
 			"# The maximum amount of allies that a nation can have, set to -1 to have no limit."),
+
+	GNATION_SETTINGS_ALLOW_NUMBERS_IN_NATION_NAME(
+		"global_nation_settings.allow_numbers_in_nation_name",
+		"true",
+		"",
+		"# When disabled, nations will not be able to be created with or renamed to a name that contains numbers.",
+		"# Disabling this option does not affect already created nations."),
 
 	PLUGIN(
 			"plugin",

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -3206,5 +3206,13 @@ public class TownySettings {
 	public static String getNotificationsAppearAs() {
 		return getString(ConfigNodes.NOTIFICATION_NOTIFICATIONS_APPEAR_AS);
 	}
+	
+	public static boolean areNumbersAllowedInTownNames() {
+		return getBoolean(ConfigNodes.GTOWN_SETTINGS_ALLOW_NUMBERS_IN_TOWN_NAME);
+	}
+	
+	public static boolean areNumbersAllowedInNationNames() {
+		return getBoolean(ConfigNodes.GNATION_SETTINGS_ALLOW_NUMBERS_IN_NATION_NAME);
+	}
 }
 

--- a/src/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -979,7 +979,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 				filteredName = null;
 			}
 
-			if ((filteredName == null) || TownyUniverse.getInstance().hasNation(filteredName))
+			if (filteredName == null || TownyUniverse.getInstance().hasNation(filteredName) || (!TownySettings.areNumbersAllowedInNationNames() && NameValidation.containsNumbers(filteredName)))
 				throw new TownyException(Translatable.of("msg_err_invalid_name", filteredName));
 
 			PreNewNationEvent preEvent = new PreNewNationEvent(capitalTown, filteredName);
@@ -2156,8 +2156,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 			
 			String name = split[1];
 			
-			if (NameValidation.isBlacklistName(name)
-				|| TownyUniverse.getInstance().hasNation(name))
+			if (NameValidation.isBlacklistName(name) || TownyUniverse.getInstance().hasNation(name) || (!TownySettings.areNumbersAllowedInNationNames() && NameValidation.containsNumbers(name)))
 				throw new TownyException(Translatable.of("msg_invalid_name"));
 			
 			if (TownySettings.getTownAutomaticCapitalisationEnabled())

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -2794,7 +2794,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 				filteredName = null;
 			}
 
-			if ((filteredName == null) || TownyUniverse.getInstance().hasTown(filteredName) || (!TownySettings.areNumbersAllowedInTownNames() && NameValidation.containsNumbers(filteredName)))
+			if (filteredName == null || TownyUniverse.getInstance().hasTown(filteredName) || (!TownySettings.areNumbersAllowedInTownNames() && NameValidation.containsNumbers(filteredName)))
 				throw new TownyException(Translatable.of("msg_err_invalid_name", name));
 			
 			name = filteredName;

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -2390,8 +2390,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 
 					String name = split[1];
 					
-					if (NameValidation.isBlacklistName(name) 
-						|| TownyUniverse.getInstance().hasTown(name))
+					if (NameValidation.isBlacklistName(name) || TownyUniverse.getInstance().hasTown(name) || (!TownySettings.areNumbersAllowedInTownNames() && NameValidation.containsNumbers(name)))
 						throw new TownyException(Translatable.of("msg_invalid_name"));
 
         			if (TownySettings.getTownAutomaticCapitalisationEnabled())
@@ -2795,7 +2794,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 				filteredName = null;
 			}
 
-			if ((filteredName == null) || TownyUniverse.getInstance().hasTown(filteredName))
+			if ((filteredName == null) || TownyUniverse.getInstance().hasTown(filteredName) || (!TownySettings.areNumbersAllowedInTownNames() && NameValidation.containsNumbers(filteredName)))
 				throw new TownyException(Translatable.of("msg_err_invalid_name", name));
 			
 			name = filteredName;

--- a/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -1291,7 +1291,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 					return;
 				}
 
-				if (!NameValidation.isBlacklistName(split[2])) {
+				if (!NameValidation.isBlacklistName(split[2]) && (TownySettings.areNumbersAllowedInTownNames() || !NameValidation.containsNumbers(split[2]))) {
 					townyUniverse.getDataSource().renameTown(town, split[2]);
 					TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_town_set_name", ((getSender() instanceof Player) ? player.getName() : "CONSOLE"), town.getName()));
 					TownyMessaging.sendMsg(getSender(), Translatable.of("msg_town_set_name", ((getSender() instanceof Player) ? player.getName() : "CONSOLE"), town.getName()));
@@ -1628,7 +1628,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 					return;
 				}
 				
-				if (!NameValidation.isBlacklistName(split[2])) {
+				if (!NameValidation.isBlacklistName(split[2]) && (TownySettings.areNumbersAllowedInNationNames() || !NameValidation.containsNumbers(split[2]))) {
 					townyUniverse.getDataSource().renameNation(nation, split[2]);
 					TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_nation_set_name", ((getSender() instanceof Player) ? player.getName() : "CONSOLE"), nation.getName()));
 				} else

--- a/src/com/palmergames/bukkit/util/NameValidation.java
+++ b/src/com/palmergames/bukkit/util/NameValidation.java
@@ -17,7 +17,8 @@ public class NameValidation {
 
 	private static Pattern namePattern = null;
 	private static Pattern stringPattern = null;
-	private static Collection<String> bannedNames;
+	private static final Collection<String> bannedNames;
+	private static final Pattern numberPattern = Pattern.compile("\\d");
 	
 	static {
 		bannedNames = new HashSet<>(
@@ -174,5 +175,9 @@ public class NameValidation {
 	
 	public static String filterCommas(String input) {
 		return input.replace(",", "_");
+	}
+	
+	public static boolean containsNumbers(String input) {
+		return numberPattern.matcher(input).find();
 	}
 }


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
Adds 2 new config options: global_town_settings.allow_numbers_in_town_name & global_nation_settings.allow_numbers_in_nation_name

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #5954 

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
