### PR TITLE
Put limits on how many unclaimed townblocks can have their material/entity deletions run at once.

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/PlotCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/PlotCommand.java
@@ -44,7 +44,7 @@ import com.palmergames.bukkit.towny.object.WorldCoord;
 import com.palmergames.bukkit.towny.object.jail.Jail;
 import com.palmergames.bukkit.towny.permissions.PermissionNodes;
 import com.palmergames.bukkit.towny.permissions.TownyPermissionSource;
-import com.palmergames.bukkit.towny.regen.TownyRegenAPI;
+import com.palmergames.bukkit.towny.regen.WorldCoordMaterialRemover;
 import com.palmergames.bukkit.towny.tasks.CooldownTimerTask;
 import com.palmergames.bukkit.towny.tasks.PlotClaim;
 import com.palmergames.bukkit.towny.tasks.CooldownTimerTask.CooldownType;
@@ -761,7 +761,7 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 						if (materialsToDelete.isEmpty())
 							return true;
 						
-						TownyRegenAPI.deleteMaterialsFromWorldCoord(townBlock.getWorldCoord(), materialsToDelete);
+						WorldCoordMaterialRemover.queueDeleteWorldCoordMaterials(townBlock.getWorldCoord(), materialsToDelete);
 						TownyMessaging.sendMsg(player, Translatable.of("msg_clear_plot_material", StringMgmt.join(materialsToDelete, ", ")));
 
 						// Raise an event for the claim

--- a/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
@@ -41,6 +41,8 @@ import com.palmergames.bukkit.towny.object.jail.Jail;
 import com.palmergames.bukkit.towny.object.jail.UnJailReason;
 import com.palmergames.bukkit.towny.regen.PlotBlockData;
 import com.palmergames.bukkit.towny.regen.TownyRegenAPI;
+import com.palmergames.bukkit.towny.regen.WorldCoordEntityRemover;
+import com.palmergames.bukkit.towny.regen.WorldCoordMaterialRemover;
 import com.palmergames.bukkit.towny.tasks.CooldownTimerTask;
 import com.palmergames.bukkit.towny.tasks.DeleteFileTask;
 import com.palmergames.bukkit.towny.tasks.CooldownTimerTask.CooldownType;
@@ -496,10 +498,10 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 		deleteTownBlock(townBlock);
 
 		if (townBlock.getWorld().isDeletingEntitiesOnUnclaim())
-			TownyRegenAPI.addDeleteTownBlockEntityQueue(townBlock.getWorldCoord());
+			WorldCoordEntityRemover.addToQueue(townBlock.getWorldCoord());
 
 		if (townBlock.getWorld().isUsingPlotManagementDelete())
-			TownyRegenAPI.addDeleteTownBlockIdQueue(townBlock.getWorldCoord());
+			WorldCoordMaterialRemover.addToQueue(townBlock.getWorldCoord());
 
 		// Move the plot to be restored
 		if (townBlock.getWorld().isUsingPlotManagementRevert())

