### PR TITLE
separated data sources for loading and saving, fixed hikaricp connect…

### DIFF
--- a/src/com/palmergames/bukkit/towny/Towny.java
+++ b/src/com/palmergames/bukkit/towny/Towny.java
@@ -172,9 +172,10 @@ public class Towny extends JavaPlugin {
 			// Update config with new version.
 			TownySettings.setLastRunVersion(getVersion());
 			// Save database.
-			townyUniverse.getDataSource().saveAll();
+			townyUniverse.getSaveDataSource().saveAll();
 			// cleanup() updates SQL schema for any changes.
-			townyUniverse.getDataSource().cleanup();
+			townyUniverse.getSaveDataSource().cleanup();
+			townyUniverse.getLoadDataSource().cleanup();
 		}
 		
 		// It is probably a good idea to always handle permissions
@@ -416,8 +417,8 @@ public class Towny extends JavaPlugin {
 
 		Bukkit.getLogger().info("==============================================================");
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
-		if (townyUniverse.getDataSource() != null && !isError()) {
-			townyUniverse.getDataSource().saveQueues();
+		if (townyUniverse.getSaveDataSource() != null && !isError()) {
+			townyUniverse.getSaveDataSource().saveQueues();
 		}
 
 		// Turn off timers.		
@@ -430,7 +431,8 @@ public class Towny extends JavaPlugin {
 		try {
 			// Shut down our saving task.
 			plugin.getLogger().info("Finishing File IO Tasks...");
-			townyUniverse.getDataSource().finishTasks();
+			townyUniverse.getSaveDataSource().finishTasks();
+			townyUniverse.getLoadDataSource().finishTasks();
 			townyUniverse.finishTasks();
 		} catch (NullPointerException ignored) {
 			// The saving task will not have started if this disable was fired by onEnable failing.			

--- a/src/com/palmergames/bukkit/towny/TownyAPI.java
+++ b/src/com/palmergames/bukkit/towny/TownyAPI.java
@@ -660,14 +660,34 @@ public class TownyAPI {
     }
     
     /**
-     * Gets Towny's saving Database
+     * Gets Towny's loading Database
      *
+	 * @deprecated use TownyAPI#getLoadDataSource() and TownyAPI#getSaveDataSource() instead
      * @return the {@link TownyDataSource}
      */
+	@Deprecated
     public TownyDataSource getDataSource() {
-        return townyUniverse.getDataSource();
+        return townyUniverse.getLoadDataSource();
     }
-    
+
+	/**
+	 * Gets Towny's loading Database
+	 *
+	 * @return the {@link TownyDataSource}
+	 */
+	public TownyDataSource getLoadDataSource() {
+		return townyUniverse.getLoadDataSource();
+	}
+	
+	/**
+	 * Gets Towny's saving Database
+	 *
+	 * @return the {@link TownyDataSource}
+	 */
+	public TownyDataSource getSaveDataSource() {
+		return townyUniverse.getSaveDataSource();
+	}
+	
     /**
      * Check which {@link Resident}s are online in a {@link ResidentList}
      *

--- a/src/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -1025,7 +1025,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
 		
 		UUID nationUUID = UUID.randomUUID();
-		townyUniverse.getDataSource().newNation(name, nationUUID);
+		townyUniverse.getSaveDataSource().newNation(name, nationUUID);
 		Nation nation = townyUniverse.getNation(nationUUID);
 		
 		// Should never happen
@@ -1088,7 +1088,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 		}
 		Confirmation.runOnAccept(() -> {
 			BukkitTools.fireEvent(new NationMergeEvent(nation, remainingNation));
-			TownyUniverse.getInstance().getDataSource().mergeNation(nation, remainingNation);
+			TownyUniverse.getInstance().getSaveDataSource().mergeNation(nation, remainingNation);
 			TownyMessaging.sendGlobalMessage(Translatable.of("nation1_has_merged_with_nation2", nation, remainingNation));
 			if (TownySettings.getNationRequiresProximity() > 0)
 				remainingNation.removeOutOfRangeTowns();
@@ -1148,7 +1148,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 
 				Confirmation.runOnAccept(() -> {
 					TownyMessaging.sendGlobalMessage(Translatable.of("msg_del_nation", nation.getName()));
-					TownyUniverse.getInstance().getDataSource().removeNation(nation);
+					TownyUniverse.getInstance().getSaveDataSource().removeNation(nation);
 					if (tooManyResidents)
 						ResidentUtil.reduceResidentCountToFitTownMaxPop(town);
 				})
@@ -1164,7 +1164,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 				Nation nation = getNationOrThrow(split[0]);
 				Confirmation.runOnAccept(() -> {
 					TownyMessaging.sendGlobalMessage(Translatable.of("msg_del_nation", nation.getName()));
-					TownyUniverse.getInstance().getDataSource().removeNation(nation);					
+					TownyUniverse.getInstance().getSaveDataSource().removeNation(nation);					
 				})
 				.sendTo(player);
 			} catch (TownyException x) {
@@ -1738,7 +1738,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 			targetNations.remove(removedNation);
 	
 		if (targetNations.size() > 0) {
-			TownyUniverse.getInstance().getDataSource().saveNations();
+			TownyUniverse.getInstance().getSaveDataSource().saveNations();
 			plugin.resetCache();
 		} else {
 			throw new TownyException(Translatable.of("msg_invalid_name"));
@@ -1933,7 +1933,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 			else
 				TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_enemy_to_neutral", player.getName(), msg));
 
-			TownyUniverse.getInstance().getDataSource().saveNations();
+			TownyUniverse.getInstance().getSaveDataSource().saveNations();
 
 			plugin.resetCache();
 		} else
@@ -2540,7 +2540,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 			if (TownyEconomyHandler.isActive() && renameCost > 0 && !nation.getAccount().withdraw(renameCost, String.format("Nation renamed to: %s", newName)))
 				throw new TownyException(Translatable.of("msg_err_no_money", TownyEconomyHandler.getFormattedBalance(renameCost)));
 	
-			TownyUniverse.getInstance().getDataSource().renameNation(nation, newName);
+			TownyUniverse.getInstance().getSaveDataSource().renameNation(nation, newName);
 			TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_nation_set_name", player.getName(), nation.getName()));
 		} catch (TownyException e) {
 			TownyMessaging.sendErrorMsg(player, e.getMessage(player));

--- a/src/com/palmergames/bukkit/towny/command/PlotCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/PlotCommand.java
@@ -1432,7 +1432,7 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 						if (oldGroup.getTownBlocks().isEmpty()) {
 							String oldName = oldGroup.getName();
 							town.removePlotGroup(oldGroup);
-							TownyUniverse.getInstance().getDataSource().removePlotGroup(oldGroup);
+							TownyUniverse.getInstance().getSaveDataSource().removePlotGroup(oldGroup);
 							TownyMessaging.sendMsg(player, Translatable.of("msg_plotgroup_deleted", oldName));
 						} else 
 							oldGroup.save();
@@ -1462,7 +1462,7 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 				PlotGroup group = townBlock.getPlotObjectGroup();
 				String name = group.getName();
 				town.removePlotGroup(group);
-				TownyUniverse.getInstance().getDataSource().removePlotGroup(group);
+				TownyUniverse.getInstance().getSaveDataSource().removePlotGroup(group);
 				TownyMessaging.sendMsg(player, Translatable.of("msg_plotgroup_deleted", name));
 			}).sendTo(player);
 			
@@ -1487,7 +1487,7 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 			
 			if (group.getTownBlocks().isEmpty()) {
 				town.removePlotGroup(group);
-				TownyUniverse.getInstance().getDataSource().removePlotGroup(group);
+				TownyUniverse.getInstance().getSaveDataSource().removePlotGroup(group);
 				TownyMessaging.sendMsg(player, Translatable.of("msg_plotgroup_empty_deleted", name));
 			}
 
@@ -1507,7 +1507,7 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 			String newName= split[1];			
 			String oldName = townBlock.getPlotObjectGroup().getName();
 			// Change name;
-			TownyUniverse.getInstance().getDataSource().renameGroup(townBlock.getPlotObjectGroup(), newName);
+			TownyUniverse.getInstance().getSaveDataSource().renameGroup(townBlock.getPlotObjectGroup(), newName);
 			TownyMessaging.sendMsg(player, Translatable.of("msg_plot_renamed_from_x_to_y", oldName, newName));
 
 		} else if (split[0].equalsIgnoreCase("forsale") || split[0].equalsIgnoreCase("fs")) {

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -2925,7 +2925,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 
 		// Rename the town.
 		try {
-			townyUniverse.getDataSource().renameTown(town, newName);
+			townyUniverse.getSaveDataSource().renameTown(town, newName);
 			town = townyUniverse.getTown(newName);
 			// This should never happen
 			if (town == null)
@@ -3018,7 +3018,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 					TownyMessaging.sendErrorMsg(player, Translatable.of("msg_warning_town_ruined_if_deleted2", TownySettings.getTownRuinsMinDurationHours()));
 			}
 			Confirmation.runOnAccept(() -> {
-				townyUniverse.getDataSource().removeTown(town);
+				townyUniverse.getSaveDataSource().removeTown(town);
 				if (TownySettings.getTownUnclaimCoolDownTime() > 0)
 					CooldownTimerTask.addCooldownTimer(player.getName(), CooldownType.TOWN_DELETE);
 			}).sendTo(player);
@@ -3030,7 +3030,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 
 		Confirmation.runOnAccept(() -> {
 			TownyMessaging.sendMsg(player, Translatable.of("town_deleted_by_admin", town.getName()));
-			townyUniverse.getDataSource().removeTown(town);
+			townyUniverse.getSaveDataSource().removeTown(town);
 		}).sendTo(player);
 	}
 
@@ -3258,7 +3258,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 				}
 			TownyMessaging.sendPrefixedNationMessage(town.getNation(), Translatable.of("msg_nation_disbanded_town_not_enough_residents", town.getName()));
 			TownyMessaging.sendGlobalMessage(Translatable.of("msg_del_nation", town.getNation()));
-			TownyUniverse.getInstance().getDataSource().removeNation(town.getNation());
+			TownyUniverse.getInstance().getSaveDataSource().removeNation(town.getNation());
 
 			if (TownyEconomyHandler.isActive() && TownySettings.isRefundNationDisbandLowResidents()) {
 				town.getAccount().deposit(TownySettings.getNewNationPrice(), "nation refund");
@@ -3939,7 +3939,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 			String succumbingTownName = succumbingTown.getName();
 
 			// Start merge
-			TownyUniverse.getInstance().getDataSource().mergeTown(remainingTown, succumbingTown);
+			TownyUniverse.getInstance().getSaveDataSource().mergeTown(remainingTown, succumbingTown);
 			TownyMessaging.sendGlobalMessage(Translatable.of("town1_has_merged_with_town2", succumbingTown, remainingTown));
 
 			TownMergeEvent townMergeEvent = new TownMergeEvent(remainingTown, succumbingTownName, succumbingTownUUID);

--- a/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -811,12 +811,12 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		}
 		
 		if (split[0].equalsIgnoreCase("save")) {
-			if (TownyUniverse.getInstance().getDataSource().saveAll())
+			if (TownyUniverse.getInstance().getSaveDataSource().saveAll())
 				TownyMessaging.sendMsg(sender, Translatable.of("msg_save_success"));
 	
 		} else if (split[0].equalsIgnoreCase("load")) {
 			TownyUniverse.getInstance().clearAllObjects();			
-			if (TownyUniverse.getInstance().getDataSource().loadAll()) {
+			if (TownyUniverse.getInstance().getLoadDataSource().loadAll()) {
 				TownyMessaging.sendMsg(sender, Translatable.of("msg_load_success"));
 				BukkitTools.fireEvent(new TownyLoadedDatabaseEvent());
 			}
@@ -1073,7 +1073,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		if (NameValidation.isBlacklistName(split[2]))
 			throw new TownyException(Translatable.of("msg_invalid_name"));
 
-		TownyUniverse.getInstance().getDataSource().renamePlayer(resident, split[2]);
+		TownyUniverse.getInstance().getSaveDataSource().renamePlayer(resident, split[2]);
 	}
 
 	private void residentFriend(CommandSender sender, String[] split, Resident resident) throws TownyException {
@@ -1105,7 +1105,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_RESIDENT_DELETE.getNode());
 		Confirmation.runOnAccept(()-> {
 			Player player = resident.isOnline() ? resident.getPlayer() : null;
-			TownyUniverse.getInstance().getDataSource().removeResident(resident);
+			TownyUniverse.getInstance().getSaveDataSource().removeResident(resident);
 			TownyMessaging.sendMsg(sender, Translatable.of("msg_del_resident", resident.getName()));
 
 			if (player != null)
@@ -1161,7 +1161,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOWN_DELETE.getNode());
 			Confirmation.runOnAccept(() -> {
 				TownyMessaging.sendMsg(sender, Translatable.of("town_deleted_by_admin", town.getName()));
-				TownyUniverse.getInstance().getDataSource().removeTown(town);
+				TownyUniverse.getInstance().getSaveDataSource().removeTown(town);
 			}).sendTo(sender);
 			break;
 		case "rename":
@@ -1175,7 +1175,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			if (NameValidation.isBlacklistName(name) || (!TownySettings.areNumbersAllowedInTownNames() && NameValidation.containsNumbers(name)))
 				throw new TownyException(Translatable.of("msg_invalid_name"));
 
-			townyUniverse.getDataSource().renameTown(town, name);
+			townyUniverse.getSaveDataSource().renameTown(town, name);
 			TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_town_set_name", getSenderFormatted(sender), town.getName()));
 			TownyMessaging.sendMsg(sender, Translatable.of("msg_town_set_name", getSenderFormatted(sender), town.getName()));
 			break;
@@ -1302,7 +1302,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			if (remainingTown.equals(town))
 				throw new TownyException(Translatable.of("msg_err_invalid_name", split[2]));
 			Confirmation.runOnAccept(() -> {
-				townyUniverse.getDataSource().mergeTown(town, remainingTown);
+				townyUniverse.getSaveDataSource().mergeTown(town, remainingTown);
 				TownyMessaging.sendGlobalMessage(Translatable.of("town1_has_merged_with_town2", town, remainingTown));
 			}).sendTo(sender);
 			break;
@@ -1531,7 +1531,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 				if (sender instanceof Player)
 					TownyMessaging.sendMsg(sender, Translatable.of("nation_deleted_by_admin", nation.getName()));
 				
-				TownyUniverse.getInstance().getDataSource().removeNation(nation);
+				TownyUniverse.getInstance().getSaveDataSource().removeNation(nation);
 				TownyMessaging.sendGlobalMessage(Translatable.of("MSG_DEL_NATION", nation.getName()));
 			}).sendTo(sender);
 			break;
@@ -1546,7 +1546,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			BukkitTools.ifCancelledThenThrow(new NationPreRenameEvent(nation, name));
 			if (NameValidation.isBlacklistName(name) || (!TownySettings.areNumbersAllowedInNationNames() && NameValidation.containsNumbers(name)))
 				throw new TownyException(Translatable.of("msg_invalid_name"));
-			townyUniverse.getDataSource().renameNation(nation, name);
+			townyUniverse.getSaveDataSource().renameNation(nation, name);
 			TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_nation_set_name", getSenderFormatted(sender), nation.getName()));
 			TownyMessaging.sendMsg(sender, Translatable.of("msg_nation_set_name", getSenderFormatted(sender), nation.getName()));
 			break;
@@ -1560,7 +1560,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			if (remainingNation.equals(nation))
 				throw new TownyException(Translatable.of("msg_err_invalid_name", split[2]));
 			Confirmation.runOnAccept(() -> {
-				townyUniverse.getDataSource().mergeNation(nation, remainingNation);
+				townyUniverse.getSaveDataSource().mergeNation(nation, remainingNation);
 				TownyMessaging.sendGlobalMessage(Translatable.of("nation1_has_merged_with_nation2", nation, remainingNation));
 			}).sendTo(sender);
 			break;
@@ -1912,7 +1912,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 
 		// If the previous mayor was an NPC make sure they're removed from the database.
 		if (deleteOldMayor)
-			TownyUniverse.getInstance().getDataSource().removeResident(oldMayor);
+			TownyUniverse.getInstance().getSaveDataSource().removeResident(oldMayor);
 
 		// NPC mayors set their towns to not pay any upkeep.
 		town.setHasUpkeep(!newMayor.isNPC());
@@ -2064,7 +2064,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 	public void reloadConfig(CommandSender sender, boolean reset) {
 
 		if (reset) {
-			TownyUniverse.getInstance().getDataSource().deleteFile(plugin.getConfigPath());
+			TownyUniverse.getInstance().getSaveDataSource().deleteFile(plugin.getConfigPath());
 			TownyMessaging.sendMsg(sender, Translatable.of("msg_reset_config"));
 		}
 		
@@ -2088,7 +2088,8 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 	 *
 	 */
 	public void reloadDatabase(CommandSender sender) {
-		TownyUniverse.getInstance().getDataSource().finishTasks();
+		TownyUniverse.getInstance().getLoadDataSource().finishTasks();
+		TownyUniverse.getInstance().getSaveDataSource().finishTasks();
 		try {
 			plugin.loadFoundation(true);
 		} catch (TownyInitException tie) {

--- a/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
@@ -443,7 +443,7 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 			if (town != null) {
 				// Delete the town if there are no more residents
 				if (town.getNumResidents() <= 1) {
-					universe.getDataSource().removeTown(town);
+					universe.getSaveDataSource().removeTown(town);
 				}
 
 				resident.removeTown();

--- a/src/com/palmergames/bukkit/towny/object/Nation.java
+++ b/src/com/palmergames/bukkit/towny/object/Nation.java
@@ -608,7 +608,7 @@ public class Nation extends Government {
 	
 	@Override
 	public void save() {
-		TownyUniverse.getInstance().getDataSource().saveNation(this);
+		TownyUniverse.getInstance().getSaveDataSource().saveNation(this);
 	}
 	
 	@Override

--- a/src/com/palmergames/bukkit/towny/object/PlotGroup.java
+++ b/src/com/palmergames/bukkit/towny/object/PlotGroup.java
@@ -162,7 +162,7 @@ public class PlotGroup extends ObjectGroup implements TownBlockOwner, Savable {
 
 	@Override
 	public void save() {
-		TownyUniverse.getInstance().getDataSource().savePlotGroup(this);
+		TownyUniverse.getInstance().getSaveDataSource().savePlotGroup(this);
 	}
 
 	public void setTrustedResidents(Set<Resident> trustedResidents) {

--- a/src/com/palmergames/bukkit/towny/object/Resident.java
+++ b/src/com/palmergames/bukkit/towny/object/Resident.java
@@ -887,7 +887,7 @@ public class Resident extends TownyObject implements InviteReceiver, EconomyHand
 
 	@Override
 	public void save() {
-		TownyUniverse.getInstance().getDataSource().saveResident(this);
+		TownyUniverse.getInstance().getSaveDataSource().saveResident(this);
 	}
 
 	public long getJoinedTownAt() {

--- a/src/com/palmergames/bukkit/towny/object/Town.java
+++ b/src/com/palmergames/bukkit/towny/object/Town.java
@@ -251,7 +251,7 @@ public class Town extends Government implements TownBlockOwner {
 		try {
 			oldNation.removeTown(this);
 		} catch (EmptyNationException e) {
-			TownyUniverse.getInstance().getDataSource().removeNation(oldNation);
+			TownyUniverse.getInstance().getSaveDataSource().removeNation(oldNation);
 			TownyMessaging.sendGlobalMessage(Translatable.of("msg_del_nation", e.getNation().getName()));
 		}
 		
@@ -1460,7 +1460,7 @@ public class Town extends Government implements TownBlockOwner {
 
 	@Override
 	public void save() {
-		TownyUniverse.getInstance().getDataSource().saveTown(this);
+		TownyUniverse.getInstance().getSaveDataSource().saveTown(this);
 	}
 
 	public void saveTownBlocks() {

--- a/src/com/palmergames/bukkit/towny/object/TownBlock.java
+++ b/src/com/palmergames/bukkit/towny/object/TownBlock.java
@@ -351,7 +351,7 @@ public class TownBlock extends TownyObject {
 		
 		// Delete a jail if this is no longer going to be a jail.
 		if (this.isJail() && !TownBlockType.JAIL.equals(type) && getJail() != null) {
-			TownyUniverse.getInstance().getDataSource().removeJail(getJail());
+			TownyUniverse.getInstance().getSaveDataSource().removeJail(getJail());
 			setJail(null);
 		}
 
@@ -549,7 +549,7 @@ public class TownBlock extends TownyObject {
 
 	@Override
 	public void save() {
-		TownyUniverse.getInstance().getDataSource().saveTownBlock(this);
+		TownyUniverse.getInstance().getSaveDataSource().saveTownBlock(this);
 	}
 
 	public long getClaimedAt() {

--- a/src/com/palmergames/bukkit/towny/object/TownyWorld.java
+++ b/src/com/palmergames/bukkit/towny/object/TownyWorld.java
@@ -998,6 +998,6 @@ public class TownyWorld extends TownyObject {
 
 	@Override
 	public void save() {
-		TownyUniverse.getInstance().getDataSource().saveWorld(this);
+		TownyUniverse.getInstance().getSaveDataSource().saveWorld(this);
 	}
 }

--- a/src/com/palmergames/bukkit/towny/object/jail/Jail.java
+++ b/src/com/palmergames/bukkit/towny/object/jail/Jail.java
@@ -103,7 +103,7 @@ public class Jail implements Savable {
 	
 	@Override
 	public void save() {
-		TownyUniverse.getInstance().getDataSource().saveJail(this);
+		TownyUniverse.getInstance().getSaveDataSource().saveJail(this);
 	}
 
 	public boolean hasCells() {

--- a/src/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
+++ b/src/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
@@ -191,7 +191,7 @@ public class TownyRegenAPI {
 		regenWorldCoordList = getRegenQueueList().stream()
 			.filter(wc -> !world.equals(wc.getTownyWorld()))
 			.collect(Collectors.toList());
-		TownyUniverse.getInstance().getDataSource().saveRegenList();
+		TownyUniverse.getInstance().getSaveDataSource().saveRegenList();
 	}
 
 	/**
@@ -202,7 +202,7 @@ public class TownyRegenAPI {
 		if (!regenWorldCoordList.contains(wc))
 			return;
 		regenWorldCoordList.remove(wc);
-		TownyUniverse.getInstance().getDataSource().saveRegenList();
+		TownyUniverse.getInstance().getSaveDataSource().saveRegenList();
 	}
 
 	/**
@@ -215,7 +215,7 @@ public class TownyRegenAPI {
 			return;
 		regenWorldCoordList.add(wc);
 		if (save)
-			TownyUniverse.getInstance().getDataSource().saveRegenList();
+			TownyUniverse.getInstance().getSaveDataSource().saveRegenList();
 	}
 
 	public static  void getWorldCoordFromQueueForRegeneration() {
@@ -321,8 +321,8 @@ public class TownyRegenAPI {
 	 */
 	public static void addPlotChunkSnapshot(PlotBlockData plotChunk) {
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
-		if (townyUniverse.getDataSource().loadPlotData(plotChunk.getWorldName(), plotChunk.getX(), plotChunk.getZ()) == null) {
-			townyUniverse.getDataSource().savePlotData(plotChunk);
+		if (townyUniverse.getLoadDataSource().loadPlotData(plotChunk.getWorldName(), plotChunk.getX(), plotChunk.getZ()) == null) {
+			townyUniverse.getSaveDataSource().savePlotData(plotChunk);
 		}
 	}
 
@@ -332,7 +332,7 @@ public class TownyRegenAPI {
 	 * @param plotChunk - Chunk to delete snapshot (PlotBlockData)
 	 */
 	private static void deletePlotChunkSnapshot(PlotBlockData plotChunk) {
-		TownyUniverse.getInstance().getDataSource().deletePlotData(plotChunk);
+		TownyUniverse.getInstance().getSaveDataSource().deletePlotData(plotChunk);
 	}
 
 	/**
@@ -342,7 +342,7 @@ public class TownyRegenAPI {
 	 * @return loads the PlotData for the given townBlock or returns null.   
 	 */
 	public static PlotBlockData getPlotChunkSnapshot(TownBlock townBlock) {
-		return TownyUniverse.getInstance().getDataSource().loadPlotData(townBlock);
+		return TownyUniverse.getInstance().getLoadDataSource().loadPlotData(townBlock);
 	}
 
 	/**
@@ -426,7 +426,7 @@ public class TownyRegenAPI {
 //				}
 //			}
 //			
-//			TownyUniverse.getDataSource().getResident(player.getName()).addUndo(snapshot);
+//			TownyUniverse.getLoadDataSource().getResident(player.getName()).addUndo(snapshot);
 //
 //			Bukkit.getWorld(player.getWorld().getName()).regenerateChunk(coord.getX(), coord.getZ());
 //

--- a/src/com/palmergames/bukkit/towny/tasks/BackupTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/BackupTask.java
@@ -10,7 +10,7 @@ public class BackupTask implements Runnable {
 	@Override
 	public void run() {
 
-		TownyDataSource dataSource = TownyUniverse.getInstance().getDataSource();
+		TownyDataSource dataSource = TownyUniverse.getInstance().getLoadDataSource();
 		Towny.getPlugin().getLogger().info("Making backup...");
 		try {
 			dataSource.backup();

--- a/src/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
@@ -92,7 +92,7 @@ public class DailyTimerTask extends TownyTimerTask {
 				if (town.getTownBlocks().size() == 0) {
 					deletedTowns.add(town.getName());
 					removedTowns.add(town.getName());
-					universe.getDataSource().removeTown(town);
+					universe.getSaveDataSource().removeTown(town);
 				}
 			}
 			if (!deletedTowns.isEmpty())
@@ -219,7 +219,7 @@ public class DailyTimerTask extends TownyTimerTask {
 						// OR Bankruptcy enabled but towns aren't allowed to use debt to pay nation tax. 
 							
 							if (TownySettings.doesNationTaxDeleteConqueredTownsWhichCannotPay() && town.isConquered()) {
-								universe.getDataSource().removeTown(town);
+								universe.getSaveDataSource().removeTown(town);
 								localTownsDestroyed.add(town.getName());
 								continue;
 							}
@@ -476,7 +476,7 @@ public class DailyTimerTask extends TownyTimerTask {
 						if (!TownySettings.isTownBankruptcyEnabled()) {
 						// Bankruptcy is disabled, remove the town for not paying upkeep.
 							TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_your_town_couldnt_pay_upkeep", TownyEconomyHandler.getFormattedBalance(upkeep)));
-							universe.getDataSource().removeTown(town);
+							universe.getSaveDataSource().removeTown(town);
 							removedTowns.add(town.getName());
 							continue;
 						}
@@ -493,7 +493,7 @@ public class DailyTimerTask extends TownyTimerTask {
 							// Alternatively, if configured, towns will not be allowed to exceed
 							// their debt and be deleted from the server for non-payment finally.
 								TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_your_town_couldnt_pay_upkeep", TownyEconomyHandler.getFormattedBalance(upkeep)));
-								universe.getDataSource().removeTown(town);
+								universe.getSaveDataSource().removeTown(town);
 								removedTowns.add(town.getName());
 								continue;
 							}
@@ -607,7 +607,7 @@ public class DailyTimerTask extends TownyTimerTask {
 						TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_your_nation_payed_upkeep", TownyEconomyHandler.getFormattedBalance(upkeep)));						
 					} else {
 						TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_your_nation_couldnt_pay_upkeep", TownyEconomyHandler.getFormattedBalance(upkeep)));
-						universe.getDataSource().removeNation(nation);
+						universe.getSaveDataSource().removeNation(nation);
 						removedNations.add(nation.getName());
 					}
 				} else if (upkeep < 0) {

--- a/src/com/palmergames/bukkit/towny/tasks/NPCCleanupTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/NPCCleanupTask.java
@@ -15,7 +15,7 @@ public class NPCCleanupTask implements Runnable {
 	public void run() {
 		for (Resident resident : new ArrayList<>(TownyUniverse.getInstance().getResidents())) {
 			if (resident.isNPC() && !resident.hasTown())
-				TownyUniverse.getInstance().getDataSource().removeResident(resident);
+				TownyUniverse.getInstance().getSaveDataSource().removeResident(resident);
 		}
 	}
 }

--- a/src/com/palmergames/bukkit/towny/tasks/OnPlayerLogin.java
+++ b/src/com/palmergames/bukkit/towny/tasks/OnPlayerLogin.java
@@ -81,7 +81,7 @@ public class OnPlayerLogin implements Runnable {
 				 * Make a brand new Resident.
 				 */
 				try {
-					universe.getDataSource().newResident(player.getName(), player.getUniqueId());
+					universe.getSaveDataSource().newResident(player.getName(), player.getUniqueId());
 					TownySettings.incrementUUIDCount();
 					
 					resident = universe.getResident(player.getUniqueId());
@@ -92,7 +92,7 @@ public class OnPlayerLogin implements Runnable {
 					resident.setRegistered(System.currentTimeMillis());
 
 					final Resident finalResident = resident;
-					universe.getDataSource().getHibernatedResidentRegistered(player.getUniqueId()).thenAccept(registered -> {
+					universe.getLoadDataSource().getHibernatedResidentRegistered(player.getUniqueId()).thenAccept(registered -> {
 						if (registered.isPresent()) {
 							finalResident.setRegistered(registered.get());
 							finalResident.save();
@@ -126,7 +126,7 @@ public class OnPlayerLogin implements Runnable {
 			// Name change test.
 			if (!resident.getName().equals(player.getName())) {
 				try {
-					universe.getDataSource().renamePlayer(resident, player.getName());
+					universe.getSaveDataSource().renamePlayer(resident, player.getName());
 				} catch (AlreadyRegisteredException e) {
 					e.printStackTrace();
 				} catch (NotRegisteredException e) {

--- a/src/com/palmergames/bukkit/towny/tasks/ResidentPurge.java
+++ b/src/com/palmergames/bukkit/towny/tasks/ResidentPurge.java
@@ -62,7 +62,7 @@ public class ResidentPurge extends Thread {
 				}
 				count++;
 				message(Translatable.of("msg_deleting_resident", resident.getName()));
-				townyUniverse.getDataSource().removeResident(resident);
+				townyUniverse.getSaveDataSource().removeResident(resident);
 			}
 		}
 

--- a/src/com/palmergames/bukkit/towny/tasks/TownClaim.java
+++ b/src/com/palmergames/bukkit/towny/tasks/TownClaim.java
@@ -203,7 +203,7 @@ public class TownClaim implements Runnable {
 			TownyRegenAPI.removeFromRegenQueueList(worldCoord);
 		}
 		// Check if a plot snapshot exists for this townblock already (inactive, unqueued regeneration.)
-		if (!TownyUniverse.getInstance().getDataSource().hasPlotData(townBlock)) {
+		if (!TownyUniverse.getInstance().getLoadDataSource().hasPlotData(townBlock)) {
 			// Queue to have a snapshot made if there is not already an earlier snapshot.
 			TownyRegenAPI.addWorldCoord(worldCoord);
 			townBlock.setLocked(true);
@@ -251,7 +251,7 @@ public class TownClaim implements Runnable {
 	 */
 	private void unclaimTownBlock(TownBlock townBlock) {
 		Bukkit.getScheduler().scheduleSyncDelayedTask(plugin,
-				() -> TownyUniverse.getInstance().getDataSource().removeTownBlock(townBlock), 1);
+				() -> TownyUniverse.getInstance().getSaveDataSource().removeTownBlock(townBlock), 1);
 	}
 
 	private void refundForUnclaim(double unclaimRefund, int numUnclaimed) {

--- a/src/com/palmergames/bukkit/towny/utils/ResidentUtil.java
+++ b/src/com/palmergames/bukkit/towny/utils/ResidentUtil.java
@@ -215,7 +215,7 @@ public class ResidentUtil {
 		try {
 			String name = nextNpcName();
 			final UUID npcUUID = UUID.randomUUID();
-			TownyUniverse.getInstance().getDataSource().newResident(name, npcUUID);
+			TownyUniverse.getInstance().getSaveDataSource().newResident(name, npcUUID);
 			npc = TownyUniverse.getInstance().getResident(npcUUID);
 			npc.setRegistered(System.currentTimeMillis());
 			npc.setLastOnline(0);

--- a/src/com/palmergames/bukkit/towny/utils/TownRuinUtil.java
+++ b/src/com/palmergames/bukkit/towny/utils/TownRuinUtil.java
@@ -117,7 +117,7 @@ public class TownRuinUtil {
 		// Unregister the now empty plotgroups.
 		if (town.getPlotGroups() != null)
 			for (PlotGroup group : new ArrayList<>(town.getPlotGroups()))
-				TownyUniverse.getInstance().getDataSource().removePlotGroup(group);
+				TownyUniverse.getInstance().getSaveDataSource().removePlotGroup(group);
 		
 		// Check if Town has more residents than it should be allowed (if it were the capital of a nation.)
 		if (TownySettings.getMaxResidentsPerTown() > 0)
@@ -201,7 +201,7 @@ public class TownRuinUtil {
 		if (oldMayor != null && oldMayor.isNPC()) {
 			// Delete the resident if the old mayor was an NPC.
 			oldMayor.removeTown();
-			TownyUniverse.getInstance().getDataSource().removeResident(oldMayor);
+			TownyUniverse.getInstance().getSaveDataSource().removeResident(oldMayor);
 			// set upkeep again
 			town.setHasUpkeep(true);
 		}
@@ -230,7 +230,7 @@ public class TownRuinUtil {
 					&& town.getRuinedTime() != 0 && getTimeSinceRuining(town) > TownySettings
 					.getTownRuinsMaxDurationHours()) {
 				//Ruin found & recently ruined end time reached. Delete town now.
-				townyUniverse.getDataSource().removeTown(town, false);
+				townyUniverse.getSaveDataSource().removeTown(town, false);
 			}
 		}
     }


### PR DESCRIPTION
…ion leak

<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
The following are problems caused by sharing one data source even if the data saving/loading method is different.

1. When dispatching a command /townyadmin database load, the load does not work properly because saving after loading overwrites single datasource field.
2. As with the problem above, connection leaks occur because the datasource is not closed properly way (It MUST be closed through the close method) and disappears from the referencing.
____
#### Relevant Towny Issue ticket:
https://discord.com/channels/321452088519426058/321452088519426058/1064914491252420739
____
- [x] I have tested this pull request for defects on a server. 
the test completes on a server with 300 online players

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
