### PR TITLE
Deprecate redundant WorldCoord#getTownyWorldOrNull method

### DIFF
--- a/src/com/palmergames/bukkit/towny/ChunkNotification.java
+++ b/src/com/palmergames/bukkit/towny/ChunkNotification.java
@@ -168,7 +168,7 @@ public class ChunkNotification {
 			if (toWild) {
 				if (TownySettings.getNationZonesEnabled() && TownySettings.getNationZonesShowNotifications()) {
 					Player player = resident.getPlayer();
-					TownyWorld toWorld = to.getTownyWorldOrNull();
+					TownyWorld toWorld = to.getTownyWorld();
 					if (PlayerCacheUtil.fetchTownBlockStatus(player, this.to).equals(TownBlockStatus.NATION_ZONE)) {
 						Town nearestTown = null; 
 						nearestTown = toWorld.getClosestTownWithNationFromCoord(this.to.getCoord(), nearestTown);
@@ -176,7 +176,7 @@ public class ChunkNotification {
 					}
 				}
 				
-				return String.format(areaWildernessNotificationFormat, to.getTownyWorldOrNull().getFormattedUnclaimedZoneName());
+				return String.format(areaWildernessNotificationFormat, to.getTownyWorld().getFormattedUnclaimedZoneName());
 			
 			} else if (TownySettings.isNotificationsTownNamesVerbose())
 				return String.format(areaTownNotificationFormat, toTown.getFormattedName());
@@ -186,13 +186,13 @@ public class ChunkNotification {
 		} else if (fromWild && toWild)
 			if (TownySettings.getNationZonesEnabled() && TownySettings.getNationZonesShowNotifications()) {
 				Player player = resident.getPlayer();
-				TownyWorld toWorld = this.to.getTownyWorldOrNull();
+				TownyWorld toWorld = this.to.getTownyWorld();
 				if (PlayerCacheUtil.fetchTownBlockStatus(player, this.to).equals(TownBlockStatus.NATION_ZONE) && PlayerCacheUtil.fetchTownBlockStatus(player, this.from).equals(TownBlockStatus.UNCLAIMED_ZONE)) {
 					Town nearestTown = null; 
 					nearestTown = toWorld.getClosestTownWithNationFromCoord(this.to.getCoord(), nearestTown);
 					return String.format(areaWildernessNotificationFormat, Translatable.of("nation_zone_this_area_under_protection_of", toWorld.getFormattedUnclaimedZoneName(), nearestTown.getNationOrNull().getName()).forLocale(resident));
 				} else if (PlayerCacheUtil.fetchTownBlockStatus(player, this.to).equals(TownBlockStatus.UNCLAIMED_ZONE) && PlayerCacheUtil.fetchTownBlockStatus(player, this.from).equals(TownBlockStatus.NATION_ZONE)) {
-					return String.format(areaWildernessNotificationFormat, to.getTownyWorldOrNull().getFormattedUnclaimedZoneName());
+					return String.format(areaWildernessNotificationFormat, to.getTownyWorld().getFormattedUnclaimedZoneName());
 				}
 			}
 		return null;
@@ -202,7 +202,7 @@ public class ChunkNotification {
 
 		if (fromWild ^ toWild || !fromWild && !toWild && fromTown != null && toTown != null && fromTown != toTown) {
 			if (toWild)
-				return String.format(areaWildernessPvPNotificationFormat, ((to.getTownyWorldOrNull().isPVP() && testWorldPVP()) ? " " + Translatable.of("status_title_pvp").forLocale(resident) : ""));
+				return String.format(areaWildernessPvPNotificationFormat, ((to.getTownyWorld().isPVP() && testWorldPVP()) ? " " + Translatable.of("status_title_pvp").forLocale(resident) : ""));
 		}
 		return null;
 	}
@@ -228,14 +228,14 @@ public class ChunkNotification {
 	public String getTownPVPNotification(Resident resident) {
 
 		if (!toWild && ((fromWild) || (toTownBlock.getPermissions().pvp != fromTownBlock.getPermissions().pvp))) {
-			return String.format(areaTownPvPNotificationFormat, ( !CombatUtil.preventPvP(to.getTownyWorldOrNull(), toTownBlock) ? Translatable.of("status_title_pvp").forLocale(resident) : Translatable.of("status_title_nopvp").forLocale(resident)));
+			return String.format(areaTownPvPNotificationFormat, ( !CombatUtil.preventPvP(to.getTownyWorld(), toTownBlock) ? Translatable.of("status_title_pvp").forLocale(resident) : Translatable.of("status_title_nopvp").forLocale(resident)));
 		}
 		return null;
 	}
 
 	private boolean testWorldPVP() {
 
-		return to.getTownyWorldOrNull().isPVP();
+		return to.getTownyWorld().isPVP();
 	}
 
 	public String getPlotNotification() {

--- a/src/com/palmergames/bukkit/towny/command/PlotCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/PlotCommand.java
@@ -2127,7 +2127,7 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 		} catch (NumberFormatException | ArrayIndexOutOfBoundsException ignored) {}
 
 		if (TownyAPI.getInstance().isWilderness(coord))
-			TownyMessaging.sendStatusScreen(player, TownyFormatter.getStatus(coord.getTownyWorldOrNull(), player));
+			TownyMessaging.sendStatusScreen(player, TownyFormatter.getStatus(coord.getTownyWorld(), player));
 		else
 			TownyMessaging.sendStatusScreen(player, TownyFormatter.getStatus(coord.getTownBlockOrNull(), player));
 	}

--- a/src/com/palmergames/bukkit/towny/event/asciimap/WildernessMapEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/asciimap/WildernessMapEvent.java
@@ -19,7 +19,7 @@ public class WildernessMapEvent extends Event {
 	
 	public WildernessMapEvent(WorldCoord worldCoord) {
 		this.worldCoord = worldCoord;
-		this.hoverText = Component.text(worldCoord.getTownyWorldOrNull().getFormattedUnclaimedZoneName(), NamedTextColor.DARK_RED).append(Component.text(" (" + worldCoord.getX() + ", " + worldCoord.getZ() + ")", NamedTextColor.WHITE));
+		this.hoverText = Component.text(worldCoord.getTownyWorld().getFormattedUnclaimedZoneName(), NamedTextColor.DARK_RED).append(Component.text(" (" + worldCoord.getX() + ", " + worldCoord.getZ() + ")", NamedTextColor.WHITE));
 	}
 
 	/**

--- a/src/com/palmergames/bukkit/towny/huds/MapHUD.java
+++ b/src/com/palmergames/bukkit/towny/huds/MapHUD.java
@@ -76,7 +76,7 @@ public class MapHUD {
 		Objective objective = board.getObjective("MAP_HUD_OBJ");
 		objective.setDisplayName(ChatColor.GOLD + "Towny Map " + ChatColor.WHITE + "(" + wc.getX() + ", " + wc.getZ() + ")");
 
-		TownyWorld world = wc.getTownyWorldOrNull();
+		TownyWorld world = wc.getTownyWorld();
 		if (world == null || !world.isUsingTowny()) {
 			HUDManager.toggleOff(player);
 			return;

--- a/src/com/palmergames/bukkit/towny/object/WorldCoord.java
+++ b/src/com/palmergames/bukkit/towny/object/WorldCoord.java
@@ -131,10 +131,14 @@ public class WorldCoord extends Coord {
 	 */
 	@Nullable
 	public TownyWorld getTownyWorld() {
-		return TownyUniverse.getInstance().getWorld(getWorldName()); 
+		return TownyAPI.getInstance().getTownyWorld(world);
 	}
 
+	/**
+	 * @deprecated as of 0.98.4.9, please use {@link #getTownyWorld()} instead.
+	 */
 	@Nullable
+	@Deprecated
 	public TownyWorld getTownyWorldOrNull() {
 		return TownyAPI.getInstance().getTownyWorld(world);
 	}

--- a/src/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
+++ b/src/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
@@ -110,13 +110,13 @@ public class TownyRegenAPI {
 	/**
 	 * Gets a list of WorldCoords which are having snapshots taken, for one TownyWorld.
 	 * 
-	 * @param world - TownyWorld to gather a list of WorldCoords in.
-	 * @return list - List<WorldCoord> matched to above world.
+	 * @param world TownyWorld to gather a list of WorldCoords in.
+	 * @return list List<WorldCoord> matched to above world.
 	 */
-	private static List<WorldCoord> getWorldCoords(TownyWorld world) {
+	private static List<WorldCoord> getWorldCoords(@NotNull TownyWorld world) {
 		List<WorldCoord> list = new ArrayList<>();
 		for (WorldCoord wc : worldCoords)
-			if (wc.getTownyWorldOrNull().equals(world))
+			if (world.equals(wc.getTownyWorld()))
 				list.add(wc);
 
 		return list;
@@ -189,7 +189,7 @@ public class TownyRegenAPI {
 	 */
 	private static void removeRegenQueueListOfWorld(@NotNull TownyWorld world) {
 		regenWorldCoordList = getRegenQueueList().stream()
-			.filter(wc -> !world.equals(wc.getTownyWorldOrNull()))
+			.filter(wc -> !world.equals(wc.getTownyWorld()))
 			.collect(Collectors.toList());
 		TownyUniverse.getInstance().getDataSource().saveRegenList();
 	}
@@ -228,7 +228,7 @@ public class TownyRegenAPI {
 				continue;
 			
 			// This worldCoord isn't actively regenerating, start the regeneration.
-			PlotBlockData plotData = getPlotChunkSnapshot(new TownBlock(wc.getX(), wc.getZ(), wc.getTownyWorldOrNull()));
+			PlotBlockData plotData = getPlotChunkSnapshot(new TownBlock(wc.getX(), wc.getZ(), wc.getTownyWorld()));
 			if (plotData != null) {
 				// Load the chunks.
 				plotData.getWorldCoord().loadChunks();
@@ -601,7 +601,7 @@ public class TownyRegenAPI {
 	 * @param worldCoord - WorldCoord for the Town Block
 	 */
 	public static void doDeleteTownBlockIds(WorldCoord worldCoord) {
-		TownyWorld world = worldCoord.getTownyWorldOrNull();
+		TownyWorld world = worldCoord.getTownyWorld();
 		if (world == null)
 			return;
 		

--- a/src/com/palmergames/bukkit/towny/utils/PlayerCacheUtil.java
+++ b/src/com/palmergames/bukkit/towny/utils/PlayerCacheUtil.java
@@ -406,7 +406,7 @@ public class PlayerCacheUtil {
 			/*
 			 * Handle the Wilderness.
 			 */
-			boolean hasWildOverride = townyUniverse.getPermissionSource().hasWildOverride(pos.getTownyWorldOrNull(), player, material, action);
+			boolean hasWildOverride = townyUniverse.getPermissionSource().hasWildOverride(pos.getTownyWorld(), player, material, action);
 
 			if (status == TownBlockStatus.UNCLAIMED_ZONE) {
 				if (hasWildOverride)
@@ -434,14 +434,14 @@ public class PlayerCacheUtil {
 				}
 
 				// We know that the nearest Town will have a nation because the TownBlockStatus.
-				Nation nearestNation = TownyAPI.getInstance().getTownNationOrNull(pos.getTownyWorldOrNull().getClosestTownWithNationFromCoord(pos.getCoord(), null));
+				Nation nearestNation = TownyAPI.getInstance().getTownNationOrNull(pos.getTownyWorld().getClosestTownWithNationFromCoord(pos.getCoord(), null));
 
 				// If the player has a Nation and is a member of this NationZone's nation.
 				if (res.hasNation() && res.getNationOrNull().getUUID().equals(nearestNation.getUUID()))
 					return true;
 
 				// The player is not a nation member of this NationZone.
-				cacheBlockErrMsg(player, Translatable.of("nation_zone_this_area_under_protection_of", pos.getTownyWorldOrNull().getFormattedUnclaimedZoneName(), nearestNation.getName()).forLocale(player));
+				cacheBlockErrMsg(player, Translatable.of("nation_zone_this_area_under_protection_of", pos.getTownyWorld().getFormattedUnclaimedZoneName(), nearestNation.getName()).forLocale(player));
 				return false;
 			}
 		}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
WorldCoord#getTownyWorld no longer throws a NRE as of last february, so the getTownyWorldOrNull was doing the exact same thing.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