--- a/src/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
+++ b/src/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
@@ -47,9 +47,11 @@ public class TownyRegenAPI {
 
 	// List of all old plots still to be processed for Entity removal
 	private static final List<WorldCoord> deleteTownBlockEntityQueue = new ArrayList<>();
+	private static final List<WorldCoord> activeDeleteTownBlockEntityQueue = new ArrayList<>();
 
 	// List of all old plots still to be processed for Block removal
 	private static final List<WorldCoord> deleteTownBlockIdQueue = new ArrayList<>();
+	private static final List<WorldCoord> activeDeleteTownBlockIdQueue = new ArrayList<>();
 
 	// A list of worldCoords which are needing snapshots
 	private static final List<WorldCoord> worldCoords = new ArrayList<>();
@@ -373,143 +375,134 @@ public class TownyRegenAPI {
 		return "[" + wc.getWorldName() + "|" + wc.getX() + "|" + wc.getZ() + "]";
 	}
 
-//	/**
-//	 * Regenerate the chunk the player is stood in and store the block data so it can be undone later.
-//	 * 
-//	 * @param player
-//	 */
-//	public static void regenChunk(Player player) {
-//		
-//		try {
-//			Coord coord = Coord.parseCoord(player);
-//			World world = player.getWorld();
-//			Chunk chunk = world.getChunkAt(player.getLocation());
-//			int maxHeight = world.getMaxHeight();
-//			
-//			ChunkSnapshot snapshot = chunk.getChunkSnapshot(true,true,false);
-//			
-//			Object[][][] snapshot = new Object[16][maxHeight][16];
-//			
-//			for (int x = 0; x < 16; x++) {
-//				for (int z = 0; z < 16; z++) {
-//					for (int y = 0; y < maxHeight; y++) {
-//						
-//						//Current block to save
-//						BlockState state = chunk.getBlock(x, y, z).getState();
-//						
-//						if (state instanceof org.bukkit.block.Sign) {
-//							
-//							BlockSign sign = new BlockSign(BukkitTools.getTypeId(state), BukkitTools.getDataData(state), ((org.bukkit.block.Sign) state).getLines());
-//							sign.setLocation(state.getLocation());
-//							snapshot[x][y][z] = sign;
-//							
-//						} else if (state instanceof CreatureSpawner) {
-//							
-//							BlockMobSpawner spawner = new BlockMobSpawner(((CreatureSpawner) state).getSpawnedType());
-//							spawner.setLocation(state.getLocation());
-//							spawner.setDelay(((CreatureSpawner) state).getDelay());
-//							snapshot[x][y][z] = spawner;
-//							
-//						} else if ((state instanceof InventoryHolder) && !(state instanceof Player)) {
-//							
-//							BlockInventoryHolder holder = new BlockInventoryHolder(BukkitTools.getTypeId(state), BukkitTools.getDataData(state), ((InventoryHolder) state).getInventory().getContents());
-//							holder.setLocation(state.getLocation());
-//							snapshot[x][y][z] = holder;
-//							
-//						} else {
-//						
-//							snapshot[x][y][z] = new BlockObject(BukkitTools.getTypeId(state), BukkitTools.getDataData(state), state.getLocation());
-//									
-//						}
-//						
-//					}
-//				}
-//			}
-//			
-//			TownyUniverse.getDataSource().getResident(player.getName()).addUndo(snapshot);
-//
-//			Bukkit.getWorld(player.getWorld().getName()).regenerateChunk(coord.getX(), coord.getZ());
-//
-//		} catch (NotRegisteredException e) {
-//			// Failed to get resident
-//		}
-//	}
-//	
-//	/**
-//	 * Restore the relevant chunk using the snapshot data stored in the resident
-//	 * object.
-//	 * 
-//	 * @param snapshot
-//	 * @param resident
-//	 */
-//	public static void regenUndo(Object[][][] snapshot, Resident resident) {
-//
-//		BlockObject key = ((BlockObject) snapshot[0][0][0]);
-//		World world = key.getLocation().getWorld();
-//		Chunk chunk = key.getLocation().getChunk();
-//		
-//		int maxHeight = world.getMaxHeight();
-//		
-//		for (int x = 0; x < 16; x++) {
-//			for (int z = 0; z < 16; z++) {
-//				for (int y = 0; y < maxHeight; y++) {
-//					
-//					// Snapshot data we need to update the world.
-//					Object state = snapshot[x][y][z];
-//					
-//					// The block we will be updating
-//					Block block = chunk.getBlock(x, y, z);
-//					
-//					if (state instanceof BlockSign) {
-//
-//						BlockSign signData = (BlockSign)state;
-//						BukkitTools.setTypeIdAndData(block, signData.getTypeId(), signData.getData(), false);
-//						
-//						Sign sign = (Sign) block.getState();
-//						int i = 0;
-//						for (String line : signData.getLines())
-//							sign.setLine(i++, line);
-//						
-//						sign.update(true);
-//						
-//					} else if (state instanceof BlockMobSpawner) {
-//						
-//						BlockMobSpawner spawnerData = (BlockMobSpawner) state;
-//						
-//						BukkitTools.setTypeIdAndData(block, spawnerData.getTypeId(), spawnerData.getData(), false);
-//						((CreatureSpawner) block.getState()).setSpawnedType(spawnerData.getSpawnedType());
-//						((CreatureSpawner) block.getState()).setDelay(spawnerData.getDelay());
-//						
-//					} else if ((state instanceof BlockInventoryHolder) && !(state instanceof Player)) {
-//						
-//						BlockInventoryHolder containerData = (BlockInventoryHolder) state;
-//						BukkitTools.setTypeIdAndData(block, containerData.getTypeId(), containerData.getData(), false);
-//						
-//						// Container to receive the inventory
-//						InventoryHolder container = (InventoryHolder) block.getState();
-//						
-//						// Contents we are respawning.						
-//						if (containerData.getItems().length > 0)
-//							container.getInventory().setContents(containerData.getItems());
-//						
-//					} else {
-//						
-//						BlockObject blockData = (BlockObject) state;	
-//						BukkitTools.setTypeIdAndData(block, blockData.getTypeId(), blockData.getData(), false);
-//					}
-//					
-//					
-//					
-//
-//				}
-//			}
-//
-//		}
-//
-//		TownyMessaging.sendMessage(BukkitTools.getPlayerExact(resident.getName()), Translation.of("msg_undo_complete"));
-//
-//	}
+/* Old Resident-stored chunk regeneration.
 
+	public static void regenChunk(Player player) {
+		
+		try {
+			Coord coord = Coord.parseCoord(player);
+			World world = player.getWorld();
+			Chunk chunk = world.getChunkAt(player.getLocation());
+			int maxHeight = world.getMaxHeight();
+			
+			ChunkSnapshot snapshot = chunk.getChunkSnapshot(true,true,false);
+			
+			Object[][][] snapshot = new Object[16][maxHeight][16];
+			
+			for (int x = 0; x < 16; x++) {
+				for (int z = 0; z < 16; z++) {
+					for (int y = 0; y < maxHeight; y++) {
+						
+						//Current block to save
+						BlockState state = chunk.getBlock(x, y, z).getState();
+						
+						if (state instanceof org.bukkit.block.Sign) {
+							
+							BlockSign sign = new BlockSign(BukkitTools.getTypeId(state), BukkitTools.getDataData(state), ((org.bukkit.block.Sign) state).getLines());
+							sign.setLocation(state.getLocation());
+							snapshot[x][y][z] = sign;
+							
+						} else if (state instanceof CreatureSpawner) {
+							
+							BlockMobSpawner spawner = new BlockMobSpawner(((CreatureSpawner) state).getSpawnedType());
+							spawner.setLocation(state.getLocation());
+							spawner.setDelay(((CreatureSpawner) state).getDelay());
+							snapshot[x][y][z] = spawner;
+							
+						} else if ((state instanceof InventoryHolder) && !(state instanceof Player)) {
+							
+							BlockInventoryHolder holder = new BlockInventoryHolder(BukkitTools.getTypeId(state), BukkitTools.getDataData(state), ((InventoryHolder) state).getInventory().getContents());
+							holder.setLocation(state.getLocation());
+							snapshot[x][y][z] = holder;
+							
+						} else {
+						
+							snapshot[x][y][z] = new BlockObject(BukkitTools.getTypeId(state), BukkitTools.getDataData(state), state.getLocation());
+									
+						}
+						
+					}
+				}
+			}
+			
+			TownyUniverse.getDataSource().getResident(player.getName()).addUndo(snapshot);
+
+			Bukkit.getWorld(player.getWorld().getName()).regenerateChunk(coord.getX(), coord.getZ());
+
+		} catch (NotRegisteredException e) {
+			// Failed to get resident
+		}
+	}
+
+	public static void regenUndo(Object[][][] snapshot, Resident resident) {
+
+		BlockObject key = ((BlockObject) snapshot[0][0][0]);
+		World world = key.getLocation().getWorld();
+		Chunk chunk = key.getLocation().getChunk();
+		
+		int maxHeight = world.getMaxHeight();
+		
+		for (int x = 0; x < 16; x++) {
+			for (int z = 0; z < 16; z++) {
+				for (int y = 0; y < maxHeight; y++) {
+					
+					// Snapshot data we need to update the world.
+					Object state = snapshot[x][y][z];
+					
+					// The block we will be updating
+					Block block = chunk.getBlock(x, y, z);
+					
+					if (state instanceof BlockSign) {
+
+						BlockSign signData = (BlockSign)state;
+						BukkitTools.setTypeIdAndData(block, signData.getTypeId(), signData.getData(), false);
+						
+						Sign sign = (Sign) block.getState();
+						int i = 0;
+						for (String line : signData.getLines())
+							sign.setLine(i++, line);
+						
+						sign.update(true);
+						
+					} else if (state instanceof BlockMobSpawner) {
+						
+						BlockMobSpawner spawnerData = (BlockMobSpawner) state;
+						
+						BukkitTools.setTypeIdAndData(block, spawnerData.getTypeId(), spawnerData.getData(), false);
+						((CreatureSpawner) block.getState()).setSpawnedType(spawnerData.getSpawnedType());
+						((CreatureSpawner) block.getState()).setDelay(spawnerData.getDelay());
+						
+					} else if ((state instanceof BlockInventoryHolder) && !(state instanceof Player)) {
+						
+						BlockInventoryHolder containerData = (BlockInventoryHolder) state;
+						BukkitTools.setTypeIdAndData(block, containerData.getTypeId(), containerData.getData(), false);
+						
+						// Container to receive the inventory
+						InventoryHolder container = (InventoryHolder) block.getState();
+						
+						// Contents we are respawning.						
+						if (containerData.getItems().length > 0)
+							container.getInventory().setContents(containerData.getItems());
+						
+					} else {
+						
+						BlockObject blockData = (BlockObject) state;	
+						BukkitTools.setTypeIdAndData(block, blockData.getTypeId(), blockData.getData(), false);
+					}
+					
+					
+					
+
+				}
+			}
+
+		}
+
+		TownyMessaging.sendMessage(BukkitTools.getPlayerExact(resident.getName()), Translation.of("msg_undo_complete"));
+
+	}
+
+*/
 	/*
 	 * TownBlock Entity Deleting Queue.
 	 */
@@ -540,7 +533,25 @@ public class TownyRegenAPI {
 		
 		return null;
 	}
+
+	public static int getActiveDeleteTownBlockEntityQueueSize() {
+
+		return activeDeleteTownBlockEntityQueue.size();
+	}
 	
+	public static void addActiveDeleteTownBlockEntityQueue(WorldCoord plot) {
+		if (!activeDeleteTownBlockEntityQueue.contains(plot))
+			activeDeleteTownBlockEntityQueue.add(plot);
+	}
+	
+	@Nullable
+	public static WorldCoord getActiveDeleteTownBlockEntityQueue() {
+
+		if (!activeDeleteTownBlockEntityQueue.isEmpty())
+			return activeDeleteTownBlockEntityQueue.remove(0);
+		
+		return null;
+	}
 
 	/**
 	 * Deletes all of a specified entity type from a TownBlock
@@ -595,6 +606,26 @@ public class TownyRegenAPI {
 		return null;
 	}
 
+	public static int getActiveDeleteTownBlockIdQueueSize() {
+
+		return activeDeleteTownBlockIdQueue.size();
+	}
+	
+	public static void addActiveDeleteTownBlockIdQueue(WorldCoord plot) {
+
+		if (!activeDeleteTownBlockIdQueue.contains(plot))
+			activeDeleteTownBlockIdQueue.add(plot);
+	}
+
+	@Nullable
+	public static WorldCoord getActiveDeleteTownBlockIdQueue() {
+
+		if (!activeDeleteTownBlockIdQueue.isEmpty())
+			return activeDeleteTownBlockIdQueue.remove(0);
+		
+		return null;
+	}
+	
 	/**
 	 * Deletes all of a specified block type from a TownBlock
 	 * 
@@ -632,6 +663,7 @@ public class TownyRegenAPI {
 	public static void deleteMaterialsFromWorldCoord(WorldCoord coord, Collection<Material> collection) {
 		int plotSize = TownySettings.getTownBlockSize();
 
+		coord.loadChunks();
 		World world = coord.getBukkitWorld();
 		if (world == null)
 			return;
@@ -655,6 +687,8 @@ public class TownyRegenAPI {
 			toRemove.forEach(block -> block.setType(Material.AIR));
 		else 
 			Bukkit.getScheduler().runTask(Towny.getPlugin(), () -> toRemove.forEach(block -> block.setType(Material.AIR)));
+		
+		coord.unloadChunks();
 	}
 
 	/*

--- a/src/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
+++ b/src/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
@@ -663,7 +663,6 @@ public class TownyRegenAPI {
 	public static void deleteMaterialsFromWorldCoord(WorldCoord coord, Collection<Material> collection) {
 		int plotSize = TownySettings.getTownBlockSize();
 
-		coord.loadChunks();
 		World world = coord.getBukkitWorld();
 		if (world == null)
 			return;
@@ -687,8 +686,6 @@ public class TownyRegenAPI {
 			toRemove.forEach(block -> block.setType(Material.AIR));
 		else 
 			Bukkit.getScheduler().runTask(Towny.getPlugin(), () -> toRemove.forEach(block -> block.setType(Material.AIR)));
-		
-		coord.unloadChunks();
 	}
 
 	/*

--- a/src/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
+++ b/src/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
@@ -2,7 +2,6 @@ package com.palmergames.bukkit.towny.regen;
 
 import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.TownyMessaging;
-import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.event.actions.TownyExplodingBlocksEvent;
 import com.palmergames.bukkit.towny.object.TownBlock;
@@ -12,11 +11,8 @@ import com.palmergames.bukkit.towny.regen.block.BlockLocation;
 import com.palmergames.bukkit.towny.tasks.ProtectionRegenTask;
 import com.palmergames.bukkit.util.BukkitTools;
 
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
-import org.bukkit.World;
 import org.bukkit.block.Block;
-import org.bukkit.entity.Entity;
 import org.bukkit.event.Event;
 import org.bukkit.event.block.BlockExplodeEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
@@ -44,14 +40,6 @@ public class TownyRegenAPI {
 	
 	// table containing snapshot data of active reversions.
 	private static Hashtable<String, PlotBlockData> plotChunks = new Hashtable<>();
-
-	// List of all old plots still to be processed for Entity removal
-	private static final List<WorldCoord> deleteTownBlockEntityQueue = new ArrayList<>();
-	private static final List<WorldCoord> activeDeleteTownBlockEntityQueue = new ArrayList<>();
-
-	// List of all old plots still to be processed for Block removal
-	private static final List<WorldCoord> deleteTownBlockIdQueue = new ArrayList<>();
-	private static final List<WorldCoord> activeDeleteTownBlockIdQueue = new ArrayList<>();
 
 	// A list of worldCoords which are needing snapshots
 	private static final List<WorldCoord> worldCoords = new ArrayList<>();
@@ -375,349 +363,6 @@ public class TownyRegenAPI {
 		return "[" + wc.getWorldName() + "|" + wc.getX() + "|" + wc.getZ() + "]";
 	}
 
-/* Old Resident-stored chunk regeneration.
-
-	public static void regenChunk(Player player) {
-		
-		try {
-			Coord coord = Coord.parseCoord(player);
-			World world = player.getWorld();
-			Chunk chunk = world.getChunkAt(player.getLocation());
-			int maxHeight = world.getMaxHeight();
-			
-			ChunkSnapshot snapshot = chunk.getChunkSnapshot(true,true,false);
-			
-			Object[][][] snapshot = new Object[16][maxHeight][16];
-			
-			for (int x = 0; x < 16; x++) {
-				for (int z = 0; z < 16; z++) {
-					for (int y = 0; y < maxHeight; y++) {
-						
-						//Current block to save
-						BlockState state = chunk.getBlock(x, y, z).getState();
-						
-						if (state instanceof org.bukkit.block.Sign) {
-							
-							BlockSign sign = new BlockSign(BukkitTools.getTypeId(state), BukkitTools.getDataData(state), ((org.bukkit.block.Sign) state).getLines());
-							sign.setLocation(state.getLocation());
-							snapshot[x][y][z] = sign;
-							
-						} else if (state instanceof CreatureSpawner) {
-							
-							BlockMobSpawner spawner = new BlockMobSpawner(((CreatureSpawner) state).getSpawnedType());
-							spawner.setLocation(state.getLocation());
-							spawner.setDelay(((CreatureSpawner) state).getDelay());
-							snapshot[x][y][z] = spawner;
-							
-						} else if ((state instanceof InventoryHolder) && !(state instanceof Player)) {
-							
-							BlockInventoryHolder holder = new BlockInventoryHolder(BukkitTools.getTypeId(state), BukkitTools.getDataData(state), ((InventoryHolder) state).getInventory().getContents());
-							holder.setLocation(state.getLocation());
-							snapshot[x][y][z] = holder;
-							
-						} else {
-						
-							snapshot[x][y][z] = new BlockObject(BukkitTools.getTypeId(state), BukkitTools.getDataData(state), state.getLocation());
-									
-						}
-						
-					}
-				}
-			}
-			
-			TownyUniverse.getDataSource().getResident(player.getName()).addUndo(snapshot);
-
-			Bukkit.getWorld(player.getWorld().getName()).regenerateChunk(coord.getX(), coord.getZ());
-
-		} catch (NotRegisteredException e) {
-			// Failed to get resident
-		}
-	}
-
-	public static void regenUndo(Object[][][] snapshot, Resident resident) {
-
-		BlockObject key = ((BlockObject) snapshot[0][0][0]);
-		World world = key.getLocation().getWorld();
-		Chunk chunk = key.getLocation().getChunk();
-		
-		int maxHeight = world.getMaxHeight();
-		
-		for (int x = 0; x < 16; x++) {
-			for (int z = 0; z < 16; z++) {
-				for (int y = 0; y < maxHeight; y++) {
-					
-					// Snapshot data we need to update the world.
-					Object state = snapshot[x][y][z];
-					
-					// The block we will be updating
-					Block block = chunk.getBlock(x, y, z);
-					
-					if (state instanceof BlockSign) {
-
-						BlockSign signData = (BlockSign)state;
-						BukkitTools.setTypeIdAndData(block, signData.getTypeId(), signData.getData(), false);
-						
-						Sign sign = (Sign) block.getState();
-						int i = 0;
-						for (String line : signData.getLines())
-							sign.setLine(i++, line);
-						
-						sign.update(true);
-						
-					} else if (state instanceof BlockMobSpawner) {
-						
-						BlockMobSpawner spawnerData = (BlockMobSpawner) state;
-						
-						BukkitTools.setTypeIdAndData(block, spawnerData.getTypeId(), spawnerData.getData(), false);
-						((CreatureSpawner) block.getState()).setSpawnedType(spawnerData.getSpawnedType());
-						((CreatureSpawner) block.getState()).setDelay(spawnerData.getDelay());
-						
-					} else if ((state instanceof BlockInventoryHolder) && !(state instanceof Player)) {
-						
-						BlockInventoryHolder containerData = (BlockInventoryHolder) state;
-						BukkitTools.setTypeIdAndData(block, containerData.getTypeId(), containerData.getData(), false);
-						
-						// Container to receive the inventory
-						InventoryHolder container = (InventoryHolder) block.getState();
-						
-						// Contents we are respawning.						
-						if (containerData.getItems().length > 0)
-							container.getInventory().setContents(containerData.getItems());
-						
-					} else {
-						
-						BlockObject blockData = (BlockObject) state;	
-						BukkitTools.setTypeIdAndData(block, blockData.getTypeId(), blockData.getData(), false);
-					}
-					
-					
-					
-
-				}
-			}
-
-		}
-
-		TownyMessaging.sendMessage(BukkitTools.getPlayerExact(resident.getName()), Translation.of("msg_undo_complete"));
-
-	}
-
-*/
-	/*
-	 * TownBlock Entity Deleting Queue.
-	 */
-	
-	/**
-	 * @return true if there are any chunks being processed.
-	 */
-	public static boolean hasDeleteTownBlockEntityQueue() {
-
-		return !deleteTownBlockEntityQueue.isEmpty();
-	}
-
-	public static boolean isDeleteTownBlockEntityQueue(WorldCoord plot) {
-
-		return deleteTownBlockEntityQueue.contains(plot);
-	}
-
-	public static int getDeleteTownBlockEntityQueueSize() {
-
-		return deleteTownBlockEntityQueue.size();
-	}
-
-	public static void addDeleteTownBlockEntityQueue(WorldCoord plot) {
-		if (!deleteTownBlockEntityQueue.contains(plot))
-			deleteTownBlockEntityQueue.add(plot);
-	}
-	
-	@Nullable
-	public static WorldCoord getDeleteTownBlockEntityQueue() {
-
-		if (!deleteTownBlockEntityQueue.isEmpty()) {
-			for (WorldCoord wc : deleteTownBlockEntityQueue)
-				if (!isActiveDeleteTownBlockEntityQueue(wc))
-					return wc;
-		}
-		
-		return null;
-	}
-
-	public static boolean isActiveDeleteTownBlockEntityQueue(WorldCoord plot) {
-
-		return activeDeleteTownBlockEntityQueue.contains(plot);
-	}
-
-	public static int getActiveDeleteTownBlockEntityQueueSize() {
-
-		return activeDeleteTownBlockEntityQueue.size();
-	}
-	
-	public static void addActiveDeleteTownBlockEntityQueue(WorldCoord plot) {
-		if (!activeDeleteTownBlockEntityQueue.contains(plot))
-			activeDeleteTownBlockEntityQueue.add(plot);
-	}
-	
-	@Nullable
-	public static WorldCoord getActiveDeleteTownBlockEntityQueue() {
-
-		if (!activeDeleteTownBlockEntityQueue.isEmpty())
-			return activeDeleteTownBlockEntityQueue.remove(0);
-		
-		return null;
-	}
-
-	/**
-	 * Deletes all of a specified entity type from a TownBlock
-	 * 
-	 * @param worldCoord - WorldCoord for the Town Block
-	 */
-	public static void doDeleteTownBlockEntities(WorldCoord worldCoord) {
-		TownyWorld world = worldCoord.getTownyWorld();
-		if (world == null || !world.isUsingTowny() || !world.isDeletingEntitiesOnUnclaim())
-			return;
-		
-		addActiveDeleteTownBlockEntityQueue(worldCoord);
-		List<Entity> toRemove = new ArrayList<>();
-		Collection<Entity> entities = worldCoord.getBukkitWorld().getNearbyEntities(worldCoord.getBoundingBox());
-		for (Entity entity : entities) {
-			if (world.getUnclaimDeleteEntityTypes().contains(entity.getType()))
-				toRemove.add(entity);
-		}
-		
-		for (Entity entity : toRemove)
-			entity.remove();
-		
-		deleteTownBlockEntityQueue.remove(worldCoord);
-		activeDeleteTownBlockEntityQueue.remove(worldCoord);
-	}
-	
-	/*
-	 * TownBlock Material Deleting Queue.
-	 */
-	
-	/**
-	 * @return true if there are any chunks being processed.
-	 */
-	public static boolean hasDeleteTownBlockIdQueue() {
-
-		return !deleteTownBlockIdQueue.isEmpty();
-	}
-
-	public static boolean isDeleteTownBlockIdQueue(WorldCoord plot) {
-
-		return deleteTownBlockIdQueue.contains(plot);
-	}
-
-	public static int getDeleteTownBlockIdQueueSize() {
-
-		return deleteTownBlockIdQueue.size();
-	}
-
-	public static void addDeleteTownBlockIdQueue(WorldCoord plot) {
-
-		if (!deleteTownBlockIdQueue.contains(plot))
-			deleteTownBlockIdQueue.add(plot);
-	}
-
-	@Nullable
-	public static WorldCoord getDeleteTownBlockIdQueue() {
-
-		if (!deleteTownBlockIdQueue.isEmpty()) {
-			for (WorldCoord wc : deleteTownBlockIdQueue)
-				if (!isActiveDeleteTownBlockIdQueue(wc))
-					return wc;
-		}
-
-		return null;
-	}
-
-	public static boolean isActiveDeleteTownBlockIdQueue(WorldCoord plot) {
-
-		return activeDeleteTownBlockIdQueue.contains(plot);
-	}
-
-	public static int getActiveDeleteTownBlockIdQueueSize() {
-
-		return activeDeleteTownBlockIdQueue.size();
-	}
-	
-	public static void addActiveDeleteTownBlockIdQueue(WorldCoord plot) {
-
-		if (!activeDeleteTownBlockIdQueue.contains(plot))
-			activeDeleteTownBlockIdQueue.add(plot);
-	}
-
-	/**
-	 * Deletes all of a specified block type from a TownBlock
-	 * 
-	 * @param worldCoord - WorldCoord for the Town Block
-	 */
-	public static void doDeleteTownBlockIds(WorldCoord worldCoord) {
-		TownyWorld world = worldCoord.getTownyWorld();
-		if (world == null || isActiveDeleteTownBlockIdQueue(worldCoord))
-			return;
-		addActiveDeleteTownBlockIdQueue(worldCoord);
-		deleteMaterialsFromWorldCoord(worldCoord, world.getPlotManagementDeleteIds());
-	}
-
-	/**
-	 * Deletes all of a specified block type from a TownBlock
-	 * 
-	 * @param townBlock - TownBlock to delete from
-	 * @param material - Material to delete
-	 */
-	public static void deleteTownBlockMaterial(TownBlock townBlock, Material material) {
-		deleteMaterialsFromWorldCoord(townBlock.getWorldCoord(), Collections.singleton(material));
-	}
-
-	@Deprecated
-	public static void deleteMaterialsFromTownBlock(TownBlock townBlock, EnumSet<Material> materialEnumSet) {
-		deleteMaterialsFromWorldCoord(townBlock.getWorldCoord(), materialEnumSet);
-	}
-	
-	/**
-	 * Deletes all blocks which are found in the given EnumSet of Materials
-	 * 
-	 * @param coord WorldCoord to delete blocks from.
-	 * @param collection Collection of Materials from which to remove.
-	 */
-	public static void deleteMaterialsFromWorldCoord(WorldCoord coord, Collection<Material> collection) {
-		int plotSize = TownySettings.getTownBlockSize();
-
-		World world = coord.getBukkitWorld();
-		if (world == null)
-			return;
-		
-		int height = world.getMaxHeight() - 1;
-		int worldX = coord.getX() * plotSize, worldZ = coord.getZ() * plotSize;
-		List<Block> toRemove = new ArrayList<>();
-
-		for (int z = 0; z < plotSize; z++)
-			for (int x = 0; x < plotSize; x++)
-				for (int y = height; y > world.getMinHeight(); y--) { //Check from bottom up else minecraft won't remove doors
-					Block block = world.getBlockAt(worldX + x, y, worldZ + z);
-					if (collection.contains(block.getType()))
-						toRemove.add(block);
-				}
-		
-		if (toRemove.isEmpty()) {
-			deleteTownBlockIdQueue.remove(coord);
-			activeDeleteTownBlockIdQueue.remove(coord);
-			return;
-		}
-		
-		if (Bukkit.isPrimaryThread())
-			deleteBlocks(coord, toRemove);
-		else 
-			Bukkit.getScheduler().runTask(Towny.getPlugin(), () -> deleteBlocks(coord, toRemove));
-	}
-	
-	private static void deleteBlocks(WorldCoord coord, List<Block> toRemove) {
-		toRemove.forEach(block -> block.setType(Material.AIR));
-		deleteTownBlockIdQueue.remove(coord);
-		activeDeleteTownBlockIdQueue.remove(coord);
-	}
-
 	/*
 	 * Protection Regen follows
 	 */
@@ -861,6 +506,145 @@ public class TownyRegenAPI {
 	public static void removePlaceholder(Block block) {
 
 		protectionPlaceholders.remove(block);
+	}
+
+	/*
+	 * Deprecated TownBlock Entity Deleting Queue.
+	 */
+
+	/**
+	 * @deprecated since 0.98.6.2 use {@link WorldCoordEntityRemover#hasQueue()} instead.
+	 * @return true if there are any chunks being processed.
+	 */
+	@Deprecated
+	public static boolean hasDeleteTownBlockEntityQueue() {
+		return WorldCoordEntityRemover.hasQueue();
+	}
+
+	/**
+	 * @deprecated since 0.98.6.2 use {@link WorldCoordEntityRemover#isQueued(WorldCoord)} instead.
+	 * @param plot WorldCoord to check.
+	 * @return true if the WorldCoord is queued to have entities removed.
+	 */
+	@Deprecated
+	public static boolean isDeleteTownBlockEntityQueue(WorldCoord plot) {
+		return WorldCoordEntityRemover.isQueued(plot);
+	}
+
+	/**
+	 * @deprecated since 0.98.6.2 use {@link WorldCoordEntityRemover#addToQueue(WorldCoord)} instead.
+	 * @param plot WorldCoord to add to the queue.
+	 */
+	@Deprecated
+	public static void addDeleteTownBlockEntityQueue(WorldCoord plot) {
+		WorldCoordEntityRemover.addToQueue(plot);
+	}
+
+	/**
+	 * @deprecated since 0.98.6.2 use {@link WorldCoordEntityRemover#getWorldCoordFromQueue()} instead.
+	 * @return a WorldCoord from the queue.
+	 */
+	@Nullable
+	@Deprecated
+	public static WorldCoord getDeleteTownBlockEntityQueue() {
+		return WorldCoordEntityRemover.getWorldCoordFromQueue();
+	}
+
+	/**
+	 * Deletes all of a specified entity type from a TownBlock
+	 * @deprecated since 0.98.6.2 use {@link WorldCoordEntityRemover#doDeleteTownBlockEntities(WorldCoord)} instead.
+	 * @param worldCoord - WorldCoord for the Town Block
+	 */
+	@Deprecated
+	public static void doDeleteTownBlockEntities(WorldCoord worldCoord) {
+		WorldCoordEntityRemover.doDeleteTownBlockEntities(worldCoord);
+	}
+
+	/*
+	 * Deprecated TownBlock Material Deleting Queue.
+	 */
+
+	/**
+	 * @deprecated since 0.98.6.2 use {@link WorldCoordMaterialRemover#hasQueue()} instead.
+	 * @return true if there are any chunks being processed.
+	 */
+	@Deprecated
+	public static boolean hasDeleteTownBlockIdQueue() {
+		return WorldCoordMaterialRemover.hasQueue();
+	}
+
+	/**
+	 * @deprecated since 0.98.6.2 use {@link WorldCoordMaterialRemover#isQueued(WorldCoord)} instead.
+	 * @param plot WorldCoord
+	 * @return true if this WorldCoord is needing Materials removed.
+	 */
+	@Deprecated
+	public static boolean isDeleteTownBlockIdQueue(WorldCoord plot) {
+		return WorldCoordMaterialRemover.isQueued(plot);
+	}
+
+	/**
+	 * @deprecated since 0.98.6.2 use {@link WorldCoordMaterialRemover#addToQueue(WorldCoord)} instead.
+	 * @param plot WorldCoord to add to queue.
+	 */
+	@Deprecated
+	public static void addDeleteTownBlockIdQueue(WorldCoord plot) {
+		WorldCoordMaterialRemover.addToQueue(plot);
+	}
+
+	/**
+	 * @deprecated since 0.98.6.2 use {@link WorldCoordMaterialRemover#getWorldCoordFromQueue()} instead.
+	 * @return a WorldCoord that is queued to have materials removed.
+	 */
+	@Nullable
+	@Deprecated
+	public static WorldCoord getDeleteTownBlockIdQueue() {
+		return WorldCoordMaterialRemover.getWorldCoordFromQueue();
+	}
+
+	/**
+	 * Deletes all of a specified block type from a TownBlock
+	 * 
+	 * @deprecated since 0.98.6.2 use {@link WorldCoordMaterialRemover#queueUnclaimMaterialsDeletion(WorldCoord)} instead.
+	 * @param worldCoord - WorldCoord for the Town Block
+	 */
+	@Deprecated
+	public static void doDeleteTownBlockIds(WorldCoord worldCoord) {
+		WorldCoordMaterialRemover.queueUnclaimMaterialsDeletion(worldCoord);
+	}
+
+	/**
+	 * Deletes all of a specified block type from a TownBlock
+	 * 
+	 * @deprecated since 0.98.6.2 use {@link WorldCoordMaterialRemover#queueDeleteWorldCoordMaterials(WorldCoord, Collection)} instead.
+	 * @param townBlock - TownBlock to delete from
+	 * @param material - Material to delete
+	 */
+	@Deprecated
+	public static void deleteTownBlockMaterial(TownBlock townBlock, Material material) {
+		WorldCoordMaterialRemover.queueDeleteWorldCoordMaterials(townBlock.getWorldCoord(), Collections.singleton(material));
+	}
+
+	/**
+	 * @deprecated since 0.98.5.0 use {@link WorldCoordMaterialRemover#queueDeleteWorldCoordMaterials(WorldCoord, Collection)} instead.
+	 * @param townBlock TownBlock to remove from.
+	 * @param materialEnumSet Material EnumSet to remove.
+	 */
+	@Deprecated
+	public static void deleteMaterialsFromTownBlock(TownBlock townBlock, EnumSet<Material> materialEnumSet) {
+		WorldCoordMaterialRemover.queueDeleteWorldCoordMaterials(townBlock.getWorldCoord(), materialEnumSet);
+	}
+
+	/**
+	 * Deletes all blocks which are found in the given EnumSet of Materials
+	 * 
+	 * @deprecated since 0.98.6.2 use {@link WorldCoordMaterialRemover#queueDeleteWorldCoordMaterials(WorldCoord, Collection)} instead. 
+	 * @param coord WorldCoord to delete blocks from.
+	 * @param collection Collection of Materials from which to remove.
+	 */
+	@Deprecated
+	public static void deleteMaterialsFromWorldCoord(WorldCoord coord, Collection<Material> collection) {
+		WorldCoordMaterialRemover.queueDeleteWorldCoordMaterials(coord, collection);
 	}
 
 }

--- a/src/com/palmergames/bukkit/towny/regen/WorldCoordEntityRemover.java
+++ b/src/com/palmergames/bukkit/towny/regen/WorldCoordEntityRemover.java
@@ -1,0 +1,119 @@
+package com.palmergames.bukkit.towny.regen;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.Nullable;
+
+import com.palmergames.bukkit.towny.object.TownyWorld;
+import com.palmergames.bukkit.towny.object.WorldCoord;
+
+public class WorldCoordEntityRemover {
+
+	/** List of all WorldCoords still to be processed for Entity removal */
+	private static final List<WorldCoord> worldCoordQueue = new ArrayList<>();
+	/** List of all WorldCoords which are being processed for Entity removal */
+	private static final List<WorldCoord> activeQueue = new ArrayList<>();
+
+	/**
+	 * @return true if there are any chunks being processed.
+	 */
+	public static boolean hasQueue() {
+
+		return !worldCoordQueue.isEmpty();
+	}
+
+	/**
+	 * @param worldCoord WorldCoord
+	 * @return true if this WorldCoord is needing entities removed.
+	 */
+	public static boolean isQueued(WorldCoord worldCoord) {
+
+		return worldCoordQueue.contains(worldCoord);
+	}
+
+	/**
+	 * @return return the current queue size.
+	 */
+	public static int getQueueSize() {
+
+		return worldCoordQueue.size();
+	}
+
+	/**
+	 * @param worldCoord WorldCoord to add to queue.
+	 */
+	public static void addToQueue(WorldCoord worldCoord) {
+
+		if (!worldCoordQueue.contains(worldCoord))
+			worldCoordQueue.add(worldCoord);
+	}
+
+	/**
+	 * @return a WorldCoord that is queued to have entities removed or null.
+	 */
+	@Nullable
+	public static WorldCoord getWorldCoordFromQueue() {
+
+		if (!worldCoordQueue.isEmpty()) {
+			for (WorldCoord wc : worldCoordQueue)
+				if (!isActiveQueue(wc))
+					return wc;
+		}
+
+		return null;
+	}
+
+	/**
+	 * @return true if this WorldCoord is actively being processed.
+	 */
+	public static boolean isActiveQueue(WorldCoord worldCoord) {
+
+		return activeQueue.contains(worldCoord);
+	}
+
+	/**
+	 * @return size of activeQueue list.
+	 */
+	public static int getActiveQueueSize() {
+
+		return activeQueue.size();
+	}
+
+	/**
+	 * @param worldCoord WorldCoord to add to the actively queued list.
+	 */
+	public static void addToActiveQueue(WorldCoord worldCoord) {
+
+		if (!activeQueue.contains(worldCoord))
+			activeQueue.add(worldCoord);
+	}
+
+	/**
+	 * Deletes all of the world's deleted-entities-on-unclaim from the given WorldCoord.
+	 * 
+	 * @param worldCoord - WorldCoord for the Town Block
+	 */
+	public static void doDeleteTownBlockEntities(WorldCoord worldCoord) {
+		TownyWorld world = worldCoord.getTownyWorld();
+		if (world == null || !world.isUsingTowny() || !world.isDeletingEntitiesOnUnclaim())
+			return;
+		
+		addToActiveQueue(worldCoord);
+		List<Entity> toRemove = new ArrayList<>();
+		Collection<Entity> entities = worldCoord.getBukkitWorld().getNearbyEntities(worldCoord.getBoundingBox());
+		for (Entity entity : entities) {
+			if (world.getUnclaimDeleteEntityTypes().contains(entity.getType()))
+				toRemove.add(entity);
+		}
+		
+		for (Entity entity : toRemove)
+			entity.remove();
+		
+		worldCoordQueue.remove(worldCoord);
+		activeQueue.remove(worldCoord);
+	}
+
+}

--- a/src/com/palmergames/bukkit/towny/regen/WorldCoordMaterialRemover.java
+++ b/src/com/palmergames/bukkit/towny/regen/WorldCoordMaterialRemover.java
@@ -1,0 +1,185 @@
+package com.palmergames.bukkit.towny.regen;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.jetbrains.annotations.Nullable;
+
+import com.palmergames.bukkit.towny.Towny;
+import com.palmergames.bukkit.towny.TownySettings;
+import com.palmergames.bukkit.towny.object.TownyWorld;
+import com.palmergames.bukkit.towny.object.WorldCoord;
+
+public class WorldCoordMaterialRemover {
+
+	/** List of all WorldCoords still to be processed for Block removal */
+	private static final List<WorldCoord> worldCoordQueue = new ArrayList<>();
+	/** List of all WorldCoords which are being processed for Block removal */
+	private static final List<WorldCoord> activeQueue = new ArrayList<>();
+
+	/**
+	 * @return true if there are any chunks being processed.
+	 */
+	public static boolean hasQueue() {
+
+		return !worldCoordQueue.isEmpty();
+	}
+
+	/**
+	 * @param worldCoord WorldCoord
+	 * @return true if this WorldCoord is needing Materials removed.
+	 */
+	public static boolean isQueued(WorldCoord worldCoord) {
+
+		return worldCoordQueue.contains(worldCoord);
+	}
+
+	/**
+	 * @return size of the waiting queue.
+	 */
+	public static int getQueueSize() {
+
+		return worldCoordQueue.size();
+	}
+
+	/**
+	 * @param worldCoord WorldCoord to add to queue.
+	 */
+	public static void addToQueue(WorldCoord worldCoord) {
+
+		if (!worldCoordQueue.contains(worldCoord))
+			worldCoordQueue.add(worldCoord);
+	}
+
+	/**
+	 * @return a WorldCoord that is queued to have materials removed or null.
+	 */
+	@Nullable
+	public static WorldCoord getWorldCoordFromQueue() {
+
+		if (!worldCoordQueue.isEmpty()) {
+			for (WorldCoord wc : worldCoordQueue)
+				if (!isActiveQueue(wc))
+					return wc;
+		}
+
+		return null;
+	}
+
+	/**
+	 * @param worldCoord WorldCoord to check for.
+	 * @return true if this WorldCoord is being actively processed.
+	 */
+	public static boolean isActiveQueue(WorldCoord worldCoord) {
+
+		return activeQueue.contains(worldCoord);
+	}
+
+	/**
+	 * @return size of the activeQueue.
+	 */
+	public static int getActiveQueueSize() {
+
+		return activeQueue.size();
+	}
+
+	/**
+	 * @param worldCoord WorldCoord to move to the activeQueue.
+	 */
+	public static void addToActiveQueue(WorldCoord worldCoord) {
+
+		if (!activeQueue.contains(worldCoord))
+			activeQueue.add(worldCoord);
+	}
+
+	/**
+	 * Used to delete the world's PlotManagementDeleteIds when a townblock is
+	 * unclaimed.
+	 * 
+	 * @param worldCoord - WorldCoord for the Town Block
+	 */
+	public static void queueUnclaimMaterialsDeletion(WorldCoord worldCoord) {
+		TownyWorld world = worldCoord.getTownyWorld();
+		if (world == null || isActiveQueue(worldCoord))
+			return;
+		addToActiveQueue(worldCoord);
+		deleteMaterialsFromWorldCoord(worldCoord, world.getPlotManagementDeleteIds());
+	}
+
+	/**
+	 * Used to delete a collection of Materials from a worldCoord.
+	 * 
+	 * Towny uses this for the /plot clear command.
+	 * 
+	 * @param coord      WorldCoord to remove materials from.
+	 * @param collection Material collection that will be used to delete.
+	 */
+	public static void queueDeleteWorldCoordMaterials(WorldCoord coord, Collection<Material> collection) {
+		if (isActiveQueue(coord))
+			return;
+		addToActiveQueue(coord);
+		deleteMaterialsFromWorldCoord(coord, collection);
+	}
+
+	/**
+	 * Deletes all blocks which are found in the given Collection of Materials
+	 * 
+	 * @param coord      WorldCoord to delete blocks from.
+	 * @param collection Collection of Materials from which to remove.
+	 */
+	public static void deleteMaterialsFromWorldCoord(WorldCoord coord, Collection<Material> collection) {
+
+		List<Block> toRemove = findBlocksIn(coord, collection);
+		if (toRemove.isEmpty()) {
+			worldCoordQueue.remove(coord);
+			activeQueue.remove(coord);
+			return;
+		}
+
+		if (Bukkit.isPrimaryThread())
+			deleteBlocks(coord, toRemove);
+		else
+			Bukkit.getScheduler().runTask(Towny.getPlugin(), () -> deleteBlocks(coord, toRemove));
+	}
+
+	/**
+	 * Scans the given WorldCoord for matching Materials in the given collection and
+	 * returns the Blocks.
+	 * 
+	 * @param coord      WorldCoord to scan.
+	 * @param collection Collection of Materials to match.
+	 * @return List of Blocks that will be removed.
+	 */
+	private static List<Block> findBlocksIn(WorldCoord coord, Collection<Material> collection) {
+		List<Block> toRemove = new ArrayList<>();
+		World world = coord.getBukkitWorld();
+		if (world == null)
+			return toRemove;
+
+		int maxHeight = world.getMaxHeight() - 1;
+		int minHeight = world.getMinHeight();
+		int plotSize = TownySettings.getTownBlockSize();
+		int worldX = coord.getX() * plotSize, worldZ = coord.getZ() * plotSize;
+		for (int z = 0; z < plotSize; z++)
+			for (int x = 0; x < plotSize; x++)
+				for (int y = maxHeight; y > minHeight; y--) { // Check from bottom up else minecraft won't remove doors
+					Block block = world.getBlockAt(worldX + x, y, worldZ + z);
+					if (collection.contains(block.getType()))
+						toRemove.add(block);
+				}
+
+		return toRemove;
+	}
+
+	private static void deleteBlocks(WorldCoord coord, List<Block> toRemove) {
+		toRemove.forEach(block -> block.setType(Material.AIR));
+		worldCoordQueue.remove(coord);
+		activeQueue.remove(coord);
+	}
+
+}

--- a/src/com/palmergames/bukkit/towny/tasks/RepeatingTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/RepeatingTimerTask.java
@@ -37,12 +37,14 @@ public class RepeatingTimerTask extends TownyTimerTask {
 		}
 
 		// Try to perform the next plot_management entity_delete
-		if (TownyRegenAPI.hasDeleteTownBlockEntityQueue())
+		if (TownyRegenAPI.hasDeleteTownBlockEntityQueue()) {
 			tryDeleteTownBlockEntityQueue();
+		}
 
 		// Try to perform the next plot_management block_delete
-		if (TownyRegenAPI.hasDeleteTownBlockIdQueue()) 
+		if (TownyRegenAPI.hasDeleteTownBlockIdQueue()) {
 			tryDeleteTownBlockIDQueue();
+		}
 	}
 
 	private void revertAnotherBlockToWilderness() {
@@ -77,27 +79,24 @@ public class RepeatingTimerTask extends TownyTimerTask {
 	}
 
 	private void tryDeleteTownBlockEntityQueue() {
-		if (TownyRegenAPI.getActiveDeleteTownBlockEntityQueueSize() > 10)
+		if (TownyRegenAPI.getActiveDeleteTownBlockEntityQueueSize() >= 10)
 			return;
 		// Remove WC from larger queue.
 		WorldCoord wc = TownyRegenAPI.getDeleteTownBlockEntityQueue();
-		// Add it to active queue.
-		TownyRegenAPI.addActiveDeleteTownBlockEntityQueue(wc);
-
+		if (wc == null)
+			return;
 		// Remove a WC from the active queue and remove the entities from it.
-		TownyRegenAPI.doDeleteTownBlockEntities(TownyRegenAPI.getDeleteTownBlockEntityQueue());
+		TownyRegenAPI.doDeleteTownBlockEntities(wc);
 	}
 
 	private void tryDeleteTownBlockIDQueue() {
-		if (TownyRegenAPI.getActiveDeleteTownBlockIdQueueSize() > 10)
+		if (TownyRegenAPI.getActiveDeleteTownBlockIdQueueSize() >= 10)
 			return;
-		// Remove WC from larger queue.
+		// Get WC from larger queue.
 		WorldCoord wc = TownyRegenAPI.getDeleteTownBlockIdQueue();
-		// Add it to active queue.
-		TownyRegenAPI.addActiveDeleteTownBlockIdQueue(wc);
-
-		// Remove a WC from the active queue and remove the blocks from it.
-		Bukkit.getScheduler().runTaskAsynchronously(plugin,
-				() -> TownyRegenAPI.doDeleteTownBlockIds(TownyRegenAPI.getActiveDeleteTownBlockIdQueue()));
+		if (wc == null)
+			return;
+		// Tell it to regen.
+		Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> TownyRegenAPI.doDeleteTownBlockIds(wc));
 	}
 }

