### PR TITLE
Remove townyadmin's getSender()

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/BaseCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/BaseCommand.java
@@ -14,7 +14,6 @@ import com.palmergames.bukkit.util.BukkitTools;
 
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
-import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
 import org.bukkit.permissions.Permissible;

--- a/src/com/palmergames/bukkit/towny/command/BaseCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/BaseCommand.java
@@ -348,9 +348,11 @@ public class BaseCommand implements TabCompleter{
 			throw new TownyException(Translatable.of("msg_err_console_only"));
 	}
 	
-	public static void catchConsole(CommandSender sender) throws TownyException {
-		if (sender instanceof ConsoleCommandSender)
+	public static Player catchConsole(CommandSender sender) throws TownyException {
+		if (!(sender instanceof Player player))
 			throw new TownyException(Translatable.of("msg_err_player_only"));
+		
+		return player;
 	}
 	
 	public static void checkPermOrThrow(Permissible permissible, String node) throws NoPermissionException {

--- a/src/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -954,15 +954,19 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 		newNation(player, nationName, resident.getTown(), noCharge);
 	}
 	
+	public static void newNation(Player player, String name, Town capitalTown, boolean noCharge) {
+		newNation((CommandSender) player, name, capitalTown, noCharge);
+	}
+	
 	/**
 	 * Create a new nation. Command: /nation new [nation] *[capital]
 	 *
-	 * @param player - Player creating the new nation.
-	 * @param name - Nation name.
-	 * @param capitalTown - Capital city town.
-	 * @param noCharge - charging for creation - /ta nation new NAME CAPITAL has no charge.
+	 * @param sender Sender who initiated the creation of the nation.
+	 * @param name Nation name.
+	 * @param capitalTown Capital city town.
+	 * @param noCharge charging for creation - /ta nation new NAME CAPITAL has no charge.
 	 */
-	public static void newNation(Player player, String name, Town capitalTown, boolean noCharge) {
+	public static void newNation(CommandSender sender, String name, Town capitalTown, boolean noCharge) {
 
 		try {
 			if (capitalTown.hasNation())
@@ -995,24 +999,24 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 					try {
 						newNation(finalName, capitalTown);
 					} catch (AlreadyRegisteredException | NotRegisteredException e) {
-						TownyMessaging.sendErrorMsg(player, e.getMessage(player));
+						TownyMessaging.sendErrorMsg(sender, e.getMessage(sender));
 						return;
 					}
-					TownyMessaging.sendGlobalMessage(Translatable.of("msg_new_nation", player.getName(), StringMgmt.remUnderscore(finalName)));
+					TownyMessaging.sendGlobalMessage(Translatable.of("msg_new_nation", sender.getName(), StringMgmt.remUnderscore(finalName)));
 
 				})
-					.setCost(new ConfirmationTransaction(() -> TownySettings.getNewNationPrice(), capitalTown.getAccount(), "New Nation Cost",
+					.setCost(new ConfirmationTransaction(TownySettings::getNewNationPrice, capitalTown.getAccount(), "New Nation Cost",
 							Translatable.of("msg_no_funds_new_nation2", TownySettings.getNewNationPrice())))
 					.setTitle(Translatable.of("msg_confirm_purchase", TownyEconomyHandler.getFormattedBalance(TownySettings.getNewNationPrice())))
-					.sendTo(player);
+					.sendTo(sender);
 				
 			// Or, it is free, so just make the nation.
 			} else {
 				newNation(filteredName, capitalTown);
-				TownyMessaging.sendGlobalMessage(Translatable.of("msg_new_nation", player.getName(), StringMgmt.remUnderscore(filteredName)));
+				TownyMessaging.sendGlobalMessage(Translatable.of("msg_new_nation", sender.getName(), StringMgmt.remUnderscore(filteredName)));
 			}
 		} catch (TownyException x) {
-			TownyMessaging.sendErrorMsg(player, x.getMessage(player));
+			TownyMessaging.sendErrorMsg(sender, x.getMessage(sender));
 		}
 	}
 

--- a/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -1331,7 +1331,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			} else if (split[1].equalsIgnoreCase("rank")) {
 
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOWN_RANK.getNode());
-				parseAdminTownRankCommand(catchConsole(sender), town, StringMgmt.remArgs(split, 2));
+				parseAdminTownRankCommand(sender, town, StringMgmt.remArgs(split, 2));
 			} else if (split[1].equalsIgnoreCase("toggle")) {
 				
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOWN_TOGGLE.getNode());
@@ -1377,7 +1377,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			} else if (split[1].equalsIgnoreCase("meta")) {
 
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOWN_META.getNode());
-				handleTownMetaCommand(catchConsole(sender), town, split);
+				handleTownMetaCommand(sender, town, split);
 			} else if (split[1].equalsIgnoreCase("giveboughtblocks")) {
 
 				giveTownBoughtTownBlocks(sender, town, StringMgmt.remArgs(split, 2));
@@ -1539,7 +1539,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		TownyMessaging.sendMsg(sender, Translatable.of("msg_town_level_overridden_with", town, level));
 	}
 
-	private void parseAdminTownRankCommand(Player player, Town town, String[] split) throws TownyException {
+	private void parseAdminTownRankCommand(CommandSender sender, Town town, String[] split) throws TownyException {
 		if (split.length < 3) {
 			throw new TownyException("Eg: /townyadmin town [townname] rank add/remove [resident] [rank]");
 		}
@@ -1566,10 +1566,10 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 				target.addTownRank(rank);
 				if (target.isOnline())
 					TownyMessaging.sendMsg(target, Translatable.of("msg_you_have_been_given_rank", "Town", rank));
-				TownyMessaging.sendMsg(player, Translatable.of("msg_you_have_given_rank", "Town", rank, target.getName()));
+				TownyMessaging.sendMsg(sender, Translatable.of("msg_you_have_given_rank", "Town", rank, target.getName()));
 			} else {
 				// Must already have this rank
-				TownyMessaging.sendMsg(player, Translatable.of("msg_resident_already_has_rank", target.getName(), "Town"));
+				TownyMessaging.sendMsg(sender, Translatable.of("msg_resident_already_has_rank", target.getName(), "Town"));
 				return;
 			}
 
@@ -1579,15 +1579,15 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 				target.removeTownRank(rank);
 				if (target.isOnline())
 					TownyMessaging.sendMsg(target, Translatable.of("msg_you_have_had_rank_taken", "Town", rank));
-				TownyMessaging.sendMsg(player, Translatable.of("msg_you_have_taken_rank_from", "Town", rank, target.getName()));
+				TownyMessaging.sendMsg(sender, Translatable.of("msg_you_have_taken_rank_from", "Town", rank, target.getName()));
 			} else {
 				// Doesn't have this rank
-				TownyMessaging.sendMsg(player, Translatable.of("msg_resident_doesnt_have_rank", target.getName(), "Town"));
+				TownyMessaging.sendMsg(sender, Translatable.of("msg_resident_doesnt_have_rank", target.getName(), "Town"));
 				return;
 			}
 
 		} else {
-			TownyMessaging.sendErrorMsg(player, Translatable.of("msg_err_invalid_property", split[0]));
+			TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_invalid_property", split[0]));
 			return;
 		}
 
@@ -1619,7 +1619,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 				if (capitalTown == null)
 					throw new TownyException(Translatable.of("msg_err_invalid_name", split[2]));
 
-				NationCommand.newNation(catchConsole(sender), split[1], capitalTown, true); // TODO: console should be able to create nations
+				NationCommand.newNation(sender, split[1], capitalTown, true);
 				return;
 			}
 			
@@ -2441,26 +2441,26 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		}
 	}
 
-	public static void handleTownMetaCommand(Player player, Town town, String[] split) throws TownyException {
+	public static void handleTownMetaCommand(CommandSender sender, Town town, String[] split) throws TownyException {
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
 
-		checkPermOrThrow(player, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOWN_META.getNode());
+		checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOWN_META.getNode());
 
 		if (split.length == 2) {
 			if (town.hasMeta()) {
-				TownyMessaging.sendMessage(player, ChatTools.formatTitle("Custom Meta Data"));
+				TownyMessaging.sendMessage(sender, ChatTools.formatTitle("Custom Meta Data"));
 				for (CustomDataField<?> field : town.getMetadata()) {
-					TownyMessaging.sendMessage(player, field.getKey() + " = " + field.getValue());
+					TownyMessaging.sendMessage(sender, field.getKey() + " = " + field.getValue());
 				}
 			} else {
-				TownyMessaging.sendErrorMsg(player, Translatable.of("msg_err_this_town_doesnt_have_any_associated_metadata"));
+				TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_this_town_doesnt_have_any_associated_metadata"));
 			}
 
 			return;
 		}
 
 		if (split.length < 4) {
-			HelpMenu.TA_TOWN_META.send(player);
+			HelpMenu.TA_TOWN_META.send(sender);
 			return;
 		}
 		
@@ -2479,7 +2479,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 
 					cdf.isValidType(val);
 				} catch (InvalidMetadataTypeException e) {
-					TownyMessaging.sendErrorMsg(player, e.getMessage());
+					TownyMessaging.sendErrorMsg(sender, e.getMessage());
 					return;
 				}
 
