### PR TITLE
Config and API options for handling unjailed player teleports.

### DIFF
--- a/resources/ChangeLog.txt
+++ b/resources/ChangeLog.txt
@@ -8296,3 +8296,9 @@ v0.92.0.11:
   - Fix missing spaces in the /{object} set perm command feedback.
   - Fix missing feedback when /ta plot is used with an incorrect subcommand.
   - Fix /t unjail tabcompleter not including non-residents which are jailed in the town.
+  - New Config Option: jail.unjailed_players_get_teleported
+    - Default: true
+    - Most types of unjailing result in a player being teleported when they are freed.
+    - Setting this to false will prevent that teleporting, resulting in the player not being teleported when they are freed.
+  - API: Added UnjailedResidentTeleportEvent.
+    - Lets other plugins move unjailed residents to a location of their choice.

--- a/resources/ChangeLog.txt
+++ b/resources/ChangeLog.txt
@@ -8296,9 +8296,3 @@ v0.92.0.11:
   - Fix missing spaces in the /{object} set perm command feedback.
   - Fix missing feedback when /ta plot is used with an incorrect subcommand.
   - Fix /t unjail tabcompleter not including non-residents which are jailed in the town.
-  - New Config Option: jail.unjailed_players_get_teleported
-    - Default: true
-    - Most types of unjailing result in a player being teleported when they are freed.
-    - Setting this to false will prevent that teleporting, resulting in the player not being teleported when they are freed.
-  - API: Added UnjailedResidentTeleportEvent.
-    - Lets other plugins move unjailed residents to a location of their choice, or cancel the teleport altogether.

--- a/resources/ChangeLog.txt
+++ b/resources/ChangeLog.txt
@@ -8301,4 +8301,4 @@ v0.92.0.11:
     - Most types of unjailing result in a player being teleported when they are freed.
     - Setting this to false will prevent that teleporting, resulting in the player not being teleported when they are freed.
   - API: Added UnjailedResidentTeleportEvent.
-    - Lets other plugins move unjailed residents to a location of their choice.
+    - Lets other plugins move unjailed residents to a location of their choice, or cancel the teleport altogether.

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -2707,6 +2707,12 @@ public enum ConfigNodes {
 			"1h",
 			"",
 			"# How long do new players have to be on the server before they can be jailed?"),
+	JAIL_UNJAIL_TELEPORT(
+			"jail.unjailed_players_get_teleported",
+			"true",
+			"",
+			"# Most types of unjailing result in a player being teleported when they are freed.",
+			"# Setting this to false will prevent that teleporting, resulting in the player not being teleported when they are freed."),
 	
 	BANK(
 			"bank",

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -1876,6 +1876,10 @@ public class TownySettings {
 		return TimeTools.getMillis(getString(ConfigNodes.JAIL_NEW_PLAYER_IMMUNITY));
 	}
 
+	public static boolean doesUnjailingTeleportPlayer() {
+		return getBoolean(ConfigNodes.JAIL_UNJAIL_TELEPORT);
+	}
+
 	public static boolean isDevMode() {
 
 		return getBoolean(ConfigNodes.PLUGIN_DEV_MODE_ENABLE);

--- a/src/com/palmergames/bukkit/towny/event/teleport/UnjailedResidentTeleportEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/teleport/UnjailedResidentTeleportEvent.java
@@ -1,0 +1,54 @@
+package com.palmergames.bukkit.towny.event.teleport;
+
+import org.bukkit.Location;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+import com.palmergames.bukkit.towny.object.Resident;
+
+public class UnjailedResidentTeleportEvent extends Event implements Cancellable {
+
+	private static final HandlerList handlers = new HandlerList();
+	private boolean isCancelled = false;
+	private final Resident resident;
+	private Location location;
+	
+	public UnjailedResidentTeleportEvent(Resident resident, Location location) {
+		this.resident = resident;
+		this.setLocation(location);
+	}
+
+	public Resident getResident() {
+		return resident;
+	}
+
+	public Location getLocation() {
+		return location;
+	}
+
+	public void setLocation(Location location) {
+		this.location = location;
+	}
+
+	@Override
+	public boolean isCancelled() {
+		return isCancelled;
+	}
+
+	@Override
+	public void setCancelled(boolean cancelled) {
+		isCancelled = cancelled;
+	}
+
+	@NotNull
+	@Override
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
+}

--- a/src/com/palmergames/bukkit/towny/utils/JailUtil.java
+++ b/src/com/palmergames/bukkit/towny/utils/JailUtil.java
@@ -268,6 +268,8 @@ public class JailUtil {
 	private static void teleportAwayFromJail(Resident resident) {
 		// Don't teleport a player who isn't online.
 		if (!resident.isOnline()) return;
+		// Don't teleport a player if the config is set to not allow it.
+		if (!TownySettings.doesUnjailingTeleportPlayer()) return;
 		SpawnUtil.jailAwayTeleport(resident);
 	}
 	

--- a/src/com/palmergames/bukkit/towny/utils/SpawnUtil.java
+++ b/src/com/palmergames/bukkit/towny/utils/SpawnUtil.java
@@ -4,11 +4,13 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 import com.palmergames.bukkit.towny.event.NationSpawnEvent;
 import com.palmergames.bukkit.towny.event.SpawnEvent;
 import com.palmergames.bukkit.towny.event.TownSpawnEvent;
 import com.palmergames.bukkit.towny.event.teleport.ResidentSpawnEvent;
+import com.palmergames.bukkit.towny.event.teleport.UnjailedResidentTeleportEvent;
 import com.palmergames.bukkit.towny.object.Translatable;
 import com.palmergames.bukkit.towny.object.economy.Account;
 import com.palmergames.bukkit.towny.object.spawnlevel.NationSpawnLevel;
@@ -160,7 +162,16 @@ public class SpawnUtil {
 	 * @param jailed Resident which is being moved from jail.
 	 */
 	public static void jailAwayTeleport(Resident jailed) {
-		initiatePluginTeleport(jailed, getIdealLocation(jailed), false);
+		Location loc = jailed.getPlayer().getWorld().getSpawnLocation();
+		try {
+			loc = getIdealLocation(jailed).get();
+		} catch (InterruptedException | ExecutionException ignored) {}
+
+		UnjailedResidentTeleportEvent event = new UnjailedResidentTeleportEvent(jailed, loc); 
+		if (BukkitTools.isEventCancelled(event))
+			return;
+
+		initiatePluginTeleport(jailed, event.getLocation(), false);
 	}
 	
 	/**


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
```
  - New Config Option: jail.unjailed_players_get_teleported
    - Default: true
    - Most types of unjailing result in a player being teleported when they are freed.
    - Setting this to false will prevent that teleporting, resulting in the player not being teleported when they are freed.
  - API: Added UnjailedResidentTeleportEvent.
    - Lets other plugins move unjailed residents to a location of their choice, or cancel the teleport altogether.
```

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

Closes #6437.

____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
