### PR TITLE
Make unkickable ranks configurable

### DIFF
--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -961,6 +961,11 @@ public enum ConfigNodes {
 			"# This setting determines the list of allowed town map colors.",
 			"# The color codes are in hex format."
 	),
+	GTOWN_SETTINGS_UNKICKABLE_RANKS(
+			"global_town_settings.unkickable_ranks",
+			"assistant",
+			"",
+			"# List of ranks (separated by a comma) that will prevent a player from being kicked from a town."),
 	
 	GNATION_SETTINGS(
 			"global_nation_settings",

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -3334,5 +3334,9 @@ public class TownySettings {
 	public static boolean doesNewDayUseTimer() {
 		return getBoolean(ConfigNodes.PLUGIN_NEWDAY_USES_JAVA_TIMER);
 	}
+	
+	public static List<String> getTownUnkickableRanks() {
+		return getStrArr(ConfigNodes.GTOWN_SETTINGS_UNKICKABLE_RANKS);
+	}
 }
 

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -3200,7 +3200,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		Resident senderResident = sender instanceof Player player ? TownyAPI.getInstance().getResident(player) : null;
 		
 		for (Resident member : new ArrayList<>(kicking)) {
-			if (!town.getResidents().contains(member)) {
+			if (!town.hasResident(member)) {
 				TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_resident_not_your_town"));
 				kicking.remove(member);
 				continue;
@@ -3212,9 +3212,9 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 				continue;
 			}
 
-			if (!town.hasResident(member) 
-				|| member.isMayor() 
-				|| (senderResident != null && !senderResident.isMayor() && TownySettings.getTownUnkickableRanks().stream().anyMatch(member::hasTownRank))) {
+			// The player being kicked is either the mayor or has an 'unkickable' rank (usually an assistant)
+			// The rank check is bypassed if the sender is either not a player or not in the same town as the player being kicked, for townyadmin purposes
+			if (member.isMayor() || (senderResident != null && !senderResident.isMayor() && town.hasResident(senderResident) && TownySettings.getTownUnkickableRanks().stream().anyMatch(member::hasTownRank))) {
 				TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_you_cannot_kick_this_resident", member));
 				kicking.remove(member);
 				continue;

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -3197,35 +3197,35 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 	 */
 	public static void townKickResidents(CommandSender sender, Resident resident, Town town, List<Resident> kicking) {
 
+		Resident senderResident = sender instanceof Player player ? TownyAPI.getInstance().getResident(player) : null;
+		
 		for (Resident member : new ArrayList<>(kicking)) {
 			if (!town.getResidents().contains(member)) {
 				TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_resident_not_your_town"));
 				kicking.remove(member);
 				continue;
 			}
+
 			if (resident == member) {
 				TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_you_cannot_kick_yourself"));
 				kicking.remove(member);
 				continue;
 			}
-			if (member.isMayor() || town.hasResidentWithRank(member, "assistant")) {
+
+			if (!town.hasResident(member) 
+				|| member.isMayor() 
+				|| (senderResident != null && !senderResident.isMayor() && TownySettings.getTownUnkickableRanks().stream().anyMatch(member::hasTownRank))) {
 				TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_you_cannot_kick_this_resident", member));
 				kicking.remove(member);
 				continue;
-			} else {
-				if (!town.hasResident(member))
-					kicking.remove(member);
-				else {
-					TownKickEvent townKickEvent = new TownKickEvent(member, sender);
-					Bukkit.getPluginManager().callEvent(townKickEvent);
-
-					if (townKickEvent.isCancelled()) {
-						TownyMessaging.sendErrorMsg(sender, townKickEvent.getCancelMessage());
-						kicking.remove(member);
-					} else
-						member.removeTown();
-				}
 			}
+
+			TownKickEvent townKickEvent = new TownKickEvent(member, sender);
+			if (BukkitTools.isEventCancelled(townKickEvent)) {
+				TownyMessaging.sendErrorMsg(sender, townKickEvent.getCancelMessage());
+				kicking.remove(member);
+			} else
+				member.removeTown();
 		}
 		
 		if (kicking.size() > 0) {


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
New config option: global_town_settings.unkickable_ranks
Default value: assistant
List of ranks (separated by a comma) that will prevent a player from being kicked from a town.

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes https://github.com/EarthMC/Issue-Tracker/issues/1523

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