@@ -2487,42 +2487,39 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 				cdf.setValueFromString(val);
 
 				// Let user know that it was successful.
-				TownyMessaging.sendMsg(player, Translatable.of("msg_key_x_was_successfully_updated_to_x", mdKey, cdf.getValue()));
+				TownyMessaging.sendMsg(sender, Translatable.of("msg_key_x_was_successfully_updated_to_x", mdKey, cdf.getValue()));
 
 				// Save changes.
 				town.save();
 			}
 			else {
-				TownyMessaging.sendErrorMsg(player, Translatable.of("msg_err_key_x_is_not_part_of_this_town", mdKey));
+				TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_key_x_is_not_part_of_this_town", mdKey));
 			}
 		} else if (split[2].equalsIgnoreCase("add")) {
 
 			if (!townyUniverse.getRegisteredMetadataMap().containsKey(mdKey)){
-				TownyMessaging.sendErrorMsg(player, Translatable.of("msg_err_the_metadata_for_key_is_not_registered", mdKey));
+				TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_the_metadata_for_key_is_not_registered", mdKey));
 				return;
 			}
 			
 			CustomDataField<?> md = townyUniverse.getRegisteredMetadataMap().get(mdKey);
 
 			if (town.hasMeta() && town.hasMeta(md.getKey())) {
-				TownyMessaging.sendErrorMsg(player, Translatable.of("msg_err_key_x_already_exists", mdKey));
+				TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_key_x_already_exists", mdKey));
 				return;
 			}
 
-			TownyMessaging.sendMsg(player, Translatable.of("msg_custom_data_was_successfully_added_to_town"));
+			TownyMessaging.sendMsg(sender, Translatable.of("msg_custom_data_was_successfully_added_to_town"));
 			
-			town.addMetaData(md.clone());
+			town.addMetaData(md.clone(), true);
 			
 		} else if (split[2].equalsIgnoreCase("remove")) {
 
 			if (town.hasMeta() && town.hasMeta(mdKey)) {
-				CustomDataField<?> cdf = town.getMetadata(mdKey);
-				town.removeMetaData(cdf);
-				TownyMessaging.sendMsg(player, Translatable.of("msg_data_successfully_deleted"));
-				return;
-			}
-			
-			TownyMessaging.sendErrorMsg(player, Translatable.of("msg_err_key_cannot_be_deleted"));
+				town.removeMetaData(mdKey, true);
+				TownyMessaging.sendMsg(sender, Translatable.of("msg_data_successfully_deleted"));
+			} else 
+				TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_key_cannot_be_deleted"));
 		}
 	}
 	

--- a/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -74,10 +74,12 @@ import org.bukkit.World;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.conversations.ConversationContext;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.permissions.Permission;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
@@ -98,7 +100,7 @@ import java.util.stream.Stream;
 
 public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 
-	private static Towny plugin;
+	private final Towny plugin;
 	
 	private static final List<String> adminTabCompletes = Arrays.asList(
 		"plot",
@@ -248,31 +250,15 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		"all"
 	);
 
-	private boolean isConsole;
-	private Player player;
-	private CommandSender sender;
-
-	public TownyAdminCommand(Towny instance) {
-
-		plugin = instance;
+	public TownyAdminCommand(Towny towny) {
+		this.plugin = towny;
 	}
 
 	@Override
-	public boolean onCommand(CommandSender sender, Command cmd, String commandLabel, String[] args) {
-
-		this.sender = sender;
-
-		if (sender instanceof Player) {
-			player = (Player) sender;
-			isConsole = false;
-
-		} else {
-			isConsole = true;
-			this.player = null;
-		}
+	public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, String[] args) {
 
 		try {
-			return parseTownyAdminCommand(args);
+			return parseTownyAdminCommand(sender, args);
 		} catch (TownyException e) {
 			TownyMessaging.sendErrorMsg(sender, e.getMessage(sender));
 		}
@@ -584,11 +570,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		return Collections.emptyList();
 	}
 
-	private CommandSender getSender() {
-		return sender;
-	}
-
-	public boolean parseTownyAdminCommand(String[] split) throws TownyException {
+	public boolean parseTownyAdminCommand(CommandSender sender, String[] split) throws TownyException {
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
 		checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_SCREEN.getNode());
 		if (split.length == 0 || split[0].equalsIgnoreCase("?") || split[0].equalsIgnoreCase("help"))
@@ -597,36 +579,36 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 
 			if (split[0].equalsIgnoreCase("set")) {
 
-				adminSet(StringMgmt.remFirstArg(split));
+				adminSet(sender, StringMgmt.remFirstArg(split));
 				return true;
 			} else if (split[0].equalsIgnoreCase("resident")){
 				
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_RESIDENT.getNode());
-				parseAdminResidentCommand(StringMgmt.remFirstArg(split));
+				parseAdminResidentCommand(sender, StringMgmt.remFirstArg(split));
 				return true;
 
 			} else if (split[0].equalsIgnoreCase("town")) {
 
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOWN.getNode());
-				parseAdminTownCommand(StringMgmt.remFirstArg(split));
+				parseAdminTownCommand(sender, StringMgmt.remFirstArg(split));
 				return true;
 
 			} else if (split[0].equalsIgnoreCase("nation")) {
 
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_NATION.getNode());
-				parseAdminNationCommand(StringMgmt.remFirstArg(split));
+				parseAdminNationCommand(sender, StringMgmt.remFirstArg(split));
 				return true;
 
 			} else if (split[0].equalsIgnoreCase("toggle")) {
 
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOGGLE.getNode());
-				parseToggleCommand(StringMgmt.remFirstArg(split));
+				parseToggleCommand(sender, StringMgmt.remFirstArg(split));
 				return true;
 
 			} else if (split[0].equalsIgnoreCase("plot")) {
 
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_PLOT.getNode());
-				parseAdminPlotCommand(StringMgmt.remFirstArg(split));
+				parseAdminPlotCommand(catchConsole(sender), StringMgmt.remFirstArg(split));
 				return true;
 
 			}
@@ -634,7 +616,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			if (split[0].equalsIgnoreCase("givebonus") || split[0].equalsIgnoreCase("giveplots")) {
 
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_GIVEBONUS.getNode());
-				giveBonus(StringMgmt.remFirstArg(split));
+				giveBonus(sender, StringMgmt.remFirstArg(split));
 
 			} else if (split[0].equalsIgnoreCase("reload")) {
 				
@@ -643,24 +625,24 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 					switch (split[1]) {
 						case "db":
 						case "database":
-							reloadDatabase();
+							reloadDatabase(sender);
 							break;
 						case "config":
-							reloadConfig(false);
+							reloadConfig(sender, false);
 							break;
 						case "perms":
 						case "townyperms":
 						case "permissions":
-							reloadPerms();
+							reloadPerms(sender);
 							break;
 						case "language":
 						case "lang":
-							reloadLangs();
+							reloadLangs(sender);
 							break;
 						case "all":
 							// reloadDatabase() already reloads lang & config.
-							reloadPerms();
-							reloadDatabase();
+							reloadPerms(sender);
+							reloadDatabase(sender);
 							break;
 						default:
 							if (TownyCommandAddonAPI.hasCommand(CommandType.TOWNYADMIN_RELOAD, split[1]))
@@ -675,7 +657,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			} else if (split[0].equalsIgnoreCase("reset")) {
 
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_RESET.getNode());
-				Confirmation.runOnAccept(()-> reloadConfig(true))
+				Confirmation.runOnAccept(()-> reloadConfig(sender, true))
 					.setTitle(Translatable.of("this_will_reset_your_config"))
 					.sendTo(sender);
 
@@ -683,12 +665,12 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_BACKUP.getNode());
 				CompletableFuture.runAsync(new BackupTask())
-					.thenRun(()-> TownyMessaging.sendMsg(getSender(), Translatable.of("mag_backup_success")));
+					.thenRun(()-> TownyMessaging.sendMsg(sender, Translatable.of("mag_backup_success")));
 				
 			} else if (split[0].equalsIgnoreCase("database")) {
 
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_DATABASE.getNode());
-				parseAdminDatabaseCommand(StringMgmt.remFirstArg(split));
+				parseAdminDatabaseCommand(sender, StringMgmt.remFirstArg(split));
 				return true;				
 				
 			} else if (split[0].equalsIgnoreCase("mysqldump")) {
@@ -697,7 +679,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 				if (TownySettings.getSaveDatabase().equalsIgnoreCase("mysql") && TownySettings.getLoadDatabase().equalsIgnoreCase("mysql")) {
 					TownyDataSource dataSource = new TownyFlatFileSource(plugin, townyUniverse);
 					dataSource.saveAll();
-					TownyMessaging.sendMsg(getSender(), Translatable.of("msg_mysql_dump_success"));
+					TownyMessaging.sendMsg(sender, Translatable.of("msg_mysql_dump_success"));
 					return true;
 				} else 
 					throw new TownyException(Translatable.of("msg_err_mysql_not_being_used"));
@@ -718,16 +700,16 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_NEWHOUR.getNode());
 				TownyTimerHandler.newHour();
