### PR TITLE
TrustTown command

### DIFF
--- a/resources/lang/en-US.yml
+++ b/resources/lang/en-US.yml
@@ -1835,5 +1835,5 @@ msg_town_plots_type_line: '<dark_green>%s: <green>%s <gray>/ <aqua>%s <gray>/ <y
 #Part of the /town plots output.
 msg_town_plots_type_line_revenue: ' <gray>/ <dark_green>%s'
 
-
-
+#Message giving confirmation warning for trusttown
+confirmation_msg_trusttown_consequences: 'Are you sure you wish to trust all residents in this town? This may include future residents of this town if not revoked.'

--- a/resources/lang/en-US.yml
+++ b/resources/lang/en-US.yml
@@ -1836,4 +1836,4 @@ msg_town_plots_type_line: '<dark_green>%s: <green>%s <gray>/ <aqua>%s <gray>/ <y
 msg_town_plots_type_line_revenue: ' <gray>/ <dark_green>%s'
 
 #Message giving confirmation warning for trusttown
-confirmation_msg_trusttown_consequences: 'Are you sure you wish to trust all residents in this town? This may include future residents of this town if not revoked.'
+confirmation_msg_trusttown_consequences: 'You are about to give full plot permissions to an entire town. This means that the mayor of the town will be able to decide who gets permission to build and break in your town, by adding residents. If this town is open, then anyone can join and gain full access to your town. Are you sure you wish to trust all residents (including future residents,) from this town?'

--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -370,6 +370,7 @@ permissions:
             towny.command.town.merge: true
             towny.command.town.unjail: true
             towny.command.town.trust: true
+            towny.command.town.trusttown: true
 
     towny.command.town.list:
         description: Users are able to use the default method of sorting the town list.
@@ -678,6 +679,7 @@ permissions:
             towny.command.townyadmin.town.spawn.*: true
             towny.command.townyadmin.town.toggle: true
             towny.command.townyadmin.town.trust: true
+            towny.command.townyadmin.town.trusttown: true
             towny.command.townyadmin.town.unruin: true
             towny.command.townyadmin.town.withdraw: true
 

--- a/src/com/palmergames/bukkit/towny/command/BaseCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/BaseCommand.java
@@ -360,15 +360,4 @@ public class BaseCommand implements TabCompleter{
 	public static void checkPermOrThrowWithMessage(Permissible permissible, String node, Translatable errormsg) throws NoPermissionException {
 		TownyUniverse.getInstance().getPermissionSource().testPermissionOrThrow(permissible, node, errormsg);
 	}
-
-	public static List<String> getTrustedTownsFromResident(Player player){
-		Resident res = TownyUniverse.getInstance().getResident(player.getUniqueId());
-
-		if (res != null && res.hasTown()) {
-			return res.getTownOrNull().getTrustedTowns().stream().map(Town ->Town.getName())
-				.collect(Collectors.toList());
-		}
-
-		return Collections.emptyList();
-	}
 }

--- a/src/com/palmergames/bukkit/towny/command/BaseCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/BaseCommand.java
@@ -360,4 +360,15 @@ public class BaseCommand implements TabCompleter{
 	public static void checkPermOrThrowWithMessage(Permissible permissible, String node, Translatable errormsg) throws NoPermissionException {
 		TownyUniverse.getInstance().getPermissionSource().testPermissionOrThrow(permissible, node, errormsg);
 	}
+
+	public static List<String> getTrustedTownsFromResidentOrThrow(Player player){
+		Resident res = TownyUniverse.getInstance().getResident(player.getUniqueId());
+
+		if (res != null && res.hasTown()) {
+			return res.getTownOrNull().getTrustedTowns().stream().map(Town ->Town.getName())
+				.collect(Collectors.toList());
+		}
+
+		return Collections.emptyList();
+	}
 }

--- a/src/com/palmergames/bukkit/towny/command/BaseCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/BaseCommand.java
@@ -361,7 +361,7 @@ public class BaseCommand implements TabCompleter{
 		TownyUniverse.getInstance().getPermissionSource().testPermissionOrThrow(permissible, node, errormsg);
 	}
 
