### PR TITLE
Make area selection tool able to handle already claimed plots.

### DIFF
--- a/resources/lang/en-US.yml
+++ b/resources/lang/en-US.yml
@@ -1861,3 +1861,6 @@ msg_town_allowedtowar_setting_set_to: 'The town %s has had their allowed-to-war 
 
 #Message shown to confirm that a player wants to unclaim all of their land, besides the homeblock, seen with /t unclaim all.
 confirmation_did_you_want_to_unclaim_all: 'Are you sure you want to unclaim all of your land? (Your homeblock will not be unclaimed.)'
+
+#Message shown after a player unclaims all their land.
+msg_you_have_unclaimed_everything_but_your_homeblock: "You have unclaimed everything but your homeblock. To unclaim your homeblock you must set a new homeblock using '/t set homeblock' first."

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -3660,7 +3660,8 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 					throw new TownyException(Translatable.of("msg_already_claimed_1", key));
 
 				// Select a single WorldCoord using the AreaSelectionUtil.
-				selection = AreaSelectionUtil.selectWorldCoordArea(town, new WorldCoord(world.getName(), key), new String[0], true);
+				selection = new ArrayList<>();
+				selection.add(new WorldCoord(world.getName(), key));
 				outpost = true;
 			} else
 				throw new TownyException(Translatable.of("msg_outpost_disable"));
@@ -3678,9 +3679,8 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 			if (selection.size() > 1) 
 				checkPermOrThrow(player, PermissionNodes.TOWNY_COMMAND_TOWN_CLAIM_TOWN_MULTIPLE.getNode());
 
-			// TODO: deny using selection claiming from unclaimed land.
-//				if (selection.size() > 1 && TownyAPI.getInstance().isWilderness(player.getLocation()))
-//					throw new TownyException();
+			// Filter out any TownBlocks which aren't Wilderness. 
+			selection = AreaSelectionUtil.filterOutTownOwnedBlocks(selection);
 		}
 
 		// Not enough available claims.

--- a/src/com/palmergames/bukkit/towny/tasks/TownClaim.java
+++ b/src/com/palmergames/bukkit/towny/tasks/TownClaim.java
@@ -137,6 +137,7 @@ public class TownClaim implements Runnable {
 			}
 			townUnclaimAll(town);
 			successfulRun = true;
+			TownyMessaging.sendMessage(player, Translatable.of("msg_you_have_unclaimed_everything_but_your_homeblock"));
 		})
 		.setTitle(Translatable.of("confirmation_did_you_want_to_unclaim_all"))
 		.sendTo(player);


### PR DESCRIPTION
The AreaSelectionUtil could not account for larger radii being supplied from within an already claimed space.

ex: /t claim 5 and then /t claim 6,

on the 2nd usage, it would think it would require all 6 layers of TownBlocks available to claim.

This PR removes the available aspect of the selection, which means it will just pass a selection and the incorrect TownBlocks are filtered out afterwards (as you see done in the TownCommand.

This also takes outpost-selecting out of the util.

This also redoes a fair number of the filtering methods to use Streams.

Fixes a missing feedback message when `/t unclaim all` is used.


<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

Closes #6431.
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
