### PR TITLE
Add option to use a timer for new day scheduling.

### DIFF
--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1173,11 +1173,11 @@ public enum ConfigNodes {
 			"# The time each \"day\", when taxes will be collected.",
 			"# Only used when less than day_interval. Default is 12h (midday).",
 			"# If day_interval is set to something like 20m, the new_day_time is not used, day_interval will be used instead."),
-	PLUGIN_NEWDAY_USES_TIMER(
-			"plugin.day_timer.uses_timer",
+	PLUGIN_NEWDAY_USES_JAVA_TIMER(
+			"plugin.day_timer.uses_java_timer",
 			"false",
 			"",
-			"# If enabled (disabled by default), a timer will be used for scheduling new days, which is more accurate but uses an extra thread."),
+			"# If enabled (disabled by default), a Java Timer will be used for scheduling new days, which is more accurate than Towny's Bukkit timer task but uses an extra thread."),
 	PLUGIN_NEWDAY_DELETE_0_PLOT_TOWNS(
 			"plugin.day_timer.delete_0_plot_towns",
 			"false",

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1173,6 +1173,11 @@ public enum ConfigNodes {
 			"# The time each \"day\", when taxes will be collected.",
 			"# Only used when less than day_interval. Default is 12h (midday).",
 			"# If day_interval is set to something like 20m, the new_day_time is not used, day_interval will be used instead."),
+	PLUGIN_NEWDAY_USES_TIMER(
+			"plugin.day_timer.uses_timer",
+			"false",
+			"",
+			"# If enabled (disabled by default), a timer will be used for scheduling new days, which is more accurate but uses an extra thread."),
 	PLUGIN_NEWDAY_DELETE_0_PLOT_TOWNS(
 			"plugin.day_timer.delete_0_plot_towns",
 			"false",

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -3288,7 +3288,7 @@ public class TownySettings {
 	}
 	
 	public static boolean doesNewDayUseTimer() {
-		return getBoolean(ConfigNodes.PLUGIN_NEWDAY_USES_TIMER);
+		return getBoolean(ConfigNodes.PLUGIN_NEWDAY_USES_JAVA_TIMER);
 	}
 }
 

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -3286,5 +3286,9 @@ public class TownySettings {
 	public static void removeReloadListener(NamespacedKey key) {
 		CONFIG_RELOAD_LISTENERS.remove(key);
 	}
+	
+	public static boolean doesNewDayUseTimer() {
+		return getBoolean(ConfigNodes.PLUGIN_NEWDAY_USES_TIMER);
+	}
 }
 

--- a/src/com/palmergames/bukkit/towny/tasks/NewDayScheduler.java
+++ b/src/com/palmergames/bukkit/towny/tasks/NewDayScheduler.java
@@ -5,10 +5,12 @@ import org.bukkit.Bukkit;
 import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.TownySettings;
-import com.palmergames.bukkit.util.BukkitTools;
 import com.palmergames.util.TimeMgmt;
-import com.palmergames.util.TimeTools;
 import org.jetbrains.annotations.ApiStatus;
+
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.TimeUnit;
 
 public class NewDayScheduler extends TownyTimerTask {
 
@@ -16,27 +18,42 @@ public class NewDayScheduler extends TownyTimerTask {
 		super(plugin);
 	}
 
+	private static Timer newDayTimer;
 	private static int scheduleTask = -1;
 	private static int newDayTask = -1;
 	
 	@Override
 	public void run() {
-		long secondsUntilNextNewDay = TimeMgmt.townyTime();
-		plugin.getLogger().info("Time until a New Day: " + TimeMgmt.formatCountdownTime(secondsUntilNextNewDay));
-
-		// If the next new day is less than 2 minutes away, schedule the new day.
-		if (secondsUntilNextNewDay < TimeTools.secondsFromDhms("2m")) {
-			TownyMessaging.sendDebugMsg("New Day time finalized for: " + TimeMgmt.formatCountdownTime(secondsUntilNextNewDay) + " from now.");
-			scheduleUpComingNewDay(secondsUntilNextNewDay);
-		// Else the new day scheduler will run again at half the secondsUntilNextNewDay, to check again.
+		logTime();
+		cancelScheduledNewDay();
+		
+		if (!TownySettings.doesNewDayUseTimer()) {
+			long secondsUntilNextNewDay = TimeMgmt.townyTime();
+			
+			// If the next new day is less than 2 minutes away, schedule the new day.
+			if (secondsUntilNextNewDay < TimeUnit.MINUTES.toSeconds(2)) {
+				TownyMessaging.sendDebugMsg("New Day time finalized for: " + TimeMgmt.formatCountdownTime(secondsUntilNextNewDay) + " from now.");
+				scheduleUpComingNewDay(secondsUntilNextNewDay);
+				// Else the new day scheduler will run again at half the secondsUntilNextNewDay, to check again.
+			} else {
+				scheduleTask = Bukkit.getScheduler().runTaskLaterAsynchronously(plugin, new NewDayScheduler(plugin), (secondsUntilNextNewDay / 2) * 20).getTaskId();
+				TownyMessaging.sendDebugMsg("Re-evaluation of New Day time scheduled for: " + TimeMgmt.formatCountdownTime(secondsUntilNextNewDay / 2) + " from now.");
+			}
 		} else {
-			scheduleTask = Bukkit.getScheduler().runTaskLaterAsynchronously(plugin, new NewDayScheduler(plugin), (secondsUntilNextNewDay / 2) * 20).getTaskId();
-			TownyMessaging.sendDebugMsg("Re-evaluation of New Day time scheduled for: " + TimeMgmt.formatCountdownTime(secondsUntilNextNewDay/2) + " from now.");
+			TownyMessaging.sendDebugMsg("Starting new new day scheduler timer.");
+
+			newDayTimer = new Timer("towny-new-day-scheduler", true);
+			newDayTimer.schedule(new TimerTask() {
+				@Override
+				public void run() {
+					newDay();
+				}
+			}, TimeUnit.SECONDS.toMillis(TimeMgmt.townyTime()), TimeUnit.SECONDS.toMillis(TownySettings.getDayInterval()));
 		}
 	}
 
 	/**
-	 * Schedules the next occurence of the NewDayScheduler.
+	 * Schedules the next occurrence of the NewDayScheduler.
 	 * @param secondsUntilNextNewDay long seconds until the next task.
 	 */
 	private void scheduleUpComingNewDay(long secondsUntilNextNewDay) {
@@ -50,6 +67,9 @@ public class NewDayScheduler extends TownyTimerTask {
 	}
 	
 	public static boolean isNewDaySchedulerRunning() {
+		if (TownySettings.doesNewDayUseTimer())
+			return newDayTimer != null;
+		
 		return Bukkit.getScheduler().isCurrentlyRunning(scheduleTask) || Bukkit.getScheduler().isQueued(scheduleTask);
 	}
 	
@@ -58,6 +78,11 @@ public class NewDayScheduler extends TownyTimerTask {
 	}
 	
 	public static void cancelScheduledNewDay() {
+		if (newDayTimer != null) {
+			newDayTimer.cancel();
+			newDayTimer = null;
+		}
+		
 		if (scheduleTask != -1) {
 			Bukkit.getScheduler().cancelTask(scheduleTask);
 			scheduleTask = -1;
@@ -75,12 +100,16 @@ public class NewDayScheduler extends TownyTimerTask {
 	 */
 	public static void newDay() {
 		if (TownySettings.isEconomyAsync())
-			newDayTask = BukkitTools.scheduleAsyncDelayedTask(new DailyTimerTask(Towny.getPlugin()),0L);
+			newDayTask = Bukkit.getScheduler().runTaskAsynchronously(Towny.getPlugin(), new DailyTimerTask(Towny.getPlugin())).getTaskId();
 		else
-			newDayTask = BukkitTools.scheduleSyncDelayedTask(new DailyTimerTask(Towny.getPlugin()),0L);
+			newDayTask = Bukkit.getScheduler().runTask(Towny.getPlugin(), new DailyTimerTask(Towny.getPlugin())).getTaskId();
 		
 		if (newDayTask == -1)
 			TownyMessaging.sendErrorMsg("Could not run newDay.");
+	}
+	
+	public static void logTime() {
+		Towny.getPlugin().getLogger().info("Time until a New Day: " + TimeMgmt.formatCountdownTime(TimeMgmt.townyTime()));
 	}
 	
 	/**

--- a/src/com/palmergames/bukkit/towny/tasks/NewDayScheduler.java
+++ b/src/com/palmergames/bukkit/towny/tasks/NewDayScheduler.java
@@ -19,9 +19,11 @@ public class NewDayScheduler extends TownyTimerTask {
 		super(plugin);
 	}
 	
+	private static long newDayInterval = -1;
+
 	static {
 		TownySettings.addReloadListener(NamespacedKey.fromString("towny:new-day-scheduler"), config -> {
-			if (TownySettings.doesNewDayUseTimer() && isNewDaySchedulerRunning()) {
+			if (newDayInterval != TownySettings.getDayInterval() && isNewDaySchedulerRunning()) {
 				cancelScheduledNewDay();
 				new NewDayScheduler(Towny.getPlugin()).run();
 			}
@@ -37,6 +39,8 @@ public class NewDayScheduler extends TownyTimerTask {
 		logTime();
 		cancelScheduledNewDay();
 		
+		newDayInterval = TownySettings.getDayInterval();
+
 		if (!TownySettings.doesNewDayUseTimer()) {
 			long secondsUntilNextNewDay = TimeMgmt.townyTime();
 			

--- a/src/com/palmergames/bukkit/towny/tasks/NewDayScheduler.java
+++ b/src/com/palmergames/bukkit/towny/tasks/NewDayScheduler.java
@@ -6,6 +6,7 @@ import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.util.TimeMgmt;
+import org.bukkit.NamespacedKey;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Timer;
@@ -16,6 +17,15 @@ public class NewDayScheduler extends TownyTimerTask {
 
 	public NewDayScheduler(Towny plugin) {
 		super(plugin);
+	}
+	
+	static {
+		TownySettings.addReloadListener(NamespacedKey.fromString("towny:new-day-scheduler"), config -> {
+			if (TownySettings.doesNewDayUseTimer() && isNewDaySchedulerRunning()) {
+				cancelScheduledNewDay();
+				new NewDayScheduler(Towny.getPlugin()).run();
+			}
+		});
 	}
 
 	private static Timer newDayTimer;


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Adds an option to use a timer for new day scheduling instead of using the bukkit scheduler, has the benefit of being guaranteed to be accurate without having to schedule lots of tasks.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
New config option: plugin.day_timer.uses_timer
Default value: false
If enabled (disabled by default), a timer will be used for scheduling new days, which is more accurate but uses an extra thread.

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes https://github.com/EarthMC/Issue-Tracker/issues/1585

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
