### PR TITLE
Fix plot info command not being usable in wilderness

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/PlotCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/PlotCommand.java
@@ -281,7 +281,7 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 			try {
 				
 				TownBlock townBlock = TownyAPI.getInstance().getTownBlock(player);
-				if (townBlock == null && !split[0].equalsIgnoreCase("perm") && !split[0].equalsIgnoreCase("claim"))
+				if (townBlock == null && !split[0].equalsIgnoreCase("perm") && !split[0].equalsIgnoreCase("claim") && !"info".equalsIgnoreCase(split[0]))
 					throw new TownyException(Translatable.of("msg_not_claimed_1"));
 				
 				if (!TownyAPI.getInstance().isWilderness(player.getLocation()) && townBlock.getTownOrNull().isRuined())
@@ -2215,12 +2215,10 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 	
 	public void sendPlotInfo(Player player, String[] args) {
 		WorldCoord coord = WorldCoord.parseWorldCoord(player);
-		String world = player.getWorld().getName();
 
 		try {
-			coord = new WorldCoord(world, Integer.parseInt(args[0]), Integer.parseInt(args[1]));
-		} catch (NumberFormatException | ArrayIndexOutOfBoundsException ignored) {
-		}
+			coord = new WorldCoord(player.getWorld().getName(), Integer.parseInt(args[0]), Integer.parseInt(args[1]));
+		} catch (NumberFormatException | ArrayIndexOutOfBoundsException ignored) {}
 
 		if (TownyAPI.getInstance().isWilderness(coord))
 			TownyMessaging.sendStatusScreen(player, TownyFormatter.getStatus(coord.getTownyWorldOrNull(), player));


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Fixes the /plot info command (used by the ascii map) not being usable while standing in an unclaimed area.

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
