### PR TITLE
Stop removing title/surname when nation is deleted

### DIFF
--- a/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
@@ -647,10 +647,6 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 		for (Town town : toSave) {
 
 			for (Resident res : town.getResidents()) {
-				if (res.hasTitle() || res.hasSurname()) {
-					res.setTitle("");
-					res.setSurname("");
-				}
 				res.updatePermsForNationRemoval();
 				res.save();
 			}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Due to towns being able to set titles/surnames, it no longer makes sense to clear a resident's titles/surnames when a nation is removed.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
N/A

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
N/A

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
