### PR TITLE
Feature: Town allowedToWar setting.

### DIFF
--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -101,6 +101,13 @@ public enum ConfigNodes {
 			"false",
 			"",
 			"# Default neutral status of the town (are new towns neutral by default?)"),
+	TOWN_DEF_ALLOWED_TO_WAR(
+			"town.default_allowed_to_war",
+			"true",
+			"",
+			"# Default status of new towns, (are they allowed to have a war/battle?)",
+			"# This setting is not used internally by Towny. It is available for war/battle plugins to use.",
+			"# Setting this false should mean your town cannot be involved in a war supplied by another plugin."),
 	TOWN_DEF_BOARD("town.default_board", 
 			"/town set board [msg]",
 			"",

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -1396,6 +1396,10 @@ public class TownySettings {
 		return getDouble(ConfigNodes.TOWN_DEF_TAXES_MINIMUMTAX);
 	}
 	
+	public static boolean getTownDefaultAllowedToWar() {
+		return getBoolean(ConfigNodes.TOWN_DEF_ALLOWED_TO_WAR);
+	}
+	
 	public static boolean hasTownLimit() {
 
 		return getTownLimit() != 0;

--- a/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -156,7 +156,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		"forcemerge"
 	);
 	private static final List<String> adminTownToggleTabCompletes = Stream.concat(TownCommand.townToggleTabCompletes.stream(),
-			Arrays.asList("forcepvp", "forcedisablepvp", "unlimitedclaims", "upkeep").stream()).collect(Collectors.toList()); 
+			Arrays.asList("forcepvp", "forcedisablepvp", "unlimitedclaims", "upkeep", "allowedtowar").stream()).collect(Collectors.toList()); 
 
 	private static final List<String> adminNationTabCompletes = Arrays.asList(
 		"add",
@@ -1370,6 +1370,11 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			town.setHasUpkeep(choice.orElse(!town.hasUpkeep()));
 			town.save();
 			TownyMessaging.sendMsg(sender, Translatable.of("msg_town_upkeep_setting_set_to", town.getName(), town.hasUpkeep()));
+		} else if (split[0].equalsIgnoreCase("allowedtowar")) {
+			
+			town.setAllowedToWar(choice.orElse(!town.isAllowedToWar()));
+			town.save();
+			TownyMessaging.sendMsg(sender, Translatable.of("msg_town_allowedtowar_setting_set_to", town.getName(), town.isAllowedToWar()));
 		} else
 			TownCommand.townToggle(sender, split, true, town);
 	}

--- a/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
+++ b/src/com/palmergames/bukkit/towny/db/SQL_Schema.java
@@ -175,6 +175,7 @@ public class SQL_Schema {
 		columns.add("`public` bool NOT NULL DEFAULT '0'");
 		columns.add("`admindisabledpvp` bool NOT NULL DEFAULT '0'");
 		columns.add("`adminenabledpvp` bool NOT NULL DEFAULT '0'");
+		columns.add("`allowedToWar` bool NOT NULL DEFAULT '1'");
 		columns.add("`homeblock` mediumtext NOT NULL");
 		columns.add("`spawn` mediumtext NOT NULL");
 		columns.add("`outpostSpawns` mediumtext DEFAULT NULL");

--- a/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -763,6 +763,13 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 					} catch (Exception ignored) {
 					}
 				
+				line = keys.get("allowedToWar");
+				if (line != null)
+					try {
+						town.setAllowedToWar(Boolean.parseBoolean(line));
+					} catch (Exception ignored) {
+					}
+				
 				line = keys.get("open");
 				if (line != null)
 					try {
@@ -1990,6 +1997,8 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 		// PVP
 		list.add("adminDisabledPvP=" + town.isAdminDisabledPVP());
 		list.add("adminEnabledPvP=" + town.isAdminEnabledPVP());
+		// Allowed to War
+		list.add("allowedToWar=" + town.isAllowedToWar());
 		// Public
 		list.add("public=" + town.isPublic());
 		// Conquered towns setting + date

--- a/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -983,6 +983,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			town.setConquered(rs.getBoolean("conquered"));
 			town.setAdminDisabledPVP(rs.getBoolean("admindisabledpvp"));
 			town.setAdminEnabledPVP(rs.getBoolean("adminenabledpvp"));
+			town.setAllowedToWar(rs.getBoolean("allowedToWar"));
 			town.setJoinedNationAt(rs.getLong("joinedNationAt"));
 			town.setMovedHomeBlockAt(rs.getLong("movedHomeBlockAt"));
 
@@ -2187,6 +2188,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			twn_hm.put("conqueredDays", town.getConqueredDays());
 			twn_hm.put("admindisabledpvp", town.isAdminDisabledPVP());
 			twn_hm.put("adminenabledpvp", town.isAdminEnabledPVP());
+			twn_hm.put("allowedToWar", town.isAllowedToWar());
 			twn_hm.put("joinedNationAt", town.getJoinedNationAt());
 			twn_hm.put("mapColorHexCode", town.getMapColorHexCode());
 			twn_hm.put("movedHomeBlockAt", town.getMovedHomeBlockAt());

--- a/src/com/palmergames/bukkit/towny/object/Town.java
+++ b/src/com/palmergames/bukkit/towny/object/Town.java
@@ -86,6 +86,7 @@ public class Town extends Government implements TownBlockOwner {
 	private TownyWorld world;
 	private boolean adminDisabledPVP = false; // This is a special setting to make a town ignore All PVP settings and keep PVP disabled.
 	private boolean adminEnabledPVP = false; // This is a special setting to make a town ignore All PVP settings and keep PVP enabled. Overrides the admin disabled too.
+	private boolean allowedToWar = TownySettings.getTownDefaultAllowedToWar();
 	private boolean isConquered = false;
 	private int conqueredDays;
 	private int nationZoneOverride = 0;
@@ -456,6 +457,14 @@ public class Town extends Government implements TownBlockOwner {
 
 		// Admin has enabled PvP for this town.
 		return this.adminEnabledPVP;
+	}
+
+	public boolean isAllowedToWar() {
+		return allowedToWar;
+	}
+
+	public void setAllowedToWar(boolean allowedToWar) {
+		this.allowedToWar = allowedToWar;
 	}
 
 	/**


### PR DESCRIPTION
Defaults to true, but set in the config. Makes it possible for war plugins to know they should not allow certain towns to take part in wars, and for admins/other plugins to opt towns out of wars.

New Config Option: town.default_allowed_to_war
  - Default: true
  - Default status of new towns, (are they allowed to have a war/battle?)
  - This setting is not used internally by Towny. It is available for war/battle plugins to use.
  - Setting this false should mean your town cannot be involved in a war supplied by another plugin.

New Command: /ta town TOWNNAME toggle allowedtowar [on|off]
  - Toggles a town's allowedtowar setting on/off.

<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
