### PR TITLE
Outsiders can prevent unclaiming.

### DIFF
--- a/resources/lang/en-US.yml
+++ b/resources/lang/en-US.yml
@@ -1842,3 +1842,6 @@ confirmation_msg_trusttown_consequences: 'You are about to give full plot permis
 
 #Message shown when a player uses a command that is blocked because their location has an active war.
 msg_command_war_blocked: 'You cannot run that command because your town is at war.'
+
+#Message shown when a player tries to unclaim land but cannot because an outsider is there (and the config doesn't allow this.)
+msg_cant_unclaim_outsider_in_town: 'There is an outsider in this townblock, you can''t unclaim this townblock!'

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -869,6 +869,13 @@ public enum ConfigNodes {
 			"",
 			"# If Towny should show players the townboard when they login"
 	),
+	GTOWN_SETTINGS_OUTSIDERS_PREVENT_UNCLAIM_TOWNBLOCK(
+			"global_town_settings.outsiders_prevent_unclaim_townblock",
+			"false",
+			"",
+			"# If set to true, Towny will prevent a townblock from being unclaimed while an outsider is within the townblock's boundaries.",
+			"# When active this feature can cause a bit of lag when the /t unclaim command is used, depending on how many players are online."
+	),
 	GTOWN_SETTINGS_OUTSIDERS_PREVENT_PVP_TOGGLE(
 			"global_town_settings.outsiders_prevent_pvp_toggle",
 			"false",

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -2645,6 +2645,10 @@ public class TownySettings {
 		return getBoolean(ConfigNodes.GTOWN_SETTINGS_OUTSIDERS_PREVENT_PVP_TOGGLE);
 	}
 	
+	public static boolean getOutsidersUnclaimingTownBlocks() {
+		return getBoolean(ConfigNodes.GTOWN_SETTINGS_OUTSIDERS_PREVENT_UNCLAIM_TOWNBLOCK);
+	}
+	
 	public static boolean isForcePvpNotAffectingHomeblocks() {
 		return getBoolean(ConfigNodes.GTOWN_SETTINGS_HOMEBLOCKS_PREVENT_FORCEPVP);
 	}

--- a/src/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
@@ -17,9 +17,11 @@ import com.palmergames.bukkit.towny.event.PlayerChangePlotEvent;
 import com.palmergames.bukkit.towny.event.SpawnEvent;
 import com.palmergames.bukkit.towny.event.damage.TownyPlayerDamagePlayerEvent;
 import com.palmergames.bukkit.towny.event.nation.NationPreTownLeaveEvent;
+import com.palmergames.bukkit.towny.event.town.TownPreUnclaimCmdEvent;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
+import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.TownyWorld;
 import com.palmergames.bukkit.towny.object.Translatable;
 import com.palmergames.bukkit.towny.object.Translation;
@@ -247,5 +249,33 @@ public class TownyCustomListener implements Listener {
 			return;
 		event.setCancelled(true);
 		event.setCancelMessage(Translatable.of("msg_error_cannot_town_spawn_youre_an_outlaw_in_town", town.getName()).forLocale(event.getPlayer()));
+	}
+
+	/**
+	 * Used to prevent unclaiming when there is an outsider in the TownBlock,
+	 * and the config does not allow for this.
+	 * 
+	 * @param event {@link TownPreUnclaimCmdEvent} thrown when someone runs /t unclaim.
+	 */
+	@EventHandler(ignoreCancelled = true)
+	public void onTownUnclaim(TownPreUnclaimCmdEvent event) {
+		Player player = event.getResident().getPlayer();
+		if (!TownySettings.getOutsidersUnclaimingTownBlocks() || player == null)
+			return;
+
+		TownBlock townblock = TownyAPI.getInstance().getTownBlock(player);
+		if (townblock == null)
+			return;
+
+		Town town = event.getTown();
+		for (Player target : Bukkit.getOnlinePlayers()) {
+			if (!town.hasResident(target) &&
+				!TownyAPI.getInstance().isWilderness(target.getLocation()) &&
+				townblock.equals(TownyAPI.getInstance().getTownBlock(target.getLocation()))) {
+				event.setCancelled(true);
+				event.setCancelMessage(Translatable.of("msg_cant_unclaim_outsider_in_town").forLocale(event.getResident()));
+				break;
+			}
+		}
 	}
 }


### PR DESCRIPTION


<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
  - New Config Option: global_town_settings.outsiders_prevent_unclaim_townblock
    - Default: false
    - If set to true, Towny will prevent a townblock from being unclaimed while an outsider is within the townblock's boundaries.
    - When active this feature can cause a bit of lag when the /t unclaim command is used, depending on how many players are online.

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