-				TownyMessaging.sendMsg(getSender(), Translatable.of("msg_newhour_success"));
+				TownyMessaging.sendMsg(sender, Translatable.of("msg_newhour_success"));
 
 			} else if (split[0].equalsIgnoreCase("purge")) {
 
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_PURGE.getNode());
-				purge(StringMgmt.remFirstArg(split));
+				purge(sender, StringMgmt.remFirstArg(split));
 			} else if (split[0].equalsIgnoreCase("unclaim")) {
 
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_UNCLAIM.getNode());
-				parseAdminUnclaimCommand(StringMgmt.remFirstArg(split));
+				parseAdminUnclaimCommand(catchConsole(sender), StringMgmt.remFirstArg(split));
 				/*
 				 * else if (split[0].equalsIgnoreCase("seed") &&
 				 * TownySettings.getDebug()) seedTowny(); else if
@@ -738,39 +720,39 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			} else if (split[0].equalsIgnoreCase("checkperm")) {
 				
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_CHECKPERM.getNode());
-				parseAdminCheckPermCommand(StringMgmt.remFirstArg(split));
+				parseAdminCheckPermCommand(sender, StringMgmt.remFirstArg(split));
 			} else if (split[0].equalsIgnoreCase("checkoutposts")) {
 				
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_CHECKOUTPOSTS.getNode());
-				parseAdminCheckOutpostsCommand(null);
+				parseAdminCheckOutpostsCommand(sender, null);
 			} else if (split[0].equalsIgnoreCase("townyperms")) {
 				
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOWNYPERMS.getNode());
-				parseAdminTownyPermsCommand(StringMgmt.remFirstArg(split));
+				parseAdminTownyPermsCommand(sender, StringMgmt.remFirstArg(split));
 				
 			} else if (split[0].equalsIgnoreCase("tpplot")) {
 				
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TPPLOT.getNode());
-				parseAdminTpPlotCommand(StringMgmt.remFirstArg(split));
+				parseAdminTpPlotCommand(catchConsole(sender), StringMgmt.remFirstArg(split));
 
 			} else if (split[0].equalsIgnoreCase("depositall")) {
 				if (!TownyEconomyHandler.isActive())
 					throw new TownyException(Translatable.of("msg_err_no_economy"));
 				
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_DEPOSITALL.getNode());
-				parseAdminDepositAllCommand(StringMgmt.remFirstArg(split));
+				parseAdminDepositAllCommand(sender, StringMgmt.remFirstArg(split));
 			} else if (split[0].equalsIgnoreCase("resetbanks")) {
 				if (!TownyEconomyHandler.isActive())
 					throw new TownyException(Translatable.of("msg_err_no_economy"));
 				
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_RESETBANKS.getNode());
-				parseAdminResetBanksCommand(StringMgmt.remFirstArg(split));
+				parseAdminResetBanksCommand(sender, StringMgmt.remFirstArg(split));
 			} else if (split[0].equalsIgnoreCase("install")) {
 
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_INSTALL.getNode());
-				Towny.getAdventure().sender(getSender()).sendMessage(Component.text(Translatable.of("msg_setup_full_guide_link").forLocale(getSender())).clickEvent(ClickEvent.openUrl("https://github.com/TownyAdvanced/Towny/wiki/Installation")));
+				Towny.getAdventure().sender(sender).sendMessage(Component.text(Translatable.of("msg_setup_full_guide_link").forLocale(sender)).clickEvent(ClickEvent.openUrl("https://github.com/TownyAdvanced/Towny/wiki/Installation")));
 				
-				new SetupConversation(getSender()).runOnResponse(response -> {
+				new SetupConversation(sender).runOnResponse(response -> {
 					ConversationContext context = (ConversationContext) response;
 					
 					toggleWildernessUsage(parseBoolean(context.getSessionData(0)));
@@ -784,12 +766,12 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 					}
 					
 					TownySettings.saveConfig();
-					TownyMessaging.sendMsg(getSender(), Translatable.of("msg_setup_success"));
+					TownyMessaging.sendMsg(sender, Translatable.of("msg_setup_success"));
 				});
 			} else if (TownyCommandAddonAPI.hasCommand(CommandType.TOWNYADMIN, split[0])) {
-				TownyCommandAddonAPI.getAddonCommand(CommandType.TOWNYADMIN, split[0]).execute(getSender(), "townyadmin", split);
+				TownyCommandAddonAPI.getAddonCommand(CommandType.TOWNYADMIN, split[0]).execute(sender, "townyadmin", split);
 			}  else {
-				TownyMessaging.sendErrorMsg(getSender(), Translatable.of("msg_err_invalid_sub"));
+				TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_invalid_sub"));
 				return false;
 			}
 		}
@@ -807,9 +789,9 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		};
 	}
 
-	private void parseAdminTownyPermsCommand(String[] args) {
+	private void parseAdminTownyPermsCommand(CommandSender sender, String[] args) {
 
-		if (args.length == 0 || args[0].equalsIgnoreCase("?") || (args.length > 0 && !adminTownyPermsCompletes.contains(args[0]))) {
+		if (args.length == 0 || args[0].equalsIgnoreCase("?") || !adminTownyPermsCompletes.contains(args[0])) {
 			HelpMenu.TA_TOWNYPERMS.send(sender);
 			return;
 		}
@@ -823,12 +805,12 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 					break;
 				case "group":
 					// Alter a groups permission nodes.
-					parseAdminTownypermsGroupCommand(StringMgmt.remFirstArg(args));
+					parseAdminTownypermsGroupCommand(sender, StringMgmt.remFirstArg(args));
 					break;
 				case "townrank":
 				case "nationrank":
 					// Create and remove town and nation ranks.
-					parseAdminTownypermsRankCommand(args);
+					parseAdminTownypermsRankCommand(sender, args);
 					break;
 				default:
 				}
@@ -838,7 +820,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		}
 	}
 
-	private void parseAdminTownypermsGroupCommand(String[] args) throws TownyException {
+	private void parseAdminTownypermsGroupCommand(CommandSender sender, String[] args) throws TownyException {
 		//ta townyperms group GROUPNAME add|remove NODE
 		//                    ^ args[0]
 		if (args.length == 0 || args[0].equalsIgnoreCase("?")) {
@@ -853,7 +835,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 
 		// /ta townyperms group GROUPNAME: display nodes held by group.
 		if (args.length == 1) {
-			displayNodesHelpByGroup(group, groupNodes);
+			displayNodesHelpByGroup(sender, group, groupNodes);
 			return;
 		}
 		
@@ -887,10 +869,11 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			TownyMessaging.sendMsg(sender, Translatable.of("msg_successfully_added_node_to_group", node, group));
 		else 
 			TownyMessaging.sendMsg(sender, Translatable.of("msg_successfully_removed_node_from_group", node, group));
-		reloadPerms();
+		
+		reloadPerms(sender);
 	}
 	
-	private void displayNodesHelpByGroup(String group, List<String> groupNodes) {
+	private void displayNodesHelpByGroup(CommandSender sender, String group, List<String> groupNodes) {
 		if (groupNodes.size() > 0) {
 			TownyMessaging.sendMessage(sender, ChatTools.formatTitle(Translatable.of("msg_title_group_permissions", StringMgmt.capitalize(group)).forLocale(sender)));
 			for (String node : groupNodes)
@@ -901,7 +884,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		}
 	}
 
-	private void parseAdminTownypermsRankCommand(String[] args) throws TownyException {
+	private void parseAdminTownypermsRankCommand(CommandSender sender, String[] args) throws TownyException {
 		//ta townyperms townrank|nationrank add|remove RANKNAME
 		//              ^ args[0]
 		if (args.length == 0 || args[0].equalsIgnoreCase("?")) {
@@ -965,10 +948,11 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			TownyMessaging.sendMsg(sender, Translatable.of("msg_successfully_add_rank_to_the_town_or_nation_rank", rank, args[0]));
 		else 
 			TownyMessaging.sendMsg(sender, Translatable.of("msg_successfully_removed_rank_from_the_town_or_nation_rank", rank, args[0]));
-		reloadPerms();
+		
+		reloadPerms(sender);
 	}
 
-	private void parseAdminDatabaseCommand(String[] split) {
+	private void parseAdminDatabaseCommand(CommandSender sender, String[] split) {
 	
 		if (split.length == 0 || split[0].equalsIgnoreCase("?")) {
 			HelpMenu.TA_DATABASE.send(sender);
@@ -977,20 +961,20 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		
 		if (split[0].equalsIgnoreCase("save")) {
 			if (TownyUniverse.getInstance().getDataSource().saveAll())
-				TownyMessaging.sendMsg(getSender(), Translatable.of("msg_save_success"));
+				TownyMessaging.sendMsg(sender, Translatable.of("msg_save_success"));
 	
 		} else if (split[0].equalsIgnoreCase("load")) {
 			TownyUniverse.getInstance().clearAllObjects();			
 			if (TownyUniverse.getInstance().getDataSource().loadAll()) {
-				TownyMessaging.sendMsg(getSender(), Translatable.of("msg_load_success"));
+				TownyMessaging.sendMsg(sender, Translatable.of("msg_load_success"));
 				BukkitTools.fireEvent(new TownyLoadedDatabaseEvent());
 			}
 		} else if (split[0].equalsIgnoreCase("remove")) {
-			parseAdminDatabaseRemoveCommand(StringMgmt.remFirstArg(split));
+			parseAdminDatabaseRemoveCommand(sender, StringMgmt.remFirstArg(split));
 		}
 	}
 
-	private void parseAdminDatabaseRemoveCommand(String[] split) {
+	private void parseAdminDatabaseRemoveCommand(CommandSender sender, String[] split) {
 		if (split.length == 0 || split[0].equalsIgnoreCase("?")) {
 			TownyMessaging.sendMessage(sender, ChatTools.formatTitle("/townyadmin database remove"));
 			TownyMessaging.sendMessage(sender, ChatTools.formatCommand(Translatable.of("admin_sing").forLocale(sender), "/townyadmin database remove", "titles", "Removes all titles and surnames from every resident."));
@@ -998,23 +982,22 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		}
 		
 		if (split[0].equalsIgnoreCase("titles")) {
-			TownyUniverse.getInstance().getResidents().stream()
+			TownyUniverse.getInstance().getResidents()
 				.forEach(resident -> {
 					resident.setTitle("");
 					resident.setSurname("");
 					resident.save();
 				});
-			TownyMessaging.sendMsg(getSender(), Translatable.of("msg_ta_removed_all_titles_and_surnames_removed"));
+			TownyMessaging.sendMsg(sender, Translatable.of("msg_ta_removed_all_titles_and_surnames_removed"));
 		}
 		
 	}
 
-	private void parseAdminPlotCommand(String[] split) throws TownyException {
+	private void parseAdminPlotCommand(Player player, String[] split) throws TownyException {
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
-		catchConsole(sender);
 
-		if (split.length == 0 || split.length < 1 || split[0].equalsIgnoreCase("?")) {
-			HelpMenu.TA_PLOT.send(sender);
+		if (split.length < 1 || split[0].equalsIgnoreCase("?")) {
+			HelpMenu.TA_PLOT.send(player);
 			return;
 		}
 
@@ -1027,17 +1010,16 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			checkPermOrThrow(player, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_PLOT_CLAIM.getNode());
 
 			if (split.length == 1) {
-				TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_error_ta_plot_claim"));
+				TownyMessaging.sendErrorMsg(player, Translatable.of("msg_error_ta_plot_claim"));
 				return;
 			}			
 			Optional<Resident> resOpt = townyUniverse.getResidentOpt(split[1]);
 			
 			if (!resOpt.isPresent()) {
-				TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_error_no_player_with_that_name", split[1]));
+				TownyMessaging.sendErrorMsg(player, Translatable.of("msg_error_no_player_with_that_name", split[1]));
 				return;
 			}
 
-			Player player = BukkitTools.getPlayerExact(sender.getName());
 			String world = player.getWorld().getName();
 			List<WorldCoord> selection = new ArrayList<>();
 			selection.add(new WorldCoord(world, Coord.parseCoord(player)));
@@ -1045,11 +1027,11 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		} else if (split[0].equalsIgnoreCase("claimedat")) {
 			checkPermOrThrow(player, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_PLOT_CLAIMEDAT.getNode());
 			
-			WorldCoord wc = WorldCoord.parseWorldCoord((Player) getSender());
+			WorldCoord wc = WorldCoord.parseWorldCoord(player);
 			if (!wc.hasTownBlock() || wc.getTownBlock().getClaimedAt() == 0)
 				throw new NotRegisteredException();
 			
-			TownyMessaging.sendMsg(sender, Translatable.of("msg_plot_perm_claimed_at").append(" " + TownyFormatter.fullDateFormat.format(wc.getTownBlock().getClaimedAt())));
+			TownyMessaging.sendMsg(player, Translatable.of("msg_plot_perm_claimed_at").append(" " + TownyFormatter.fullDateFormat.format(wc.getTownBlock().getClaimedAt())));
 		} else if (split[0].equalsIgnoreCase("trust")) {
 			checkPermOrThrow(player, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_PLOT_TRUST.getNode());
 			
@@ -1057,7 +1039,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		}
 	}
 
-	private void parseAdminCheckPermCommand(String[] split) throws TownyException {
+	private void parseAdminCheckPermCommand(CommandSender sender, String[] split) throws TownyException {
 		
 		if (split.length !=2 ) {
 			throw new TownyException(Translatable.of("msg_err_invalid_input", "Eg: /ta checkperm {name} {node}"));
@@ -1073,7 +1055,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_perm_false"));
 	}
 
-	private void parseAdminCheckOutpostsCommand(@Nullable Town specificTown) {
+	private void parseAdminCheckOutpostsCommand(CommandSender sender, @Nullable Town specificTown) {
 		List<Town> towns = new ArrayList<>();
 		if (specificTown == null) 
 			towns.addAll(TownyAPI.getInstance().getTowns());
@@ -1095,13 +1077,12 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		TownyMessaging.sendMsg(sender, Translatable.of("msg_removed_x_invalid_outpost_spawns", removed));
 	}
 
-	private void parseAdminTpPlotCommand(String[] split) throws TownyException {
+	private void parseAdminTpPlotCommand(Player player, String[] split) throws TownyException {
 
 		if (split.length != 3) {
 			throw new TownyException(Translatable.of("msg_err_invalid_input", "Eg: /ta tpplot world x z"));
 		}
 		
-		Player player = (Player) sender;
 		World world = Bukkit.getWorld(split[0]);
 
 		if (world == null)
@@ -1122,7 +1103,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		});
 	}
 
-	private void giveBonus(String[] split) throws TownyException {
+	private void giveBonus(CommandSender sender, String[] split) throws TownyException {
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
 		Town town;
 		Resident target = null;
@@ -1145,7 +1126,9 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		int extraBlocks = MathUtil.getIntOrThrow(split[1]);
 
 		town.setBonusBlocks(town.getBonusBlocks() + extraBlocks);
-		TownyMessaging.sendMsg(getSender(), Translatable.of("msg_give_total", town.getName(), split[1], town.getBonusBlocks()));
+		TownyMessaging.sendMsg(sender, Translatable.of("msg_give_total", town.getName(), split[1], town.getBonusBlocks()));
+		
+		boolean isConsole = sender instanceof ConsoleCommandSender;
 		if (!isConsole || isTown)
 			TownyMessaging.sendTownMessagePrefixed(town, Translatable.of("msg_you_have_been_given_bonus_blocks", extraBlocks)); 
 		if (isConsole && !isTown) {
@@ -1158,14 +1141,12 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 
 	}
 
-	public void parseAdminUnclaimCommand(String[] split) {
+	public void parseAdminUnclaimCommand(Player player, String[] split) {
 
 		if (split.length == 1 && split[0].equalsIgnoreCase("?")) {
-			HelpMenu.TA_UNCLAIM.send((CommandSender) getSender());
+			HelpMenu.TA_UNCLAIM.send(player);
 		} else {
 			try {
-				catchConsole(sender);
-
 				List<WorldCoord> selection;
 				selection = AreaSelectionUtil.selectWorldCoordArea(null, new WorldCoord(player.getWorld().getName(), Coord.parseCoord(player)), split);
 				selection = AreaSelectionUtil.filterOutWildernessBlocks(selection);
@@ -1176,13 +1157,13 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 				new TownClaim(plugin, player, null, selection, false, false, true).start();
 
 			} catch (TownyException x) {
-				TownyMessaging.sendErrorMsg(sender, x.getMessage());
+				TownyMessaging.sendErrorMsg(player, x.getMessage());
 				return;
 			}
 		}
 	}
 
-	public void parseAdminResidentCommand(String[] split) throws TownyException {
+	public void parseAdminResidentCommand(CommandSender sender, String[] split) throws TownyException {
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
 		if (split.length == 0 || split[0].equalsIgnoreCase("?")) {
 			HelpMenu.TA_RESIDENT.send(sender);
@@ -1193,7 +1174,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			Resident resident = getResidentOrThrow(split[0]);
 
 			if (split.length == 1) {
-				Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> TownyMessaging.sendStatusScreen(sender, TownyFormatter.getStatus(resident, player)));
+				Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> TownyMessaging.sendStatusScreen(sender, TownyFormatter.getStatus(resident, sender)));
 				return;
 			}
 
@@ -1212,10 +1193,8 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 					HelpMenu.TA_RESIDENT_FRIEND.send(sender);
 					return;
 				}
-				if (isConsole)
-					throw new TownyException("/ta resident {resident} friend cannot be run from console.");
 
-				ResidentCommand.residentFriend(BukkitTools.getPlayerExact(sender.getName()), StringMgmt.remArgs(split, 2), true, resident);
+				ResidentCommand.residentFriend(catchConsole(sender), StringMgmt.remArgs(split, 2), true, resident);
 
 			} else if(split[1].equalsIgnoreCase("unjail")) {
 				
@@ -1229,11 +1208,11 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 				residentDelete(sender, split[0]);
 			}
 		} catch (TownyException e) {
-			TownyMessaging.sendErrorMsg(getSender(), e.getMessage(getSender()));
+			TownyMessaging.sendErrorMsg(sender, e.getMessage(sender));
 		}
 	}
 	
-	public void parseAdminTownCommand(String[] split) throws TownyException {
+	public void parseAdminTownCommand(CommandSender sender, String[] split) throws TownyException {
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
 
 		if (split.length == 0 || split[0].equalsIgnoreCase("?")) {
@@ -1252,6 +1231,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOWN_NEW.getNode());
 
+				Player player = sender instanceof Player p ? p : null;
 				Resident resident;
 				if ("npc".equalsIgnoreCase(split[2]) && player != null) // Avoid creating a new npc resident if command is ran from console.
 					resident = ResidentUtil.createAndGetNPCResident();
@@ -1259,7 +1239,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 					resident = TownyUniverse.getInstance().getResident(split[2]);
 				
 				if (resident == null) {
-					TownyMessaging.sendErrorMsg(getSender(), Translatable.of("msg_err_not_registered_1", split[2]));
+					TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_not_registered_1", split[2]));
 					return;
 				}
 				
@@ -1278,7 +1258,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			Town town = townyUniverse.getTown(split[0]);
 			
 			if (town == null) {
-				TownyMessaging.sendErrorMsg(getSender(), Translatable.of("msg_err_not_registered_1", split[0]));
+				TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_not_registered_1", split[0]));
 				return;
 			}
 			
@@ -1296,7 +1276,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 				// Give admins the ability to invite a player to town, invite still requires acceptance.
 				if (split.length < 3)
 					throw new TownyException(Translatable.of("msg_err_invalid_input", "/ta town TOWNNAME invite PLAYERNAME"));
-				TownCommand.townAdd(getSender(), town, StringMgmt.remArgs(split, 2));
+				TownCommand.townAdd(sender, town, StringMgmt.remArgs(split, 2));
 				
 			} else if (split[1].equalsIgnoreCase("add")) {
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOWN_ADD.getNode());
@@ -1311,7 +1291,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			} else if (split[1].equalsIgnoreCase("kick")) {
 
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOWN_KICK.getNode());
-				TownCommand.townKickResidents(getSender(), town.getMayor(), town, ResidentUtil.getValidatedResidentsOfTown(getSender(), town, StringMgmt.remArgs(split, 2)));
+				TownCommand.townKickResidents(sender, town.getMayor(), town, ResidentUtil.getValidatedResidentsOfTown(sender, town, StringMgmt.remArgs(split, 2)));
 
 			} else if (split[1].equalsIgnoreCase("delete")) {
 
@@ -1332,26 +1312,26 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 
 				if (!NameValidation.isBlacklistName(name) && (TownySettings.areNumbersAllowedInTownNames() || !NameValidation.containsNumbers(name))) {
 					townyUniverse.getDataSource().renameTown(town, name);
-					TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_town_set_name", ((getSender() instanceof Player) ? player.getName() : "CONSOLE"), town.getName()));
-					TownyMessaging.sendMsg(getSender(), Translatable.of("msg_town_set_name", ((getSender() instanceof Player) ? player.getName() : "CONSOLE"), town.getName()));
+					TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_town_set_name", getSenderFormatted(sender), town.getName()));
+					TownyMessaging.sendMsg(sender, Translatable.of("msg_town_set_name", getSenderFormatted(sender), town.getName()));
 				} else {
-					TownyMessaging.sendErrorMsg(getSender(), Translatable.of("msg_invalid_name"));
+					TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_invalid_name"));
 				}
 				
 			} else if (split[1].equalsIgnoreCase("spawn")) {
 
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOWN_SPAWN.getNode());
-				SpawnUtil.sendToTownySpawn(player, StringMgmt.remArgs(split, 2), town, "", false, false, SpawnType.TOWN);
+				SpawnUtil.sendToTownySpawn(catchConsole(sender), StringMgmt.remArgs(split, 2), town, "", false, false, SpawnType.TOWN);
 
 			} else if (split[1].equalsIgnoreCase("outpost")) {
 
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOWN_OUTPOST.getNode());
-				SpawnUtil.sendToTownySpawn(player, StringMgmt.remArgs(split, 2), town, "", true, false, SpawnType.TOWN);
+				SpawnUtil.sendToTownySpawn(catchConsole(sender), StringMgmt.remArgs(split, 2), town, "", true, false, SpawnType.TOWN);
 
 			} else if (split[1].equalsIgnoreCase("rank")) {
 
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOWN_RANK.getNode());
-				parseAdminTownRankCommand(player, town, StringMgmt.remArgs(split, 2));
+				parseAdminTownRankCommand(catchConsole(sender), town, StringMgmt.remArgs(split, 2));
 			} else if (split[1].equalsIgnoreCase("toggle")) {
 				
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOWN_TOGGLE.getNode());
@@ -1397,14 +1377,14 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			} else if (split[1].equalsIgnoreCase("meta")) {
 
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOWN_META.getNode());
-				handleTownMetaCommand(player, town, split);
+				handleTownMetaCommand(catchConsole(sender), town, split);
 			} else if (split[1].equalsIgnoreCase("giveboughtblocks")) {
 
-				giveTownBoughtTownBlocks(town, StringMgmt.remArgs(split, 2));
+				giveTownBoughtTownBlocks(sender, town, StringMgmt.remArgs(split, 2));
 			} else if (split[1].equalsIgnoreCase("settownlevel")) {
 
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOWN_SETTOWNLEVEL.getNode());
-				setTownLevel(town, StringMgmt.remArgs(split, 2));
+				setTownLevel(sender, town, StringMgmt.remArgs(split, 2));
 			} else if (split[1].equalsIgnoreCase("bankhistory")) {
 
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOWN_BANKHISTORY.getNode());
@@ -1412,7 +1392,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 				if (split.length > 2)
 					pages = MathUtil.getIntOrThrow(split[2]);
 				
-				town.generateBankHistoryBook(player, pages);
+				town.generateBankHistoryBook(catchConsole(sender), pages);
 			} else if (split[1].equalsIgnoreCase("deposit")) {
 				
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOWN_DEPOSIT.getNode());
@@ -1427,7 +1407,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 				
 				if (town.getAccount().deposit(amount, "Admin Deposit")) {
 					// Send notifications
-					Translatable depositMessage = Translatable.of("msg_xx_deposited_xx", getSenderFormatted(), amount,  Translatable.of("town_sing"));
+					Translatable depositMessage = Translatable.of("msg_xx_deposited_xx", getSenderFormatted(sender), amount,  Translatable.of("town_sing"));
 					TownyMessaging.sendMsg(sender, depositMessage);
 					TownyMessaging.sendPrefixedTownMessage(town, depositMessage);
 				} else {
@@ -1448,7 +1428,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 				
 				if (town.getAccount().withdraw(amount, "Admin Withdraw")) {				
 					// Send notifications
-					Translatable withdrawMessage = Translatable.of("msg_xx_withdrew_xx", getSenderFormatted(), amount,  Translatable.of("town_sing"));
+					Translatable withdrawMessage = Translatable.of("msg_xx_withdrew_xx", getSenderFormatted(sender), amount,  Translatable.of("town_sing"));
 					TownyMessaging.sendMsg(sender, withdrawMessage);
 					TownyMessaging.sendPrefixedTownMessage(town, withdrawMessage);
 				} else {
@@ -1479,7 +1459,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 				town.save();
 			} else if (split[1].equalsIgnoreCase("checkoutposts")) {
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOWN_CHECKOUTPOSTS.getNode());
-				parseAdminCheckOutpostsCommand(town);
+				parseAdminCheckOutpostsCommand(sender, town);
 			} else if (split[1].equalsIgnoreCase("trust")) {
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOWN_TRUST.getNode());
 				TownCommand.parseTownTrustCommand(sender, StringMgmt.remArgs(split, 2), town);
@@ -1509,12 +1489,12 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			}
 
 		} catch (TownyException e) {
-			TownyMessaging.sendErrorMsg(getSender(), e.getMessage());
+			TownyMessaging.sendErrorMsg(sender, e.getMessage());
 		}
 		
 	}
 
-	private void giveTownBoughtTownBlocks(Town town, String[] split) throws TownyException {
+	private void giveTownBoughtTownBlocks(CommandSender sender, Town town, String[] split) throws TownyException {
 		// The number is missing.
 		if (split.length == 0)
 			throw new TownyException("Eg: /townyadmin town [townname] giveboughtblocks 2");
@@ -1537,7 +1517,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		TownyMessaging.sendMsg(sender, Translatable.of("msg_purchased_blocks_changed", town, blocks, town.getPurchasedBlocks()));
 	}
 
-	private void setTownLevel(Town town, String[] split) throws TownyException {
+	private void setTownLevel(CommandSender sender, Town town, String[] split) throws TownyException {
 		// The number is missing.
 		if (split.length == 0)
 			throw new TownyException("Eg: /townyadmin town [townname] settownlevel 2");
@@ -1619,7 +1599,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		
 	}
 
-	public void parseAdminNationCommand(String[] split) throws TownyException {
+	public void parseAdminNationCommand(CommandSender sender, String[] split) throws TownyException {
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
 
 		if (split.length == 0 || split[0].equalsIgnoreCase("?")) {
@@ -1639,7 +1619,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 				if (capitalTown == null)
 					throw new TownyException(Translatable.of("msg_err_invalid_name", split[2]));
 
-				NationCommand.newNation(player, split[1], capitalTown, true);
+				NationCommand.newNation(catchConsole(sender), split[1], capitalTown, true); // TODO: console should be able to create nations
 				return;
 			}
 			
@@ -1679,8 +1659,9 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_NATION_DELETE.getNode());
 				Confirmation.runOnAccept(() -> {
-					if (!isConsole)
+					if (sender instanceof Player)
 						TownyMessaging.sendMsg(sender, Translatable.of("nation_deleted_by_admin", nation.getName()));
+					
 					TownyUniverse.getInstance().getDataSource().removeNation(nation);
 					TownyMessaging.sendGlobalMessage(Translatable.of("MSG_DEL_NATION", nation.getName()));
 				}).sendTo(sender);
@@ -1700,10 +1681,10 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 
 				if (!NameValidation.isBlacklistName(name) && (TownySettings.areNumbersAllowedInNationNames() || !NameValidation.containsNumbers(name))) {
 					townyUniverse.getDataSource().renameNation(nation, name);
-					TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_nation_set_name", ((getSender() instanceof Player) ? player.getName() : "CONSOLE"), nation.getName()));
-					TownyMessaging.sendMsg(getSender(), Translatable.of("msg_nation_set_name", ((getSender() instanceof Player) ? player.getName() : "CONSOLE"), nation.getName()));
+					TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_nation_set_name", getSenderFormatted(sender), nation.getName()));
+					TownyMessaging.sendMsg(sender, Translatable.of("msg_nation_set_name", getSenderFormatted(sender), nation.getName()));
 				} else
-					TownyMessaging.sendErrorMsg(getSender(), Translatable.of("msg_invalid_name"));
+					TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_invalid_name"));
 
 			} else if (split[1].equalsIgnoreCase("merge")) {
 
@@ -1721,12 +1702,12 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 					TownyMessaging.sendGlobalMessage(Translatable.of("nation1_has_merged_with_nation2", nation, remainingNation));
 				}).sendTo(sender);
 
-			} else if(split[1].equalsIgnoreCase("set")) {
+			} else if (split[1].equalsIgnoreCase("set")) {
 
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_NATION_SET.getNode());
-				NationCommand.nationSet(player, StringMgmt.remArgs(split, 2), true, nation);
+				NationCommand.nationSet(sender, StringMgmt.remArgs(split, 2), true, nation);
 
-			} else if(split[1].equalsIgnoreCase("toggle")) {
+			} else if (split[1].equalsIgnoreCase("toggle")) {
 
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_NATION_TOGGLE.getNode());
 				NationCommand.nationToggle(sender, StringMgmt.remArgs(split, 2), true, nation);
@@ -1738,11 +1719,11 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 					try {
 						pages = Integer.parseInt(split[2]);
 					} catch (NumberFormatException e) {
-						TownyMessaging.sendErrorMsg(player, Translatable.of("msg_error_must_be_int"));
+						TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_error_must_be_int"));
 						return;
 					}
 
-				nation.generateBankHistoryBook(player, pages);
+				nation.generateBankHistoryBook(catchConsole(sender), pages);
 			} else if (split[1].equalsIgnoreCase("deposit")) {
 
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_NATION_DEPOSIT.getNode());
@@ -1758,14 +1739,14 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 				try {
 					amount = Integer.parseInt(split[2]);
 				} catch (NumberFormatException ex) {
-					TownyMessaging.sendErrorMsg(player, Translatable.of("msg_error_must_be_int"));
+					TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_error_must_be_int"));
 					return;
 				}
 
 				nation.getAccount().deposit(amount, "Admin Deposit");
 				
 				// Send notifications
-				Translatable depositMessage = Translatable.of("msg_xx_deposited_xx", (isConsole ? "Console" : player.getName()), amount,  Translatable.of("nation_sing"));
+				Translatable depositMessage = Translatable.of("msg_xx_deposited_xx", getSenderFormatted(sender), amount,  Translatable.of("nation_sing"));
 				TownyMessaging.sendMsg(sender, depositMessage);
 				TownyMessaging.sendPrefixedNationMessage(nation, depositMessage);
 			}
@@ -1784,14 +1765,14 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 				try {
 					amount = Integer.parseInt(split[2]);
 				} catch (NumberFormatException ex) {
-					TownyMessaging.sendErrorMsg(player, Translatable.of("msg_error_must_be_int"));
+					TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_error_must_be_int"));
 					return;
 				}
 
 				nation.getAccount().withdraw(amount, "Admin Withdraw");
 				
 				// Send notifications
-				Translatable withdrawMessage = Translatable.of("msg_xx_withdrew_xx", (isConsole ? "Console" : player.getName()), amount,  Translatable.of("nation_sing"));
+				Translatable withdrawMessage = Translatable.of("msg_xx_withdrew_xx", getSenderFormatted(sender), amount,  Translatable.of("nation_sing"));
 				TownyMessaging.sendMsg(sender, withdrawMessage);
 				TownyMessaging.sendPrefixedNationMessage(nation, withdrawMessage);
 			}
@@ -1817,7 +1798,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 				
 				rank = TownyPerms.matchNationRank(split[4]);
 				if (rank == null) {
-					TownyMessaging.sendErrorMsg(player, Translatable.of("msg_unknown_rank_available_ranks", split[4], StringMgmt.join(TownyPerms.getNationRanks(), ", ")));
+					TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_unknown_rank_available_ranks", split[4], StringMgmt.join(TownyPerms.getNationRanks(), ", ")));
 					return;
 				}
 
@@ -1830,12 +1811,12 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 								TownyMessaging.sendMsg(target, Translatable.of("msg_you_have_been_given_rank", "Nation", rank));
 								plugin.deleteCache(TownyAPI.getInstance().getPlayer(target));
 							}
-							TownyMessaging.sendMsg(player, Translatable.of("msg_you_have_given_rank", "Nation", rank, target.getName()));
+							TownyMessaging.sendMsg(sender, Translatable.of("msg_you_have_given_rank", "Nation", rank, target.getName()));
 							target.save();
 							return;
 						} else {
 							// Already has the rank.
-							TownyMessaging.sendMsg(player, Translatable.of("msg_resident_already_has_rank", target.getName(), "Nation"));
+							TownyMessaging.sendMsg(sender, Translatable.of("msg_resident_already_has_rank", target.getName(), "Nation"));
 							return;
 						}
 					case "remove":
@@ -1846,12 +1827,12 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 								TownyMessaging.sendMsg(target, Translatable.of("msg_you_have_had_rank_taken", "Nation", rank));
 								plugin.deleteCache(TownyAPI.getInstance().getPlayer(target));
 							}
-							TownyMessaging.sendMsg(player, Translatable.of("msg_you_have_taken_rank_from", "Nation", rank, target.getName()));
+							TownyMessaging.sendMsg(sender, Translatable.of("msg_you_have_taken_rank_from", "Nation", rank, target.getName()));
 							target.save();
 							return;
 						} else {
 							// Doesn't have the rank.
-							TownyMessaging.sendMsg(player, Translatable.of("msg_resident_doesnt_have_rank", target.getName(), "Nation"));
+							TownyMessaging.sendMsg(sender, Translatable.of("msg_resident_doesnt_have_rank", target.getName(), "Nation"));
 							return;
 						}
 					default:
@@ -1862,13 +1843,13 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_NATION_ALLY.getNode());
 				if (split.length < 4) {
-					TownyMessaging.sendErrorMsg(getSender(), Translatable.of("msg_err_invalid_input", "/ta nation [nation] ally [add/remove] [nation]"));
+					TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_invalid_input", "/ta nation [nation] ally [add/remove] [nation]"));
 					return;
 				}
 				
 				Nation ally = townyUniverse.getNation(split[3]);
 				if (ally == null || ally.equals(nation)) {
-					TownyMessaging.sendErrorMsg(getSender(), Translatable.of("msg_err_invalid_name", split[3]));
+					TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_invalid_name", split[3]));
 					return;
 				}
 
@@ -1889,9 +1870,9 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 						plugin.resetCache();
 						TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_added_ally", ally.getName()));
 						TownyMessaging.sendPrefixedNationMessage(ally, Translatable.of("msg_added_ally", nation.getName()));
-						TownyMessaging.sendMsg(getSender(), Translatable.of("msg_ta_allies_enemies_updated", nation.getName()));
+						TownyMessaging.sendMsg(sender, Translatable.of("msg_ta_allies_enemies_updated", nation.getName()));
 					} else
-						TownyMessaging.sendErrorMsg(getSender(), Translatable.of("msg_err_nation_already_allied_with_2", nation.getName(), ally.getName()));
+						TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_nation_already_allied_with_2", nation.getName(), ally.getName()));
 				} else if (split[2].equalsIgnoreCase("remove")) {
 					if (nation.hasAlly(ally)) {
 						nation.removeAlly(ally);
@@ -1903,22 +1884,22 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 						plugin.resetCache();
 						TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_removed_ally", ally.getName()));
 						TownyMessaging.sendPrefixedNationMessage(ally, Translatable.of("msg_removed_ally", nation.getName()));
-						TownyMessaging.sendMsg(getSender(), Translatable.of("msg_ta_allies_enemies_updated", nation.getName()));
+						TownyMessaging.sendMsg(sender, Translatable.of("msg_ta_allies_enemies_updated", nation.getName()));
 					} else
-						TownyMessaging.sendErrorMsg(getSender(), Translatable.of("msg_err_nation_not_allied_with_2", nation.getName(), ally.getName()));
+						TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_nation_not_allied_with_2", nation.getName(), ally.getName()));
 				} else
-					TownyMessaging.sendErrorMsg(getSender(), Translatable.of("msg_err_invalid_input", "/ta nation [nation] ally [add/remove] [nation]"));
+					TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_invalid_input", "/ta nation [nation] ally [add/remove] [nation]"));
 			} else if (split[1].equalsIgnoreCase("enemy")) {
 
 				checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_NATION_ENEMY.getNode());
 				if (split.length < 4) {
-					TownyMessaging.sendErrorMsg(getSender(), Translatable.of("msg_err_invalid_input", "/ta nation [nation] enemy [add/remove] [nation]"));
+					TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_invalid_input", "/ta nation [nation] enemy [add/remove] [nation]"));
 					return;
 				}
 				
 				Nation enemy = townyUniverse.getNation(split[3]);
 				if (enemy == null || enemy.equals(nation)) {
-					TownyMessaging.sendErrorMsg(getSender(), Translatable.of("msg_err_invalid_name", split[3]));
+					TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_invalid_name", split[3]));
 					return;
 				}
 
@@ -1932,32 +1913,32 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 
 						nation.addEnemy(enemy);
 						nation.save();
-						TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_enemy_nations", getSenderFormatted(), enemy.getName()));
-						TownyMessaging.sendMsg(getSender(), Translatable.of("msg_ta_allies_enemies_updated", nation.getName()));
+						TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_enemy_nations", getSenderFormatted(sender), enemy.getName()));
+						TownyMessaging.sendMsg(sender, Translatable.of("msg_ta_allies_enemies_updated", nation.getName()));
 					} else
-						TownyMessaging.sendErrorMsg(player, Translatable.of("msg_err_nation_already_enemies_with_2", nation.getName(), enemy.getName()));
+						TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_nation_already_enemies_with_2", nation.getName(), enemy.getName()));
 				} else if (split[2].equalsIgnoreCase("remove")) {
 					if (nation.hasEnemy(enemy)) {
 						nation.removeEnemy(enemy);
 						nation.save();
-						TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_enemy_to_neutral", getSenderFormatted(), enemy.getName()));
+						TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_enemy_to_neutral", getSenderFormatted(sender), enemy.getName()));
 						TownyMessaging.sendPrefixedNationMessage(enemy, Translatable.of("msg_removed_enemy", nation.getName()));
-						TownyMessaging.sendMsg(getSender(), Translatable.of("msg_ta_allies_enemies_updated", nation.getName()));
+						TownyMessaging.sendMsg(sender, Translatable.of("msg_ta_allies_enemies_updated", nation.getName()));
 					} else
-						TownyMessaging.sendErrorMsg(getSender(), Translatable.of("msg_err_nation_not_enemies_with_2", nation.getName(), enemy.getName()));
+						TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_nation_not_enemies_with_2", nation.getName(), enemy.getName()));
 				} else
-					TownyMessaging.sendErrorMsg(getSender(), Translatable.of("msg_err_invalid_input", "/ta nation [nation] enemy [add/remove] [nation]"));
+					TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_invalid_input", "/ta nation [nation] enemy [add/remove] [nation]"));
 			} else if (TownyCommandAddonAPI.hasCommand(CommandType.TOWNYADMIN_NATION, split[1])) {
 				TownyCommandAddonAPI.getAddonCommand(CommandType.TOWNYADMIN_NATION, split[1]).execute(sender, split, nation);
 			}
 
 		} catch (NotRegisteredException | AlreadyRegisteredException | InvalidNameException e) {
-			TownyMessaging.sendErrorMsg(getSender(), e.getMessage());
+			TownyMessaging.sendErrorMsg(sender, e.getMessage());
 		}
 	}
 
-	private String getSenderFormatted() {
-		return isConsole ? "Console" : player.getName();
+	private String getSenderFormatted(CommandSender sender) {
+		return sender instanceof Player player ? player.getName() : "Console";
 	}
 
 	/**
@@ -2015,7 +1996,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		TownyMessaging.sendMsg(sender, Translatable.of("msg_join_nation", town.getName()));
 	}
 
-	private void adminSet(String[] split) throws TownyException {
+	private void adminSet(CommandSender sender, String[] split) throws TownyException {
 		if (split.length == 0) {
 			HelpMenu.TA_SET.send(sender);
 			return;
@@ -2064,7 +2045,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 					town.save();
 					TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_new_mayor", newMayor));
 				} catch (TownyException e) {
-					TownyMessaging.sendErrorMsg(getSender(), e.getMessage());
+					TownyMessaging.sendErrorMsg(sender, e.getMessage());
 				}
 
 		} else if (split[0].equalsIgnoreCase("capital")) {
@@ -2076,15 +2057,15 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 				final Town newCapital = townyUniverse.getTown(split[1]);
 				
 				if (newCapital == null) {
-					TownyMessaging.sendErrorMsg(player, Translatable.of("msg_err_not_registered_1", split[1]));
+					TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_not_registered_1", split[1]));
 					return;
 				}
 				
 				try {
 					Nation nation = newCapital.getNation();
-					NationCommand.nationSet(player, split, true, nation);
+					NationCommand.nationSet(sender, split, true, nation);
 				} catch (Exception e) {
-					TownyMessaging.sendErrorMsg(player, e.getMessage());
+					TownyMessaging.sendErrorMsg(sender, e.getMessage());
 				}
 
 			}
@@ -2094,13 +2075,13 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			Resident resident = null;
 			// Give the resident a title
 			if (split.length < 2)
-				TownyMessaging.sendErrorMsg(player, "Eg: /townyadmin set title bilbo Jester");
+				TownyMessaging.sendErrorMsg(sender, "Eg: /townyadmin set title bilbo Jester");
 			else
 				resident = getResidentOrThrow(split[1]);
 
 			split = StringMgmt.remArgs(split, 2);
 			if (StringMgmt.join(split).length() > TownySettings.getMaxTitleLength()) {
-				TownyMessaging.sendErrorMsg(player, Translatable.of("msg_err_input_too_long"));
+				TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_input_too_long"));
 				return;
 			}
 
@@ -2122,13 +2103,13 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			Resident resident = null;
 			// Give the resident a surname
 			if (split.length < 2)
-				TownyMessaging.sendErrorMsg(player, "Eg: /townyadmin set surname bilbo Jester");
+				TownyMessaging.sendErrorMsg(sender, "Eg: /townyadmin set surname bilbo Jester");
 			else
 				resident = getResidentOrThrow(split[1]);
 
 			split = StringMgmt.remArgs(split, 2);
 			if (StringMgmt.join(split).length() > TownySettings.getMaxTitleLength()) {
-				TownyMessaging.sendErrorMsg(player, Translatable.of("msg_err_input_too_long"));
+				TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_input_too_long"));
 				return;
 			}
 
@@ -2171,6 +2152,8 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 				HelpMenu.TA_SET_PLOT.send(sender);
 				return;
 			}
+			
+			final Player player = catchConsole(sender);
 			TownBlock tb = TownyAPI.getInstance().getTownBlock(player);
 			if (tb != null) {
 				Town newTown = townyUniverse.getTown(split[1]);
@@ -2212,18 +2195,18 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 
 			}
 		} else if (TownyCommandAddonAPI.hasCommand(CommandType.TOWNYADMIN_SET, split[0])) {
-			TownyCommandAddonAPI.getAddonCommand(CommandType.TOWNYADMIN_SET, split[0]).execute(getSender(), "townyadmin", split);
+			TownyCommandAddonAPI.getAddonCommand(CommandType.TOWNYADMIN_SET, split[0]).execute(sender, "townyadmin", split);
 		} else {
-			TownyMessaging.sendErrorMsg(getSender(), Translatable.of("msg_err_invalid_property", "administrative"));
+			TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_invalid_property", "administrative"));
 		}
 	}
 
-	public void reloadLangs() {
+	public void reloadLangs(CommandSender sender) {
 		Translation.loadTranslationRegistry();
 		TownyMessaging.sendMsg(sender, Translatable.of("msg_reloaded_lang"));
 	}
 	
-	public void reloadPerms() {
+	public void reloadPerms(CommandSender sender) {
 		try {
 			plugin.loadPermissions(true);
 		} catch (TownyInitException tie) {
@@ -2242,7 +2225,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 	 * 
 	 * @param reset Whether or not to reset the config.
 	 */