-	public static List<String> getTrustedTownsFromResidentOrThrow(Player player){
+	public static List<String> getTrustedTownsFromResident(Player player){
 		Resident res = TownyUniverse.getInstance().getResident(player.getUniqueId());
 
 		if (res != null && res.hasTown()) {

--- a/src/com/palmergames/bukkit/towny/command/HelpMenu.java
+++ b/src/com/palmergames/bukkit/towny/command/HelpMenu.java
@@ -880,6 +880,16 @@ public enum HelpMenu {
 		}
 	},
 	
+	TOWN_TRUSTTOWN_HELP {
+		@Override
+		protected MenuBuilder load() {
+			return new MenuBuilder("town trusttown")
+				.add("add [town]", "")
+				.add("remove [town]", "")
+				.add("list", "");
+		}
+	},
+	
 	PLOT_GROUP_TRUST_HELP {
 		@Override
 		protected MenuBuilder load() {

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -4183,10 +4183,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		}
 
 		if (args[0].equalsIgnoreCase("list")) {
-			//TownyMessaging.sendMessage(sender, TownyFormatter.getFormattedStrings(Translatable.of("status_trustedlist").forLocale(sender), output));
-			
 			TownyMessaging.sendMessage(sender, TownyFormatter.getFormattedTownyObjects(Translatable.of("status_trustedlist").forLocale(sender), new ArrayList<>(town.getTrusted())));
-			
 			return;
 		}
 

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -45,6 +45,8 @@ import com.palmergames.bukkit.towny.event.town.toggle.TownToggleOpenEvent;
 import com.palmergames.bukkit.towny.event.town.toggle.TownTogglePVPEvent;
 import com.palmergames.bukkit.towny.event.town.toggle.TownTogglePublicEvent;
 import com.palmergames.bukkit.towny.event.town.toggle.TownToggleTaxPercentEvent;
+import com.palmergames.bukkit.towny.event.town.TownTrustTownAddEvent;
+import com.palmergames.bukkit.towny.event.town.TownTrustTownRemoveEvent;
 import com.palmergames.bukkit.towny.exceptions.AlreadyRegisteredException;
 import com.palmergames.bukkit.towny.exceptions.InvalidNameException;
 import com.palmergames.bukkit.towny.exceptions.NoPermissionException;
@@ -4192,7 +4194,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 
 		Town trustTown = getTownOrThrow(args[1]);
 
-		if ("add".equalsIgnoreCase(args[0])) {
+		if (args[0].equalsIgnoreCase("add")) {
 			if (town.hasTrustedTown(trustTown)) {
 				TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_already_trusted", trustTown.getName(), Translatable.of("town_sing")));
 				return;
@@ -4201,6 +4203,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 				TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_already_trusted", trustTown.getName(), Translatable.of("town_sing")));
 				return;
 			}
+			BukkitTools.ifCancelledThenThrow(new TownTrustTownAddEvent(sender, trustTown, town));
 			@Nullable Town finalTown = town;
 			Confirmation.runOnAccept(()-> {
 					trustTown.getResidents().forEach(res -> plugin.deleteCache(res));
@@ -4210,12 +4213,12 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 				})
 				.setTitle(Translatable.of("confirmation_msg_trusttown_consequences"))
 				.sendTo(sender);
-		} else if ("remove".equalsIgnoreCase(args[0])) {
+		} else if (args[0].equalsIgnoreCase("remove")) {
 			if (!town.hasTrustedTown(trustTown)) {
 				TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_not_trusted", trustTown.getName(), Translatable.of("town_sing")));
 				return;
 			}
-			
+			BukkitTools.ifCancelledThenThrow(new TownTrustTownRemoveEvent(sender, trustTown, town));
 			town.removeTrustedTown(trustTown);
 			trustTown.getResidents().forEach(res -> plugin.deleteCache(res));
 			TownyMessaging.sendMsg(sender, Translatable.of("msg_trusted_removed", trustTown.getName(), Translatable.of("town_sing")));

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -506,11 +506,11 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 						case 3:
 							if (args[1].equalsIgnoreCase("add")) {
 								List<String> townsList = getTownyStartingWith(args[2], "t");
-								townsList.removeAll(getTrustedTownsFromResidentOrThrow(player));
+								townsList.removeAll(getTrustedTownsFromResident(player));
 								return townsList;
 							}
 							if (args[1].equalsIgnoreCase("remove")) {
-								return NameUtil.filterByStart(getTrustedTownsFromResidentOrThrow(player), args[2]);
+								return NameUtil.filterByStart(getTrustedTownsFromResident(player), args[2]);
 							}
 							return Collections.emptyList();
 						default:
@@ -4200,12 +4200,17 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 				TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_already_trusted", trustTown.getName(), Translatable.of("town_sing")));
 				return;
 			}
-			town.addTrustedTown(trustTown);
-			for (Resident res : trustTown.getResidents()) {
-				plugin.deleteCache(res);
-			}
+			@Nullable Town finalTown = town;
+			Confirmation.runOnAccept(()-> {
+					for (Resident res : trustTown.getResidents()) {
+						plugin.deleteCache(res);
+					}
 
-			TownyMessaging.sendMsg(sender, Translatable.of("msg_trusted_added", trustTown.getName(), Translatable.of("town_sing")));
+					TownyMessaging.sendMsg(sender, Translatable.of("msg_trusted_added", trustTown.getName(), Translatable.of("town_sing")));
+					finalTown.addTrustedTown(trustTown);
+				})
+				.setTitle(Translatable.of("confirmation_msg_trusttown_consequences"))
+				.sendTo(sender);
 		} else if (args[0].equalsIgnoreCase("remove")) {
 			if (!town.hasTrustedTown(trustTown)) {
 				TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_not_trusted", trustTown.getName(), Translatable.of("town_sing")));

--- a/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -146,6 +146,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		"invite",
 		"unruin",
 		"trust",
+		"trusttown",
 		"checkoutposts",
 		"settownlevel",
 		"giveboughtblocks",
@@ -1478,6 +1479,9 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			} else if (split[1].equalsIgnoreCase("trust")) {
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOWN_TRUST.getNode());
 				TownCommand.parseTownTrustCommand(sender, StringMgmt.remArgs(split, 2), town);
+			} else if (split[1].equalsIgnoreCase("trusttown")) {
+				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOWN_TRUSTTOWN.getNode());
+				TownCommand.parseTownTrustTownCommand(sender, StringMgmt.remArgs(split, 2), town);
 			} else if (split[1].equalsIgnoreCase("merge")) {
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOWN_MERGE.getNode());
 				TownCommand.parseTownMergeCommand(sender, StringMgmt.remArgs(split, 2), town, true);

--- a/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
+++ b/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
@@ -194,6 +194,7 @@ public class SQL_Schema {
 		columns.add("`primaryJail` VARCHAR(36) DEFAULT NULL");
 		columns.add("`movedHomeBlockAt` BIGINT NOT NULL");
 		columns.add("`trustedResidents` mediumtext DEFAULT NULL");
+		columns.add("`trustedTowns` mediumtext NOT NULL");
 		columns.add("`nationZoneOverride` int(11) DEFAULT 0");
 		columns.add("`nationZoneEnabled` bool NOT NULL DEFAULT '1'");
 		columns.add("`allies` mediumtext NOT NULL");

--- a/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -968,6 +968,14 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 						town.addTrustedResident(resident);
 				}
 				
+				line = keys.get("trustedTowns");
+				if (line != null && !line.isEmpty()) {
+					List<UUID> uuids = Arrays.stream(line.split(","))
+						.map(uuid -> UUID.fromString(uuid))
+						.collect(Collectors.toList());
+					town.loadTrusted(TownyAPI.getInstance().getTowns(uuids));
+				}
+
 				line = keys.get("mapColorHexCode");
 				if (line != null) {
 					try {
@@ -2026,6 +2034,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 			list.add("primaryJail=" + town.getPrimaryJail().getUUID());
 		
 		list.add("trustedResidents=" + StringMgmt.join(toUUIDList(town.getTrustedResidents()), ","));
+		list.add("trustedTowns=" + StringMgmt.join(town.getTrustedTownsUUIDS(), ","));
 		
 		list.add("mapColorHexCode=" + town.getMapColorHexCode());
 		list.add("nationZoneOverride=" + town.getNationZoneOverride());

--- a/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -971,9 +971,9 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 				line = keys.get("trustedTowns");
 				if (line != null && !line.isEmpty()) {
 					List<UUID> uuids = Arrays.stream(line.split(","))
-						.map(uuid -> UUID.fromString(uuid))
+						.map(UUID::fromString)
 						.collect(Collectors.toList());
-					town.loadTrusted(TownyAPI.getInstance().getTowns(uuids));
+					town.loadTrustedTowns(TownyAPI.getInstance().getTowns(uuids));
 				}
 
 				line = keys.get("mapColorHexCode");

--- a/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -1173,9 +1173,9 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			if (line != null && !line.isEmpty()) {
 				search = (line.contains("#")) ? "#" : ",";
 				List<UUID> uuids = Arrays.stream(line.split(search))
-					.map(uuid -> UUID.fromString(uuid))
+					.map(UUID::fromString)
 					.collect(Collectors.toList());
-				town.loadTrusted(TownyAPI.getInstance().getTowns(uuids));
+				town.loadTrustedTowns(TownyAPI.getInstance().getTowns(uuids));
 			}
 			
 			line = rs.getString("mapColorHexCode");

--- a/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -1169,6 +1169,15 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 					town.addTrustedResident(resident);
 			}
 			
+			line = rs.getString("trustedTowns");
+			if (line != null && !line.isEmpty()) {
+				search = (line.contains("#")) ? "#" : ",";
+				List<UUID> uuids = Arrays.stream(line.split(search))
+					.map(uuid -> UUID.fromString(uuid))
+					.collect(Collectors.toList());
+				town.loadTrusted(TownyAPI.getInstance().getTowns(uuids));
+			}
+			
 			line = rs.getString("mapColorHexCode");
 			if (line != null)
 				town.setMapColorHexCode(line);
@@ -2219,6 +2228,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 				twn_hm.put("primaryJail", town.getPrimaryJail().getUUID());
 			
 			twn_hm.put("trustedResidents", StringMgmt.join(toUUIDList(town.getTrustedResidents()), "#"));
+			twn_hm.put("trustedTowns", StringMgmt.join(town.getTrustedTownsUUIDS(), "#"));
 			
 			twn_hm.put("allies", StringMgmt.join(town.getAlliesUUIDs(), "#"));
 			

--- a/src/com/palmergames/bukkit/towny/event/town/TownTrustTownAddEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/town/TownTrustTownAddEvent.java
@@ -4,12 +4,14 @@ import com.palmergames.bukkit.towny.event.CancellableTownyEvent;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.Translation;
 import org.bukkit.command.CommandSender;
+import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
 public class TownTrustTownAddEvent extends CancellableTownyEvent {
 	private final Town town;
 	private final Town trustTown;
 	private final CommandSender sender;
+	private static final HandlerList handlers = new HandlerList();
 
 	public TownTrustTownAddEvent(CommandSender sender, Town trustTown, Town town) {
 		this.town = town;
@@ -18,6 +20,16 @@ public class TownTrustTownAddEvent extends CancellableTownyEvent {
 		setCancelMessage(Translation.of("msg_err_command_disable"));
 	}
 
+	@NotNull
+	@Override
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
+	
 	/**
 	 * @return The town where the town is being added as trusted.
 	 */

--- a/src/com/palmergames/bukkit/towny/event/town/TownTrustTownAddEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/town/TownTrustTownAddEvent.java
@@ -1,0 +1,39 @@
+package com.palmergames.bukkit.towny.event.town;
+
+import com.palmergames.bukkit.towny.event.CancellableTownyEvent;
+import com.palmergames.bukkit.towny.object.Town;
+import com.palmergames.bukkit.towny.object.Translation;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+
+public class TownTrustTownAddEvent extends CancellableTownyEvent {
+	private final Town town;
+	private final Town trustTown;
+	private final CommandSender sender;
+
+	public TownTrustTownAddEvent(CommandSender sender, Town trustTown, Town town) {
+		this.town = town;
+		this.trustTown = trustTown;
+		this.sender = sender;
+		setCancelMessage(Translation.of("msg_err_command_disable"));
+	}
+
+	/**
+	 * @return The town where the town is being added as trusted.
+	 */
+	public Town getTown() {
+		return town;
+	}
+
+	/**
+	 * @return The town that is being added as trusted.
+	 */
+	public Town getTrustedTown() {
+		return trustTown;
+	}
+	
+	@NotNull
+	public CommandSender getSender() {
+		return sender;
+	}
+}

--- a/src/com/palmergames/bukkit/towny/event/town/TownTrustTownRemoveEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/town/TownTrustTownRemoveEvent.java
@@ -4,18 +4,29 @@ import com.palmergames.bukkit.towny.event.CancellableTownyEvent;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.Translation;
 import org.bukkit.command.CommandSender;
+import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
 public class TownTrustTownRemoveEvent extends CancellableTownyEvent {
 	private final Town town;
 	private final Town trustTown;
 	private final CommandSender sender;
+	private static final HandlerList handlers = new HandlerList();
 
 	public TownTrustTownRemoveEvent(CommandSender sender, Town trustTown, Town town) {
 		this.town = town;
 		this.trustTown = trustTown;
 		this.sender = sender;
 		setCancelMessage(Translation.of("msg_err_command_disable"));
+	}
+	@NotNull
+	@Override
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
 	}
 
 	/**

--- a/src/com/palmergames/bukkit/towny/event/town/TownTrustTownRemoveEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/town/TownTrustTownRemoveEvent.java
@@ -1,0 +1,38 @@
+package com.palmergames.bukkit.towny.event.town;
+
+import com.palmergames.bukkit.towny.event.CancellableTownyEvent;
+import com.palmergames.bukkit.towny.object.Town;
+import com.palmergames.bukkit.towny.object.Translation;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+
+public class TownTrustTownRemoveEvent extends CancellableTownyEvent {
+	private final Town town;
+	private final Town trustTown;
+	private final CommandSender sender;
+
+	public TownTrustTownRemoveEvent(CommandSender sender, Town trustTown, Town town) {
+		this.town = town;
+		this.trustTown = trustTown;
+		this.sender = sender;
+		setCancelMessage(Translation.of("msg_err_command_disable"));
+	}
+
+	/**
+	 * @return The town where the town is being removed as trusted.
+	 */
+	public Town getTown() {
+		return town;
+	}
+
+	/**
+	 * @return The town that is being removed as trusted.
+	 */
+	public Town getTrustedTown() {
+		return trustTown;
+	}
+	
+	public @NotNull CommandSender getSender() {
+		return sender;
+	}
+}

--- a/src/com/palmergames/bukkit/towny/object/Town.java
+++ b/src/com/palmergames/bukkit/towny/object/Town.java
@@ -1489,17 +1489,8 @@ public class Town extends Government implements TownBlockOwner {
 	}
 	
 	public boolean hasTrustedResident(Resident resident) {
-		Boolean isTrusted = false;
 		Town residentsTown = resident.getTownOrNull();
-		if (residentsTown != null) {
-			if (this.hasTrusted(residentsTown)) {
-				isTrusted = true;
-			}
-		}
-		if (!isTrusted) {
-			isTrusted = trustedResidents.contains(resident);
-		}
-		return isTrusted;
+		return trustedResidents.contains(resident) || (residentsTown != null && this.hasTrustedTown(residentsTown));
 	}
 	
 	public void addTrustedResident(Resident resident) {
@@ -1571,27 +1562,28 @@ public class Town extends Government implements TownBlockOwner {
 	 * Only to be used when loading the database.
 	 * @param towns List&lt;Town&gt; which will be loaded in as trusted towns.
 	 */
-	public void loadTrusted(List<Town> towns) {
-		for (Town town : towns)
-			trustedTowns.put(town.getUUID(), town);
+	public void loadTrustedTowns(List<Town> towns) {
+		for (Town trustTown : towns) {
+			trustedTowns.put(trustTown.getUUID(), trustTown);
+		}
 	}
 
-	public void addTrusted(Town town) {
+	public void addTrustedTown(Town town) {
 		trustedTowns.put(town.getUUID(), town);
 	}
 
-	public void removeTrusted(Town town) {
+	public void removeTrustedTown(Town town) {
 		trustedTowns.remove(town.getUUID());
 	}
 
-	public boolean removeAllTrusted() {
+	public boolean removeAllTrustedTowns() {
 		for (Town trusted : new ArrayList<>(getAllies())) {
-			removeTrusted(trusted);
+			removeTrustedTown(trusted);
 		}
-		return getTrusted().isEmpty();
+		return getTrustedTowns().isEmpty();
 	}
 
-	public boolean hasTrusted(Town town) {
+	public boolean hasTrustedTown(Town town) {
 		return trustedTowns.containsKey(town.getUUID());
 	}
 	
@@ -1644,7 +1636,7 @@ public class Town extends Government implements TownBlockOwner {
 		return Collections.unmodifiableList(allies.values().stream().collect(Collectors.toList()));
 	}
 
-	public List<Town> getTrusted() {
+	public List<Town> getTrustedTowns() {
 		return Collections.unmodifiableList(trustedTowns.values().stream().collect(Collectors.toList()));
 	}
 	

--- a/src/com/palmergames/bukkit/towny/object/Town.java
+++ b/src/com/palmergames/bukkit/towny/object/Town.java
@@ -1577,7 +1577,7 @@ public class Town extends Government implements TownBlockOwner {
 	}
 
 	public boolean removeAllTrustedTowns() {
-		for (Town trusted : new ArrayList<>(getAllies())) {
+		for (Town trusted : new ArrayList<>(getTrustedTowns())) {
 			removeTrustedTown(trusted);
 		}
 		return getTrustedTowns().isEmpty();

--- a/src/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
+++ b/src/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
@@ -133,6 +133,7 @@ public enum PermissionNodes {
 		TOWNY_COMMAND_TOWN_UNJAIL("towny.command.town.unjail"),
 		TOWNY_COMMAND_TOWN_PLOTGROUPLIST("towny.command.town.plotgrouplist"),
 		TOWNY_COMMAND_TOWN_TRUST("towny.command.town.trust"),
+		TOWNY_COMMAND_TOWN_TRUSTTOWN("towny.command.town.trusttown"),
 		
 		// Covers all assignable ranks
 		TOWNY_COMMAND_TOWN_RANK("towny.command.town.rank.*"),
@@ -317,6 +318,7 @@ public enum PermissionNodes {
 	    TOWNY_COMMAND_TOWNYADMIN_TOWN_META("towny.command.townyadmin.town.meta"),
 	    TOWNY_COMMAND_TOWNYADMIN_TOWN_BANKHISTORY("towny.command.townyadmin.town.bankhistory"),
 		TOWNY_COMMAND_TOWNYADMIN_TOWN_TRUST("towny.command.townyadmin.town.trust"),
+		TOWNY_COMMAND_TOWNYADMIN_TOWN_TRUSTTOWN("towny.command.townyadmin.town.trusttown"),
 		TOWNY_COMMAND_TOWNYADMIN_TOWN_UNRUIN("towny.command.townyadmin.town.unruin"),
 		TOWNY_COMMAND_TOWNYADMIN_TOWN_CHECKOUTPOSTS("towny.command.townyadmin.town.checkoutposts"),
 		TOWNY_COMMAND_TOWNYADMIN_TOWN_WITHDRAW("towny.command.townyadmin.town.withdraw"),


### PR DESCRIPTION
#### Description: 
This pull request adds a new command to town commands titled `trusttown`, this allows a town member with appropriate permissions the ability to trust an entire town at once. This is envisioned to greatly supplement servers which use war modes which have true conquering of towns, as nation level permissions can often become messy.

____
#### New Nodes/Commands/ConfigOptions: 
New permission nodes:
`towny.command.town.trusttown`
`towny.command.townyadmin.town.trusttown`

New commands:
`/t trusttown add *townname*`
`/t trusttown remove *townname*`
`/t trusttown list`

`/ta *townname* trusttown add *townname*`
`/ta *townname* trusttown remove *townname*`
`/ta *townname* trusttown list`
____
#### Relevant Towny Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
