### PR TITLE
Set to main scoreboard when toggling hud off

### DIFF
--- a/src/com/palmergames/bukkit/towny/huds/HUDManager.java
+++ b/src/com/palmergames/bukkit/towny/huds/HUDManager.java
@@ -13,6 +13,7 @@ import org.bukkit.event.player.PlayerQuitEvent;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class HUDManager implements Listener{
 
@@ -50,8 +51,8 @@ public class HUDManager implements Listener{
 			toggleOff(p);
 	}
 	
-	public static void toggleOff(Player p) {
-		p.setScoreboard(Bukkit.getScoreboardManager().getNewScoreboard());
+	public static void toggleOff(final Player player) {
+		Optional.ofNullable(Bukkit.getScoreboardManager()).ifPresent(manager -> player.setScoreboard(manager.getMainScoreboard()));
 	}
 
 	//**EVENTS**//


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Sets the player's scoreboard to the main scoreboard instead of an empty new one so that players don't need to relog to reset it.
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