-	public void reloadConfig(boolean reset) {
+	public void reloadConfig(CommandSender sender, boolean reset) {
 
 		if (reset) {
 			TownyUniverse.getInstance().getDataSource().deleteFile(plugin.getConfigPath());
@@ -2268,7 +2251,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 	 * Reloads both the database and the config. Used with a database reload command.
 	 *
 	 */
-	public void reloadDatabase() {
+	public void reloadDatabase(CommandSender sender) {
 		TownyUniverse.getInstance().getDataSource().finishTasks();
 		try {
 			plugin.loadFoundation(true);
@@ -2292,7 +2275,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 	 * @param split - Current command arguments.
 	 * @throws TownyException when an error message needs to be returned.
 	 */
-	public void purge(String[] split) throws TownyException {
+	public void purge(CommandSender sender, String[] split) throws TownyException {
 
 		if (split.length == 0) {
 			// command was '/townyadmin purge'
@@ -2342,7 +2325,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		}
 	}
 
-	public void parseToggleCommand(String[] split) throws TownyException {
+	public void parseToggleCommand(CommandSender sender, String[] split) throws TownyException {
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
 
 		Optional<Boolean> choice = Optional.empty();
@@ -2354,7 +2337,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 
 		if (split.length == 0) {
 			// command was '/townyadmin toggle'
-			HelpMenu.TA_TOGGLE.send(getSender());
+			HelpMenu.TA_TOGGLE.send(sender);
 			return;
 		}
 
@@ -2362,20 +2345,20 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			// Toggles build/destroy/switch/itemuse on or off in all worlds. True is the default, for installation setup to alter the defaulted false.
 			checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOGGLE_WILDERNESSUSE.getNode());
 			toggleWildernessUsage(choice.orElse(true));
-			TownyMessaging.sendMsg(getSender(), Translatable.of("msg_wilderness_use_x_in_all_worlds", choice.orElse(true)));
+			TownyMessaging.sendMsg(sender, Translatable.of("msg_wilderness_use_x_in_all_worlds", choice.orElse(true)));
 		} else if (split[0].equalsIgnoreCase("regenerations")) {
 
 			checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOGGLE_REGENERATIONS.getNode());
 			toggleRegenerations(choice.orElse(false));
-			TownyMessaging.sendMsg(getSender(), Translatable.of("msg_regenerations_use_x_in_all_worlds", choice.orElse(false)));
+			TownyMessaging.sendMsg(sender, Translatable.of("msg_regenerations_use_x_in_all_worlds", choice.orElse(false)));
 		} else if (split[0].equalsIgnoreCase("devmode")) {
 
 			checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOGGLE_DEVMODE.getNode());
 			try {
 				TownySettings.setDevMode(choice.orElse(!TownySettings.isDevMode()));
-				TownyMessaging.sendMsg(getSender(), Translatable.of("msg_admin_toggle_devmode", (TownySettings.isDevMode() ? Colors.Green + Translatable.of("enabled") : Colors.Red + Translatable.of("disabled"))));
+				TownyMessaging.sendMsg(sender, Translatable.of("msg_admin_toggle_devmode", (TownySettings.isDevMode() ? Colors.Green + Translatable.of("enabled") : Colors.Red + Translatable.of("disabled"))));
 			} catch (Exception e) {
-				TownyMessaging.sendErrorMsg(getSender(), Translatable.of("msg_err_invalid_choice"));
+				TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_invalid_choice"));
 			}
 		} else if (split[0].equalsIgnoreCase("debug")) {
 
@@ -2383,27 +2366,27 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			try {
 				TownySettings.setDebug(choice.orElse(!TownySettings.getDebug()));
 				TownyLogger.getInstance().refreshDebugLogger();
-				TownyMessaging.sendMsg(getSender(), Translatable.of("msg_admin_toggle_debugmode", (TownySettings.getDebug() ? Colors.Green + Translatable.of("enabled") : Colors.Red + Translatable.of("disabled"))));
+				TownyMessaging.sendMsg(sender, Translatable.of("msg_admin_toggle_debugmode", (TownySettings.getDebug() ? Colors.Green + Translatable.of("enabled") : Colors.Red + Translatable.of("disabled"))));
 			} catch (Exception e) {
-				TownyMessaging.sendErrorMsg(getSender(), Translatable.of("msg_err_invalid_choice"));
+				TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_invalid_choice"));
 			}
 		} else if (split[0].equalsIgnoreCase("townwithdraw")) {
 
 			checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOGGLE_TOWNWITHDRAW.getNode());
 			try {
 				TownySettings.SetTownBankAllowWithdrawls(choice.orElse(!TownySettings.getTownBankAllowWithdrawls()));
-				TownyMessaging.sendMsg(getSender(), Translatable.of("msg_admin_toggle_townwithdraw", (TownySettings.getTownBankAllowWithdrawls() ? Colors.Green + Translatable.of("enabled") : Colors.Red + Translatable.of("disabled"))));
+				TownyMessaging.sendMsg(sender, Translatable.of("msg_admin_toggle_townwithdraw", (TownySettings.getTownBankAllowWithdrawls() ? Colors.Green + Translatable.of("enabled") : Colors.Red + Translatable.of("disabled"))));
 			} catch (Exception e) {
-				TownyMessaging.sendErrorMsg(getSender(), Translatable.of("msg_err_invalid_choice"));
+				TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_invalid_choice"));
 			}
 		} else if (split[0].equalsIgnoreCase("nationwithdraw")) {
 
 			checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOGGLE_NATIONWITHDRAW.getNode());
 			try {
 				TownySettings.SetNationBankAllowWithdrawls(choice.orElse(!TownySettings.getNationBankAllowWithdrawls()));
-				TownyMessaging.sendMsg(getSender(), Translatable.of("msg_admin_toggle_nationwithdraw", (TownySettings.getNationBankAllowWithdrawls() ? Colors.Green + Translatable.of("enabled") : Colors.Red + Translatable.of("disabled"))));
+				TownyMessaging.sendMsg(sender, Translatable.of("msg_admin_toggle_nationwithdraw", (TownySettings.getNationBankAllowWithdrawls() ? Colors.Green + Translatable.of("enabled") : Colors.Red + Translatable.of("disabled"))));
 			} catch (Exception e) {
-				TownyMessaging.sendErrorMsg(getSender(), Translatable.of("msg_err_invalid_choice"));
+				TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_invalid_choice"));
 			}
 			
 		} else if (split[0].equalsIgnoreCase("npc")) {
@@ -2424,11 +2407,11 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 
 			TownyMessaging.sendMsg(sender, Translatable.of("msg_npc_flag", resident.isNPC(), resident.getName()));
 		} else if (TownyCommandAddonAPI.hasCommand(CommandType.TOWNYADMIN_TOGGLE, split[0])) {
-			TownyCommandAddonAPI.getAddonCommand(CommandType.TOWNYADMIN_TOGGLE, split[0]).execute(getSender(), "townyadmin", split);
+			TownyCommandAddonAPI.getAddonCommand(CommandType.TOWNYADMIN_TOGGLE, split[0]).execute(sender, "townyadmin", split);
 		} else {
 			// parameter error message
 			// peaceful/war/townmobs/worldmobs
-			TownyMessaging.sendErrorMsg(getSender(), Translatable.of("msg_err_invalid_choice"));
+			TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_invalid_choice"));
 		}
 	}
 
@@ -2641,7 +2624,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		return true;
 	}
 	
-	private void parseAdminDepositAllCommand(String[] split) throws TownyException {
+	private void parseAdminDepositAllCommand(CommandSender sender, String[] split) throws TownyException {
 		if (split.length != 1) {
 			HelpMenu.TA_DEPOSITALL.send(sender);
 			return;
@@ -2657,7 +2640,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		TownyMessaging.sendMsg(sender, Translatable.of("msg_ta_deposit_all_success", TownyEconomyHandler.getFormattedBalance(amount)));
 	}
 
-	private void parseAdminResetBanksCommand(String[] args) throws TownyException {
+	private void parseAdminResetBanksCommand(CommandSender sender, String[] args) throws TownyException {
 		final double amount = args.length == 1 ? MathUtil.getIntOrThrow(args[0]) : 0.0;
  		Confirmation.runOnAccept(() -> {
  			for (Town town : TownyUniverse.getInstance().getTowns())


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
The sender variable is now properly passed through all methods instead of referencing a field, this prevents the sender changing in the middle of a confirmation just because someone ran /ta for example.

Also fixes a bunch of places where player was used without checking if it was null or not, more commands can be used by console now.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