--- a/src/com/palmergames/bukkit/towny/tasks/RepeatingTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/RepeatingTimerTask.java
@@ -36,15 +36,13 @@ public class RepeatingTimerTask extends TownyTimerTask {
 			makeNextPlotSnapshot();
 		}
 
-		// Perform the next plot_management entity_delete
+		// Try to perform the next plot_management entity_delete
 		if (TownyRegenAPI.hasDeleteTownBlockEntityQueue())
-			TownyRegenAPI.doDeleteTownBlockEntities(TownyRegenAPI.getDeleteTownBlockEntityQueue());
+			tryDeleteTownBlockEntityQueue();
 
-		// Perform the next plot_management block_delete
-		if (TownyRegenAPI.hasDeleteTownBlockIdQueue()) {
-			Bukkit.getScheduler().runTaskAsynchronously(plugin,
-				() -> TownyRegenAPI.doDeleteTownBlockIds(TownyRegenAPI.getDeleteTownBlockIdQueue()));
-		}
+		// Try to perform the next plot_management block_delete
+		if (TownyRegenAPI.hasDeleteTownBlockIdQueue()) 
+			tryDeleteTownBlockIDQueue();
 	}
 
 	private void revertAnotherBlockToWilderness() {
@@ -78,4 +76,28 @@ public class RepeatingTimerTask extends TownyTimerTask {
 			TownyMessaging.sendDebugMsg("Plot snapshots completed.");
 	}
 
+	private void tryDeleteTownBlockEntityQueue() {
+		if (TownyRegenAPI.getActiveDeleteTownBlockEntityQueueSize() > 10)
+			return;
+		// Remove WC from larger queue.
+		WorldCoord wc = TownyRegenAPI.getDeleteTownBlockEntityQueue();
+		// Add it to active queue.
+		TownyRegenAPI.addActiveDeleteTownBlockEntityQueue(wc);
+
+		// Remove a WC from the active queue and remove the entities from it.
+		TownyRegenAPI.doDeleteTownBlockEntities(TownyRegenAPI.getDeleteTownBlockEntityQueue());
+	}
+
+	private void tryDeleteTownBlockIDQueue() {
+		if (TownyRegenAPI.getActiveDeleteTownBlockIdQueueSize() > 10)
+			return;
+		// Remove WC from larger queue.
+		WorldCoord wc = TownyRegenAPI.getDeleteTownBlockIdQueue();
+		// Add it to active queue.
+		TownyRegenAPI.addActiveDeleteTownBlockIdQueue(wc);
+
+		// Remove a WC from the active queue and remove the blocks from it.
+		Bukkit.getScheduler().runTaskAsynchronously(plugin,
+				() -> TownyRegenAPI.doDeleteTownBlockIds(TownyRegenAPI.getActiveDeleteTownBlockIdQueue()));
+	}
 }

