### PR TITLE
Remove old powdered snow workaround

### DIFF
--- a/src/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
@@ -29,7 +29,6 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockBurnEvent;
-import org.bukkit.event.block.BlockCanBuildEvent;
 import org.bukkit.event.block.BlockDispenseEvent;
 import org.bukkit.event.block.BlockExplodeEvent;
 import org.bukkit.event.block.BlockFertilizeEvent;
@@ -93,22 +92,9 @@ public class TownyBlockListener implements Listener {
 			event.setCancelled(true);
 		}
 		
+		//noinspection IsCancelled
 		if (!event.isCancelled() && block.getType() == Material.CHEST && !TownyUniverse.getInstance().getPermissionSource().isTownyAdmin(event.getPlayer()))
 			testDoubleChest(event.getPlayer(), event.getBlock());
-	}
-	
-	@EventHandler
-	public void onBlockCanBuild(BlockCanBuildEvent event) {
-		//Temporary workaround for grass remaining snowy when powdered snow is placed on top of it.
-		if (event.getMaterial().name().equals("POWDER_SNOW")) {
-			
-			Block block = event.getBlock();
-			if (!TownyAPI.getInstance().isTownyWorld(block.getWorld()))
-				return;
-
-			if (!TownyActionEventExecutor.canBuild(event.getPlayer(), event.getBlock().getLocation(), event.getBlock().getType()))
-				event.setBuildable(false);
-		}
 	}
 
 	private void testDoubleChest(Player player, Block block) {


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Removes an old workaround for a glitch related to powdered snow keeping grass snowy, was fixed by Paper back in february.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
