### PR TITLE
Fix NPE when clicking back button in a non-selection gui

### DIFF
--- a/src/com/palmergames/bukkit/towny/object/TownyInventory.java
+++ b/src/com/palmergames/bukkit/towny/object/TownyInventory.java
@@ -57,7 +57,7 @@ public class TownyInventory implements InventoryHolder {
 					resident.setGUIPageNum(--currentPage);
 					new TownyInventory(resident, resident.getGUIPage(), inventoryView.getTitle());
 					playClickSound(player);
-				} else if (resident.getGUIPageNum() == 0) {
+				} else if (resident.getGUIPageNum() == 0 && resident.getGUISelectionType() != null) {
 					// No page to go back from: go back to the SelectionGUI for the SelectionType
 					// that the resident is currently browsing, let them choose a different plot type.
 					playClickSound(player);


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Fixes a selection gui being opened with a null selection type when a player clicks the back item in a non-selection gui.
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
