### PR TITLE
Add a 30 second timeout for backup future

### DIFF
--- a/src/com/palmergames/bukkit/towny/TownyUniverse.java
+++ b/src/com/palmergames/bukkit/towny/TownyUniverse.java
@@ -48,6 +48,9 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Towny's class for internal API Methods
@@ -239,9 +242,15 @@ public class TownyUniverse {
      * Run during onDisable() to finish cleanup and backup.
      */
     public void finishTasks() {
-    	if (backupFuture != null) {
+    	if (backupFuture != null && !backupFuture.isDone()) {
 			// Join into main thread for proper termination.
-			backupFuture.join();
+			try {
+				backupFuture.get(30, TimeUnit.SECONDS);
+			} catch (TimeoutException e) {
+				towny.getLogger().warning("Timed out waiting for backup task to finish.");
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			} catch (ExecutionException ignored) {}
 		}
 	}
 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Changes it so the server will wait for up to 30 seconds for the backup task to finish when shutting down.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #6411 

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
