### PR TITLE
DeleteNationEvent continuity fix

### DIFF
--- a/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
@@ -676,12 +676,8 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 		}
 
 		plugin.resetCache();
-		
-		UUID kingUUID = null;
-		if (king != null)
-			kingUUID = king.getUUID();
 
-		BukkitTools.fireEvent(new DeleteNationEvent(nation, kingUUID));
+		BukkitTools.fireEvent(new DeleteNationEvent(nation, king));
 	}
 
 	@Override

--- a/src/com/palmergames/bukkit/towny/event/DeleteNationEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/DeleteNationEvent.java
@@ -56,11 +56,13 @@ public class DeleteNationEvent extends TownyObjDeleteEvent  {
 	}
 	
 	/**
-     * @deprecated in favor of {@link #getKingUUID()} 
-	 * @return deleted nation king uuid.
+     * @deprecated since 0.98.4.2 in favor of {@link #getLeaderUUID()} 
+	 * @return deleted nation leader uuid.
 	 */
 	@Nullable
+	@Deprecated
 	public UUID getNationKing() {
+
 		return kingUUID;
 	}
 

--- a/src/com/palmergames/bukkit/towny/event/DeleteNationEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/DeleteNationEvent.java
@@ -1,6 +1,8 @@
 package com.palmergames.bukkit.towny.event;
 
 import com.palmergames.bukkit.towny.object.Nation;
+import com.palmergames.bukkit.towny.object.Resident;
+
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.Nullable;
 
@@ -22,10 +24,13 @@ public class DeleteNationEvent extends TownyObjDeleteEvent  {
 	}
 
     private final UUID kingUUID;
-    
-    public DeleteNationEvent(Nation nation, UUID uuid) {
+    private final Resident king;
+
+    public DeleteNationEvent(Nation nation, Resident king) {
         super(nation.getName(), nation.getUUID(), nation.getRegistered());
-        kingUUID = uuid;
+        
+        this.king = king;
+        this.kingUUID = king == null ? null : king.getUUID();
     }
 
     /**
@@ -51,10 +56,27 @@ public class DeleteNationEvent extends TownyObjDeleteEvent  {
 	}
 	
 	/**
+     * @deprecated in favor of {@link #getKingUUID()} 
 	 * @return deleted nation king uuid.
 	 */
 	@Nullable
 	public UUID getNationKing() {
 		return kingUUID;
+	}
+
+    /**
+	 * @return the deleted nation's king's UUID, or {@code null}.
+	 */
+	@Nullable
+	public UUID getKingUUID() {
+		return kingUUID;
+	}
+
+	/**
+	 * @return The deleted nation's king, or {@code null}.
+	 */
+	@Nullable
+	public Resident getKing() {
+		return king;
 	}
 }

--- a/src/com/palmergames/bukkit/towny/event/DeleteNationEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/DeleteNationEvent.java
@@ -67,18 +67,19 @@ public class DeleteNationEvent extends TownyObjDeleteEvent  {
 	}
 
     /**
-	 * @return the deleted nation's king's UUID, or {@code null}.
+	 * @return the deleted nation's leader's UUID, or {@code null}.
 	 */
 	@Nullable
-	public UUID getKingUUID() {
+	public UUID getLeaderUUID() {
 		return kingUUID;
 	}
 
 	/**
-	 * @return The deleted nation's king, or {@code null}.
+	 * @return The deleted nation's leader's Resident object, or {@code null}.
 	 */
 	@Nullable
-	public Resident getKing() {
+	public Resident getLeader() {
 		return king;
 	}
+
 }


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

DeleteNationEvent#getNationKing was returning the UUID of the king, but
DeleteTownEvent#getMayor is returning a Resident.

So i've added two methods and deprecated the old one in DeleteNationEvent.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