--- a/src/com/palmergames/bukkit/towny/tasks/RepeatingTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/RepeatingTimerTask.java
@@ -9,6 +9,8 @@ import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.WorldCoord;
 import com.palmergames.bukkit.towny.regen.PlotBlockData;
 import com.palmergames.bukkit.towny.regen.TownyRegenAPI;
+import com.palmergames.bukkit.towny.regen.WorldCoordEntityRemover;
+import com.palmergames.bukkit.towny.regen.WorldCoordMaterialRemover;
 
 public class RepeatingTimerTask extends TownyTimerTask {
 
@@ -37,13 +39,13 @@ public class RepeatingTimerTask extends TownyTimerTask {
 		}
 
 		// Try to perform the next plot_management entity_delete
-		if (TownyRegenAPI.hasDeleteTownBlockEntityQueue()) {
+		if (WorldCoordEntityRemover.hasQueue()) {
 			tryDeleteTownBlockEntityQueue();
 		}
 
 		// Try to perform the next plot_management block_delete
-		if (TownyRegenAPI.hasDeleteTownBlockIdQueue()) {
-			tryDeleteTownBlockIDQueue();
+		if (WorldCoordMaterialRemover.hasQueue()) {
+			tryDeleteTownBlockMaterials();
 		}
 	}
 
@@ -79,24 +81,24 @@ public class RepeatingTimerTask extends TownyTimerTask {
 	}
 
 	private void tryDeleteTownBlockEntityQueue() {
-		if (TownyRegenAPI.getActiveDeleteTownBlockEntityQueueSize() >= 10)
+		if (WorldCoordEntityRemover.getActiveQueueSize() >= 10)
 			return;
 		// Remove WC from larger queue.
-		WorldCoord wc = TownyRegenAPI.getDeleteTownBlockEntityQueue();
+		WorldCoord wc = WorldCoordEntityRemover.getWorldCoordFromQueue();
 		if (wc == null)
 			return;
 		// Remove a WC from the active queue and remove the entities from it.
-		TownyRegenAPI.doDeleteTownBlockEntities(wc);
+		WorldCoordEntityRemover.doDeleteTownBlockEntities(wc);
 	}
 
-	private void tryDeleteTownBlockIDQueue() {
-		if (TownyRegenAPI.getActiveDeleteTownBlockIdQueueSize() >= 10)
+	private void tryDeleteTownBlockMaterials() {
+		if (WorldCoordMaterialRemover.getActiveQueueSize() >= 10)
 			return;
 		// Get WC from larger queue.
-		WorldCoord wc = TownyRegenAPI.getDeleteTownBlockIdQueue();
+		WorldCoord wc = WorldCoordMaterialRemover.getWorldCoordFromQueue();
 		if (wc == null)
 			return;
 		// Tell it to regen.
-		Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> TownyRegenAPI.doDeleteTownBlockIds(wc));
+		Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> WorldCoordMaterialRemover.queueUnclaimMaterialsDeletion(wc));
 	}
 }


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

Puts a hard cap of 10 WorldCoords that can have their Materials and Entities removed. (10 for Materials and 10 for Entities.)

Deprecates the methods in TownyRegenAPI for new classes WorldCoordMaterialRemover and WorldCoordEntityRemover.

This has the benefit of making TownyRegenAPI less cluttered and also being able to replace mentions about IDs with Materials (IDs are no longer used to describe MC blocks.)

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
