### PR TITLE
Nation tax percent

### DIFF
--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -321,6 +321,7 @@ permissions:
             towny.command.nation.set.taxes: true
             towny.command.nation.set.title: true
             towny.command.nation.set.mapcolor: true
+            towny.command.nation.set.taxpercentcap: true
 
     towny.command.nation.toggle.*:
         description: User can toggle any available nation setting.

--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -329,6 +329,7 @@ permissions:
             towny.command.nation.toggle.neutral: true
             towny.command.nation.toggle.public: true
             towny.command.nation.toggle.open: true
+            towny.command.nation.toggle.taxpercent: true
 
     # Town command permissions
     towny.command.town.*:

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -297,7 +297,7 @@ public enum ConfigNodes {
 			"# Default amount of tax of a new nation. This must be lower than the economy.daily_taxes.max_nation_tax_amount setting."),
     NATION_DEF_TAXES_TAXPERCENTAGE(
             "nation.default_taxes.taxpercentage",
-            "true",
+            "false",
             "",
             "# Default status of new nation's taxpercentage. True means that the default_tax is treated as a percentage instead of a fixed amount."),
     NATION_DEF_TAXES_MINIMUMTAX(

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -285,7 +285,28 @@ public enum ConfigNodes {
 			"false",
 			"",
 			"# Setting this to true will set a nation's tag automatically using the first four characters of the nation's name."),
-	
+    NATION_DEF_TAXES(
+            "nation.default_taxes", 
+            "",
+            "",
+            "# Default tax settings for new nations."),
+    NATION_DEF_TAXES_TAX(
+			"nation.default_taxes.tax",
+			"0.0",
+			"",
+			"# Default amount of tax of a new nation. This must be lower than the economy.daily_taxes.max_nation_tax_amount setting."),
+    NATION_DEF_TAXES_TAXPERCENTAGE(
+            "nation.default_taxes.taxpercentage",
+            "true",
+            "",
+            "# Default status of new nation's taxpercentage. True means that the default_tax is treated as a percentage instead of a fixed amount."),
+    NATION_DEF_TAXES_MINIMUMTAX(
+			"nation.default_taxes.minimumtax",
+			"0.0",
+			"",
+			"# A required minimum tax amount for the default_tax, will not change any nations which already have a tax set.",
+			"# Do not forget to set the default_tax to more than 0 or new nations will still begin with a tax of zero."),
+
 	NWS(
 			"new_world_settings",
 			"",
@@ -2227,6 +2248,17 @@ public enum ConfigNodes {
 			"",
 			"# The maximum amount of money that can be taken from a balance when using a percent tax, this is the default for all new towns."
 			),
+    ECO_DAILY_TAXES_MAX_NATION_TAX_PERCENT(
+            "economy.daily_taxes.max_nation_tax_percent",
+            "25",
+            "",
+            "# Maximum tax percentage allowed when taxing by percentages for nations."),
+    ECO_DAILY_TAXES_MAX_NATION_TAX_PERCENT_AMOUNT(
+            "economy.daily_taxes.max_nation_tax_percent_amount",
+            "10000",
+            "",
+            "# The maximum amount of money that can be taken from a balance when using a percent tax, this is the default for all new nations."
+            ),
 	ECO_DAILY_TAXES_DO_CAPITALS_PAY_NATION_TAX(
 			"economy.daily_taxes.do_nation_capitals_pay_nation_tax",
 			"false",

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -285,28 +285,25 @@ public enum ConfigNodes {
 			"false",
 			"",
 			"# Setting this to true will set a nation's tag automatically using the first four characters of the nation's name."),
-    NATION_DEF_TAXES(
-            "nation.default_taxes", 
-            "",
-            "",
-            "# Default tax settings for new nations."),
-    NATION_DEF_TAXES_TAX(
-			"nation.default_taxes.tax",
+	NATION_DEF_TAXES("nation.default_taxes",
+			"",
+			"",
+			"# Default tax settings for new nations."),
+	NATION_DEF_TAXES_TAX("nation.default_taxes.tax",
 			"0.0",
 			"",
 			"# Default amount of tax of a new nation. This must be lower than the economy.daily_taxes.max_nation_tax_amount setting."),
-    NATION_DEF_TAXES_TAXPERCENTAGE(
-            "nation.default_taxes.taxpercentage",
-            "false",
-            "",
-            "# Default status of new nation's taxpercentage. True means that the default_tax is treated as a percentage instead of a fixed amount."),
-    NATION_DEF_TAXES_MINIMUMTAX(
+	NATION_DEF_TAXES_TAXPERCENTAGE("nation.default_taxes.taxpercentage",
+			"false",
+			"",
+			"# Default status of new nation's taxpercentage. True means that the default_tax is treated as a percentage instead of a fixed amount."),
+	NATION_DEF_TAXES_MINIMUMTAX(
 			"nation.default_taxes.minimumtax",
 			"0.0",
 			"",
 			"# A required minimum tax amount for the default_tax, will not change any nations which already have a tax set.",
 			"# Do not forget to set the default_tax to more than 0 or new nations will still begin with a tax of zero."),
-
+	
 	NWS(
 			"new_world_settings",
 			"",
@@ -2248,17 +2245,16 @@ public enum ConfigNodes {
 			"",
 			"# The maximum amount of money that can be taken from a balance when using a percent tax, this is the default for all new towns."
 			),
-    ECO_DAILY_TAXES_MAX_NATION_TAX_PERCENT(
-            "economy.daily_taxes.max_nation_tax_percent",
-            "25",
-            "",
-            "# Maximum tax percentage allowed when taxing by percentages for nations."),
-    ECO_DAILY_TAXES_MAX_NATION_TAX_PERCENT_AMOUNT(
-            "economy.daily_taxes.max_nation_tax_percent_amount",
-            "10000",
-            "",
-            "# The maximum amount of money that can be taken from a balance when using a percent tax, this is the default for all new nations."
-            ),
+	ECO_DAILY_TAXES_MAX_NATION_TAX_PERCENT(
+			"economy.daily_taxes.max_nation_tax_percent",
+			"25",
+			"",
+			"# Maximum tax percentage allowed when taxing by percentages for nations."),
+	ECO_DAILY_TAXES_MAX_NATION_TAX_PERCENT_AMOUNT(
+			"economy.daily_taxes.max_nation_tax_percent_amount",
+			"10000",
+			"",
+			"# The maximum amount of money that can be taken from a balance when using a percent tax, this is the default for all new nations."),
 	ECO_DAILY_TAXES_DO_CAPITALS_PAY_NATION_TAX(
 			"economy.daily_taxes.do_nation_capitals_pay_nation_tax",
 			"false",

--- a/src/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/src/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -809,7 +809,7 @@ public class TownyFormatter {
 			if (nation.isNeutral() && TownySettings.getNationNeutralityCost() > 0)
 				screen.addComponentOf("neutralityCost", translator.of("status_splitter") + colourKey(translator.of("status_neutrality_cost") + " " + colourKeyImportant(formatMoney(TownySettings.getNationNeutralityCost()))));
 
-			screen.addComponentOf("nationtax", translator.of("status_splitter") + colourKey(translator.of("status_nation_tax")) + " " + colourKeyImportant(formatMoney(nation.getTaxes())));
+			screen.addComponentOf("nationtax", translator.of("status_splitter") + colourKey(translator.of("status_nation_tax")) + " " + colourKeyImportant(nation.isTaxPercentage() ? nation.getTaxes() + "%" : formatMoney(nation.getTaxes())));
 		}
 	}
 

--- a/src/com/palmergames/bukkit/towny/TownyPlaceholderExpansion.java
+++ b/src/com/palmergames/bukkit/towny/TownyPlaceholderExpansion.java
@@ -175,6 +175,7 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 		String rank = "";
 		String hex = "";
 		Double cost = 0.0;
+        boolean percentage = false;
 
 		switch (identifier) {
 		case "town": // %townyadvanced_town%
@@ -444,7 +445,6 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 				: TownySettings.getNationLevel(1).upkeepModifier();
 			return cost == 1.0 ? "0" : String.valueOf(dFormat.format((1.0 - cost) * 100));
 		case "daily_town_tax": // %townyadvanced_daily_town_tax%
-			boolean percentage = false;
 			if (resident.hasTown()) {
 				cost = resident.getTownOrNull().getTaxes();
 				percentage = resident.getTownOrNull().isTaxPercentage();
@@ -453,8 +453,9 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 		case "daily_nation_tax": // %townyadvanced_daily_nation_tax%
 			if (resident.hasNation()) {
 				cost = resident.getNationOrNull().getTaxes();
+                percentage = resident.getNationOrNull().isTaxPercentage();
 			}
-			return String.valueOf(cost);
+			return String.valueOf(cost) + (percentage ? "%" : "");
 		case "town_creation_cost": // %townyadvanced_town_creation_cost%
 			return String.valueOf(TownySettings.getNewTownPrice());
 		case "nation_creation_cost": // %townyadvanced_nation_creation_cost%

--- a/src/com/palmergames/bukkit/towny/TownyPlaceholderExpansion.java
+++ b/src/com/palmergames/bukkit/towny/TownyPlaceholderExpansion.java
@@ -175,7 +175,7 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 		String rank = "";
 		String hex = "";
 		Double cost = 0.0;
-        boolean percentage = false;
+		boolean percentage = false;
 
 		switch (identifier) {
 		case "town": // %townyadvanced_town%
@@ -453,7 +453,7 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 		case "daily_nation_tax": // %townyadvanced_daily_nation_tax%
 			if (resident.hasNation()) {
 				cost = resident.getNationOrNull().getTaxes();
-                percentage = resident.getNationOrNull().isTaxPercentage();
+				percentage = resident.getNationOrNull().isTaxPercentage();
 			}
 			return String.valueOf(cost) + (percentage ? "%" : "");
 		case "town_creation_cost": // %townyadvanced_town_creation_cost%

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -1715,7 +1715,6 @@ public class TownySettings {
 	}
 	
 	public static double getMaxTownTaxPercentAmount() { 
-        
         return getDouble(ConfigNodes.ECO_DAILY_TAXES_MAX_TOWN_TAX_PERCENT_AMOUNT); 
 	}
     

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -1715,18 +1715,19 @@ public class TownySettings {
 	}
 	
 	public static double getMaxTownTaxPercentAmount() { 
-        return getDouble(ConfigNodes.ECO_DAILY_TAXES_MAX_TOWN_TAX_PERCENT_AMOUNT); 
+		
+		return getDouble(ConfigNodes.ECO_DAILY_TAXES_MAX_TOWN_TAX_PERCENT_AMOUNT); 
 	}
-    
-    public static double getMaxNationTaxPercentAmount() { 
-        
-        return getDouble(ConfigNodes.ECO_DAILY_TAXES_MAX_NATION_TAX_PERCENT_AMOUNT); 
-    }
 
-    public static double getMaxNationTaxPercent() {
-        
-        return getDouble(ConfigNodes.ECO_DAILY_TAXES_MAX_NATION_TAX_PERCENT);
-    }
+	public static double getMaxNationTaxPercentAmount() {
+
+		return getDouble(ConfigNodes.ECO_DAILY_TAXES_MAX_NATION_TAX_PERCENT_AMOUNT);
+	}
+
+	public static double getMaxNationTaxPercent() {
+
+		return getDouble(ConfigNodes.ECO_DAILY_TAXES_MAX_NATION_TAX_PERCENT);
+	}
 	
 	public static boolean isBackingUpDaily() {
 
@@ -2072,18 +2073,18 @@ public class TownySettings {
 		return getString(ConfigNodes.NATION_DEF_BOARD);
 	}
 
-    public static double getNationDefaultTax() {
+	public static double getNationDefaultTax() {
 
 		return getDouble(ConfigNodes.NATION_DEF_TAXES_TAX);
 	}
 
-    public static boolean getNationDefaultTaxPercentage() {
+	public static boolean getNationDefaultTaxPercentage() {
 
 		return getBoolean(ConfigNodes.NATION_DEF_TAXES_TAXPERCENTAGE);
 	}
 
-    public static double getNationDefaultTaxMinimumTax() {
-		
+	public static double getNationDefaultTaxMinimumTax() {
+
 		return getDouble(ConfigNodes.NATION_DEF_TAXES_MINIMUMTAX);
 	}
 

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -1715,9 +1715,19 @@ public class TownySettings {
 	}
 	
 	public static double getMaxTownTaxPercentAmount() { 
-		
-		return getDouble(ConfigNodes.ECO_DAILY_TAXES_MAX_TOWN_TAX_PERCENT_AMOUNT); 
+        
+        return getDouble(ConfigNodes.ECO_DAILY_TAXES_MAX_TOWN_TAX_PERCENT_AMOUNT); 
 	}
+    
+    public static double getMaxNationTaxPercentAmount() { 
+        
+        return getDouble(ConfigNodes.ECO_DAILY_TAXES_MAX_NATION_TAX_PERCENT_AMOUNT); 
+    }
+
+    public static double getMaxNationTaxPercent() {
+        
+        return getDouble(ConfigNodes.ECO_DAILY_TAXES_MAX_NATION_TAX_PERCENT);
+    }
 	
 	public static boolean isBackingUpDaily() {
 
@@ -2061,6 +2071,21 @@ public class TownySettings {
 	public static String getNationDefaultBoard(){
 
 		return getString(ConfigNodes.NATION_DEF_BOARD);
+	}
+
+    public static double getNationDefaultTax() {
+
+		return getDouble(ConfigNodes.NATION_DEF_TAXES_TAX);
+	}
+
+    public static boolean getNationDefaultTaxPercentage() {
+
+		return getBoolean(ConfigNodes.NATION_DEF_TAXES_TAXPERCENTAGE);
+	}
+
+    public static double getNationDefaultTaxMinimumTax() {
+		
+		return getDouble(ConfigNodes.NATION_DEF_TAXES_MINIMUMTAX);
 	}
 
 	public static String getFlatFileBackupType() {

--- a/src/com/palmergames/bukkit/towny/command/HelpMenu.java
+++ b/src/com/palmergames/bukkit/towny/command/HelpMenu.java
@@ -837,7 +837,7 @@ public enum HelpMenu {
 				.add("", "/nation toggle", "peaceful/neutral", "")
 				.add("", "/nation toggle", "public", "")
 				.add("", "/nation toggle", "open", "")
-                .add("", "/nation toggle", "taxpercent", "");
+				.add("", "/nation toggle", "taxpercent", "");
 		}
 	}, 
 	

--- a/src/com/palmergames/bukkit/towny/command/HelpMenu.java
+++ b/src/com/palmergames/bukkit/towny/command/HelpMenu.java
@@ -836,7 +836,8 @@ public enum HelpMenu {
 			return new MenuBuilder("nation toggle")
 				.add("", "/nation toggle", "peaceful/neutral", "")
 				.add("", "/nation toggle", "public", "")
-				.add("", "/nation toggle", "open", "");
+				.add("", "/nation toggle", "open", "")
+                .add("", "/nation toggle", "taxpercent", "");
 		}
 	}, 
 	

--- a/src/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -142,7 +142,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 		"surname",
 		"tag",
 		"mapcolor",
-        "taxpercentcap"
+		"taxpercentcap"
 	);
 	
 	private static final List<String> nationListTabCompletes = Arrays.asList(
@@ -163,7 +163,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 		"peaceful",
 		"public",
 		"open",
-        "taxpercent"
+		"taxpercent"
 	);
 	
 	private static final List<String> nationEnemyTabCompletes = Arrays.asList(
@@ -1913,10 +1913,10 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 			checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_NATION_SET_TAXES.getNode());
 			nationSetTaxes(sender, nation, split, admin);
 			break;
-        case "taxpercentcap":
-            checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_NATION_SET_TAXPERCENTCAP.getNode());
-            nationSetTaxPercent(sender, split, nation);
-            break;
+		case "taxpercentcap":
+			checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_NATION_SET_TAXPERCENTCAP.getNode());
+			nationSetTaxPercentCap(sender, split, nation);
+			break;
 		case "spawncost":
 			checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_NATION_SET_SPAWNCOST.getNode());
 			nationSetSpawnCost(sender, nation, split, admin);
@@ -2146,31 +2146,26 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 
 	private static void nationSetTaxes(CommandSender sender, Nation nation, String[] split, boolean admin) throws TownyException {
 		if (split.length < 2)
-            throw new TownyException("Eg: /nation set taxes 70");
-        try {
-			Double amount = Double.parseDouble(split[1]);
-			if (amount < 0)
-				throw new TownyException(Translatable.of("msg_err_negative_money"));
-			if (nation.isTaxPercentage() && amount > 100)
-				throw new TownyException(Translatable.of("msg_err_not_percentage"));
-			if (TownySettings.getNationDefaultTaxMinimumTax() > amount)
-				throw new TownyException(Translatable.of("msg_err_tax_minimum_not_met", TownySettings.getNationDefaultTaxMinimumTax()));
-			nation.setTaxes(amount);
-			if (admin) TownyMessaging.sendMsg(sender, Translatable.of("msg_town_set_nation_tax", sender.getName(), nation.getTaxes()));
-			TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_town_set_nation_tax", sender.getName(), nation.getTaxes()));
-		} catch (NumberFormatException e) {
-			throw new TownyException(Translatable.of("msg_error_must_be_num"));
-		}
+			throw new TownyException("Eg: /nation set taxes 70");
+		int amount = MathUtil.getPositiveIntOrThrow(split[1].trim());
+		if (nation.isTaxPercentage() && amount > 100)
+			throw new TownyException(Translatable.of("msg_err_not_percentage"));
+		if (TownySettings.getNationDefaultTaxMinimumTax() > amount)
+			throw new TownyException(Translatable.of("msg_err_tax_minimum_not_met", TownySettings.getNationDefaultTaxMinimumTax()));
+		nation.setTaxes(amount);
+		if (admin) 
+			TownyMessaging.sendMsg(sender, Translatable.of("msg_town_set_nation_tax", sender.getName(), nation.getTaxes()));
+		TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_town_set_nation_tax", sender.getName(), nation.getTaxes()));
 	}
 
-    public static void nationSetTaxPercent(CommandSender sender, String[] split, Nation nation) throws TownyException {
+	public static void nationSetTaxPercentCap(CommandSender sender, String[] split, Nation nation) throws TownyException {
 		if (!nation.isTaxPercentage())
 			throw new TownyException(Translatable.of("msg_max_tax_amount_only_for_percent"));
 
 		if (split.length < 2) 
 			throw new TownyException("Eg. /nation set taxpercentcap 10000");
 
-		nation.setMaxPercentTaxAmount(Double.parseDouble(split[1]));
+		nation.setMaxPercentTaxAmount(MathUtil.getPositiveIntOrThrow(split[1]));
 
 		TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_town_set_tax_max_percent_amount", sender.getName(), TownyEconomyHandler.getFormattedBalance(nation.getMaxPercentTaxAmount())));
 	}

--- a/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
+++ b/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
@@ -137,6 +137,7 @@ public class SQL_Schema {
 		columns.add("`isPublic` bool NOT NULL DEFAULT '1'");
 		columns.add("`isOpen` bool NOT NULL DEFAULT '1'");
         columns.add("`taxpercent` bool NOT NULL DEFAULT '0'");
+        columns.add("`maxPercentTaxAmount` float DEFAULT NULL");
 		columns.add("`metadata` text DEFAULT NULL");
 		return columns;
 	}

--- a/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
+++ b/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
@@ -136,8 +136,8 @@ public class SQL_Schema {
 		columns.add("`nationSpawn` mediumtext DEFAULT NULL");
 		columns.add("`isPublic` bool NOT NULL DEFAULT '1'");
 		columns.add("`isOpen` bool NOT NULL DEFAULT '1'");
-        columns.add("`taxpercent` bool NOT NULL DEFAULT '0'");
-        columns.add("`maxPercentTaxAmount` float DEFAULT NULL");
+		columns.add("`taxpercent` bool NOT NULL DEFAULT '0'");
+		columns.add("`maxPercentTaxAmount` float DEFAULT NULL");
 		columns.add("`metadata` text DEFAULT NULL");
 		return columns;
 	}

--- a/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
+++ b/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
@@ -136,6 +136,7 @@ public class SQL_Schema {
 		columns.add("`nationSpawn` mediumtext DEFAULT NULL");
 		columns.add("`isPublic` bool NOT NULL DEFAULT '1'");
 		columns.add("`isOpen` bool NOT NULL DEFAULT '1'");
+        columns.add("`taxpercent` bool NOT NULL DEFAULT '0'");
 		columns.add("`metadata` text DEFAULT NULL");
 		return columns;
 	}

--- a/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -1170,19 +1170,19 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 						nation.setOpen(Boolean.parseBoolean(line));
 					} catch (Exception ignored) {
 					}
-                
-                line = keys.get("taxpercent");
-                if (line != null)
-                    try {
-                        nation.setTaxPercentage(Boolean.parseBoolean(line));
-                    } catch (Exception ignored) {
-                    }
 
-                line = keys.get("maxPercentTaxAmount");
-                if (line != null)
-                    nation.setMaxPercentTaxAmount(Double.parseDouble(line));
-                else 
-                    nation.setMaxPercentTaxAmount(TownySettings.getMaxTownTaxPercentAmount());
+				line = keys.get("taxpercent");
+				if (line != null)
+					try {
+						nation.setTaxPercentage(Boolean.parseBoolean(line));
+					} catch (Exception ignored) {
+					}
+
+				line = keys.get("maxPercentTaxAmount");
+				if (line != null)
+					nation.setMaxPercentTaxAmount(Double.parseDouble(line));
+				else
+					nation.setMaxPercentTaxAmount(TownySettings.getMaxNationTaxPercentAmount());
 				
 				line = keys.get("metadata");
 				if (line != null && !line.isEmpty())

--- a/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -1170,6 +1170,19 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 						nation.setOpen(Boolean.parseBoolean(line));
 					} catch (Exception ignored) {
 					}
+                
+                line = keys.get("taxpercent");
+                if (line != null)
+                    try {
+                        nation.setTaxPercentage(Boolean.parseBoolean(line));
+                    } catch (Exception ignored) {
+                    }
+
+                line = keys.get("maxPercentTaxAmount");
+                if (line != null)
+                    nation.setMaxPercentTaxAmount(Double.parseDouble(line));
+                else 
+                    nation.setMaxPercentTaxAmount(TownySettings.getMaxTownTaxPercentAmount());
 				
 				line = keys.get("metadata");
 				if (line != null && !line.isEmpty())
@@ -2068,6 +2081,10 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 
 		list.add("enemies=" + StringMgmt.join(nation.getEnemies(), ","));
 
+        // Taxpercent
+		list.add("taxpercent=" + nation.isTaxPercentage());
+		// Taxpercent Cap
+		list.add("maxPercentTaxAmount=" + nation.getMaxPercentTaxAmount());
 		// Taxes
 		list.add("taxes=" + nation.getTaxes());
 		// Nation Spawn Cost

--- a/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -1335,6 +1335,14 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			nation.setPublic(rs.getBoolean("isPublic"));
 
 			nation.setOpen(rs.getBoolean("isOpen"));
+            
+            nation.setTaxPercentage(rs.getBoolean("taxpercent"));
+
+            line = rs.getString("maxPercentTaxAmount");
+			if (line != null)
+				nation.setMaxPercentTaxAmount(Double.parseDouble(line));
+			else 
+				nation.setMaxPercentTaxAmount(TownySettings.getMaxTownTaxPercentAmount());
 
 			try {
 				line = rs.getString("registered");
@@ -2259,6 +2267,8 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			nat_hm.put("allies", StringMgmt.join(nation.getAllies(), "#"));
 			nat_hm.put("enemies", StringMgmt.join(nation.getEnemies(), "#"));
 			nat_hm.put("taxes", nation.getTaxes());
+            nat_hm.put("taxpercent", nation.isTaxPercentage());
+			nat_hm.put("maxPercentTaxAmount", nation.getMaxPercentTaxAmount());
 			nat_hm.put("spawnCost", nation.getSpawnCost());
 			nat_hm.put("neutral", nation.isNeutral());
 			nat_hm.put("nationSpawn",

--- a/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -1335,14 +1335,14 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			nation.setPublic(rs.getBoolean("isPublic"));
 
 			nation.setOpen(rs.getBoolean("isOpen"));
-            
-            nation.setTaxPercentage(rs.getBoolean("taxpercent"));
 
-            line = rs.getString("maxPercentTaxAmount");
+			nation.setTaxPercentage(rs.getBoolean("taxpercent"));
+
+			line = rs.getString("maxPercentTaxAmount");
 			if (line != null)
 				nation.setMaxPercentTaxAmount(Double.parseDouble(line));
 			else 
-				nation.setMaxPercentTaxAmount(TownySettings.getMaxTownTaxPercentAmount());
+				nation.setMaxPercentTaxAmount(TownySettings.getMaxNationTaxPercentAmount());
 
 			try {
 				line = rs.getString("registered");

--- a/src/com/palmergames/bukkit/towny/event/nation/toggle/NationToggleTaxPercentEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/nation/toggle/NationToggleTaxPercentEvent.java
@@ -1,0 +1,11 @@
+package com.palmergames.bukkit.towny.event.nation.toggle;
+
+import org.bukkit.command.CommandSender;
+import com.palmergames.bukkit.towny.object.Nation;
+
+public class NationToggleTaxPercentEvent extends NationToggleStateEvent {
+
+    public NationToggleTaxPercentEvent(CommandSender sender, Nation nation, boolean admin, boolean newState) {
+        super(sender, nation, admin, nation.isTaxPercentage(), newState);
+    }
+}

--- a/src/com/palmergames/bukkit/towny/object/Nation.java
+++ b/src/com/palmergames/bukkit/towny/object/Nation.java
@@ -40,11 +40,15 @@ public class Nation extends Government {
 	private List<Nation> enemies = new ArrayList<>();
 	private Town capital;
 	private final List<Invite> sentAllyInvites = new ArrayList<>();
+    private boolean isTaxPercentage = TownySettings.getNationDefaultTaxPercentage();
+	private double maxPercentTaxAmount = TownySettings.getMaxNationTaxPercentAmount();
+
 
 	public Nation(String name) {
 		super(name);
 		
 		// Set defaults
+        setTaxes(TownySettings.getNationDefaultTax());
 		setBoard(TownySettings.getNationDefaultBoard());
 		setOpen(TownySettings.getNationDefaultOpen());
 	}
@@ -349,7 +353,33 @@ public class Nation extends Government {
 	}
 
 	public void setTaxes(double taxes) {
-		this.taxes = Math.min(taxes, TownySettings.getMaxNationTax());
+		this.taxes = Math.min(taxes, isTaxPercentage ? TownySettings.getMaxNationTaxPercent() : TownySettings.getMaxNationTax());
+		
+		// Fix invalid taxes
+		if (this.taxes < 0)
+			this.taxes = TownySettings.getNationDefaultTax();
+	}
+    
+    public double getMaxPercentTaxAmount() {
+        return maxPercentTaxAmount;
+    }
+
+    public void setMaxPercentTaxAmount(double maxPercentTaxAmount) {
+		// Max tax amount cannot go over amount defined in config.
+		this.maxPercentTaxAmount = Math.min(maxPercentTaxAmount, TownySettings.getMaxNationTaxPercentAmount());
+	}
+
+    public void setTaxPercentage(boolean isPercentage) {
+
+		this.isTaxPercentage = isPercentage;
+		if (this.getTaxes() > 100) {
+			this.setTaxes(0);
+		}
+	}
+
+	public boolean isTaxPercentage() {
+
+		return isTaxPercentage;
 	}
 
 	public void clear() {

--- a/src/com/palmergames/bukkit/towny/object/Nation.java
+++ b/src/com/palmergames/bukkit/towny/object/Nation.java
@@ -40,7 +40,7 @@ public class Nation extends Government {
 	private List<Nation> enemies = new ArrayList<>();
 	private Town capital;
 	private final List<Invite> sentAllyInvites = new ArrayList<>();
-    private boolean isTaxPercentage = TownySettings.getNationDefaultTaxPercentage();
+	private boolean isTaxPercentage = TownySettings.getNationDefaultTaxPercentage();
 	private double maxPercentTaxAmount = TownySettings.getMaxNationTaxPercentAmount();
 
 
@@ -48,7 +48,7 @@ public class Nation extends Government {
 		super(name);
 		
 		// Set defaults
-        setTaxes(TownySettings.getNationDefaultTax());
+		setTaxes(TownySettings.getNationDefaultTax());
 		setBoard(TownySettings.getNationDefaultBoard());
 		setOpen(TownySettings.getNationDefaultOpen());
 	}
@@ -359,17 +359,17 @@ public class Nation extends Government {
 		if (this.taxes < 0)
 			this.taxes = TownySettings.getNationDefaultTax();
 	}
-    
-    public double getMaxPercentTaxAmount() {
-        return maxPercentTaxAmount;
-    }
 
-    public void setMaxPercentTaxAmount(double maxPercentTaxAmount) {
+	public double getMaxPercentTaxAmount() {
+		return maxPercentTaxAmount;
+	}
+
+	public void setMaxPercentTaxAmount(double maxPercentTaxAmount) {
 		// Max tax amount cannot go over amount defined in config.
 		this.maxPercentTaxAmount = Math.min(maxPercentTaxAmount, TownySettings.getMaxNationTaxPercentAmount());
 	}
 
-    public void setTaxPercentage(boolean isPercentage) {
+	public void setTaxPercentage(boolean isPercentage) {
 
 		this.isTaxPercentage = isPercentage;
 		if (this.getTaxes() > 100) {

--- a/src/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
+++ b/src/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
@@ -62,7 +62,7 @@ public enum PermissionNodes {
 		TOWNY_COMMAND_NATION_SET_SPAWN("towny.command.nation.set.spawn"),
 		TOWNY_COMMAND_NATION_SET_SPAWNCOST("towny.command.nation.set.spawncost"),
 		TOWNY_COMMAND_NATION_SET_MAPCOLOR("towny.command.nation.set.mapcolor"),
-        TOWNY_COMMAND_NATION_SET_TAXPERCENTCAP("towny.command.town.set.taxpercentcap"),
+        TOWNY_COMMAND_NATION_SET_TAXPERCENTCAP("towny.command.nation.set.taxpercentcap"),
 
 	TOWNY_COMMAND_NATION_TOGGLE("towny.command.nation.toggle.*"),
         TOWNY_COMMAND_NATION_TOGGLE_NEUTRAL("towny.command.nation.toggle.neutral"),

--- a/src/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
+++ b/src/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
@@ -62,11 +62,13 @@ public enum PermissionNodes {
 		TOWNY_COMMAND_NATION_SET_SPAWN("towny.command.nation.set.spawn"),
 		TOWNY_COMMAND_NATION_SET_SPAWNCOST("towny.command.nation.set.spawncost"),
 		TOWNY_COMMAND_NATION_SET_MAPCOLOR("towny.command.nation.set.mapcolor"),
+        TOWNY_COMMAND_NATION_SET_TAXPERCENTCAP("towny.command.town.set.taxpercentcap"),
 
 	TOWNY_COMMAND_NATION_TOGGLE("towny.command.nation.toggle.*"),
-    TOWNY_COMMAND_NATION_TOGGLE_NEUTRAL("towny.command.nation.toggle.neutral"),
-    TOWNY_COMMAND_NATION_TOGGLE_PUBLIC("towny.command.nation.toggle.public"),
-    TOWNY_COMMAND_NATION_TOGGLE_OPEN("towny.command.nation.toggle.open"),
+        TOWNY_COMMAND_NATION_TOGGLE_NEUTRAL("towny.command.nation.toggle.neutral"),
+        TOWNY_COMMAND_NATION_TOGGLE_PUBLIC("towny.command.nation.toggle.public"),
+        TOWNY_COMMAND_NATION_TOGGLE_OPEN("towny.command.nation.toggle.open"),
+        TOWNY_COMMAND_NATION_TOGGLE_TAXPERCENT("towny.command.nation.toggle.taxpercent"),
 
 	TOWNY_COMMAND_NATION_ENEMY("towny.command.nation.enemy"),
 	TOWNY_COMMAND_NATION_DELETE("towny.command.nation.delete"),

--- a/src/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
+++ b/src/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
@@ -62,13 +62,13 @@ public enum PermissionNodes {
 		TOWNY_COMMAND_NATION_SET_SPAWN("towny.command.nation.set.spawn"),
 		TOWNY_COMMAND_NATION_SET_SPAWNCOST("towny.command.nation.set.spawncost"),
 		TOWNY_COMMAND_NATION_SET_MAPCOLOR("towny.command.nation.set.mapcolor"),
-        TOWNY_COMMAND_NATION_SET_TAXPERCENTCAP("towny.command.nation.set.taxpercentcap"),
+		TOWNY_COMMAND_NATION_SET_TAXPERCENTCAP("towny.command.nation.set.taxpercentcap"),
 
 	TOWNY_COMMAND_NATION_TOGGLE("towny.command.nation.toggle.*"),
-        TOWNY_COMMAND_NATION_TOGGLE_NEUTRAL("towny.command.nation.toggle.neutral"),
-        TOWNY_COMMAND_NATION_TOGGLE_PUBLIC("towny.command.nation.toggle.public"),
-        TOWNY_COMMAND_NATION_TOGGLE_OPEN("towny.command.nation.toggle.open"),
-        TOWNY_COMMAND_NATION_TOGGLE_TAXPERCENT("towny.command.nation.toggle.taxpercent"),
+		TOWNY_COMMAND_NATION_TOGGLE_NEUTRAL("towny.command.nation.toggle.neutral"),
+		TOWNY_COMMAND_NATION_TOGGLE_PUBLIC("towny.command.nation.toggle.public"),
+		TOWNY_COMMAND_NATION_TOGGLE_OPEN("towny.command.nation.toggle.open"),
+		TOWNY_COMMAND_NATION_TOGGLE_TAXPERCENT("towny.command.nation.toggle.taxpercent"),
 
 	TOWNY_COMMAND_NATION_ENEMY("towny.command.nation.enemy"),
 	TOWNY_COMMAND_NATION_DELETE("towny.command.nation.delete"),

--- a/src/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
@@ -196,12 +196,21 @@ public class DailyTimerTask extends TownyTimerTask {
 					if ((town.isCapital() && !TownySettings.doCapitalsPayNationTax()) || !town.hasUpkeep() || town.isRuined())
 						continue;
 					
+                    if (nation.isTaxPercentage()) {
+                        taxAmount = town.getAccount().getHoldingBalance() * taxAmount / 100;
+                        taxAmount = Math.min(taxAmount, nation.getMaxPercentTaxAmount());
+
+                        System.out.println(taxAmount);
+                    }
+                    
 					PreTownPaysNationTaxEvent event = new PreTownPaysNationTaxEvent(town, nation, taxAmount);
 					if (BukkitTools.isEventCancelled(event)) {
 						TownyMessaging.sendPrefixedTownMessage(town, event.getCancelMessage());
 						continue;
 					}
+
 					taxAmount = event.getTax();
+                    System.out.println(taxAmount);
 					
 					if (town.getAccount().canPayFromHoldings(taxAmount)) {
 					// Town is able to pay the nation's tax.

--- a/src/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
@@ -196,17 +196,16 @@ public class DailyTimerTask extends TownyTimerTask {
 					if ((town.isCapital() && !TownySettings.doCapitalsPayNationTax()) || !town.hasUpkeep() || town.isRuined())
 						continue;
 					
-                    if (nation.isTaxPercentage()) {
-                        taxAmount = town.getAccount().getHoldingBalance() * taxAmount / 100;
-                        taxAmount = Math.min(taxAmount, nation.getMaxPercentTaxAmount());
-                    }
+					if (nation.isTaxPercentage()) {
+						taxAmount = town.getAccount().getHoldingBalance() * taxAmount / 100;
+						taxAmount = Math.min(taxAmount, nation.getMaxPercentTaxAmount());
+					}
 
 					PreTownPaysNationTaxEvent event = new PreTownPaysNationTaxEvent(town, nation, taxAmount);
 					if (BukkitTools.isEventCancelled(event)) {
 						TownyMessaging.sendPrefixedTownMessage(town, event.getCancelMessage());
 						continue;
 					}
-
 					taxAmount = event.getTax();
 					
 					if (town.getAccount().canPayFromHoldings(taxAmount)) {

--- a/src/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
@@ -199,10 +199,8 @@ public class DailyTimerTask extends TownyTimerTask {
                     if (nation.isTaxPercentage()) {
                         taxAmount = town.getAccount().getHoldingBalance() * taxAmount / 100;
                         taxAmount = Math.min(taxAmount, nation.getMaxPercentTaxAmount());
-
-                        System.out.println(taxAmount);
                     }
-                    
+
 					PreTownPaysNationTaxEvent event = new PreTownPaysNationTaxEvent(town, nation, taxAmount);
 					if (BukkitTools.isEventCancelled(event)) {
 						TownyMessaging.sendPrefixedTownMessage(town, event.getCancelMessage());
@@ -210,7 +208,6 @@ public class DailyTimerTask extends TownyTimerTask {
 					}
 
 					taxAmount = event.getTax();
-                    System.out.println(taxAmount);
 					
 					if (town.getAccount().canPayFromHoldings(taxAmount)) {
 					// Town is able to pay the nation's tax.


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description:
<!--- Describe your Pull Request's purpose here please. --->
Adds Tax percentage for nations

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
##### Commands
```
  - New Commands:
    - `/nation toggle taxpercent` - Toggle percentage nationtax on or off.
    - `/nation set taxpercentcap` - Sets the max amount of money which can be gotten via percent nationtax, from a town.
```

##### Permissions
```
  - New Permission Nodes:
    - `towny.command.nation.toggle.taxpercent` - Child node of towny.command.nation.toggle.*.
    - ` towny.command.nation.set.taxpercentcap` - Child node of towny.command.nation.set.*.
    - No changes to townyperms.yml required.
```

##### Config options
```
  - New Config Options:
    - nation.default_taxes.tax
      - Default: 0.0
      - Default amount of tax of a new nation. This must be lower than the economy.daily_taxes.max_nation_tax_amount setting.
    - nation.default_taxes.taxpercentage
      - Default: false
      - Default status of new nation's taxpercentage. True means that the default_tax is treated as a percentage instead of a fixed amount.
    - nation.default_taxes.minimumtax
      - Default: 0.0
      - A required minimum tax amount for the default_tax, will not change any nations which already have a tax set.
      - Do not forget to set the default_tax to more than 0 or new nations will still begin with a tax of zero.
    - economy.daily_taxes.max_nation_tax_percent
      - Default: 25
      - Maximum tax percentage allowed when taxing by percentages for nations.
    - economy.daily_taxes.max_nation_tax_percent_amount
      - Default: 10000
      - The maximum amount of money that can be taken from a balance when using a percent tax, this is the default for all new nations.
```

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #6106 

____
- [x] I have tested this pull request for defects on a server.
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
