### PR TITLE
Remove /plot claim repossesion logic in favour of /plot evict

### DIFF
--- a/resources/lang/en-US.yml
+++ b/resources/lang/en-US.yml
@@ -1870,4 +1870,4 @@ msg_warn_town_already_capital: "<red>The town of %s is already the nation capita
 msg_min_adjacent_blocks: 'You are required to have at least %s adjacent town blocks. There is only %s.'
 
 # Shown when a player with /plot evict permissions uses /plot claim on an owned but not for sale plot, please preserve comma space at the start when translating.
-msg_plot_claim_consider_evict_instead: '<red>, Perhaps you are looking for /plot evict instead?'
+msg_plot_claim_consider_evict_instead: ', perhaps you are looking for /plot evict instead?'

--- a/resources/lang/en-US.yml
+++ b/resources/lang/en-US.yml
@@ -9,7 +9,7 @@ description: >
 # ----------------------------
 #
 # Do not alter this file if it is in the reference folder.
-# Before you edit this file, read about how Towny handles 
+# Before you edit this file, read about how Towny handles
 # language files:
 # https://github.com/TownyAdvanced/Towny/wiki/How-Towny-Works#multi-language.
 #
@@ -1868,3 +1868,6 @@ msg_you_have_unclaimed_everything_but_your_homeblock: "You have unclaimed everyt
 msg_warn_are_you_sure_you_want_to_transfer_nation_ownership: "<red>Are you sure you want to transfer nation ownership to %s? This action is irreversible!"
 msg_warn_town_already_capital: "<red>The town of %s is already the nation capital."
 msg_min_adjacent_blocks: 'You are required to have at least %s adjacent town blocks. There is only %s.'
+
+# Shown when a player with /plot evict permissions uses /plot claim on an owned but not for sale plot, please preserve comma space at the start when translating.
+msg_plot_claim_consider_evict_instead: '<red>, Perhaps you are looking for /plot evict instead?'

--- a/resources/lang/en-US.yml
+++ b/resources/lang/en-US.yml
@@ -9,7 +9,7 @@ description: >
 # ----------------------------
 #
 # Do not alter this file if it is in the reference folder.
-# Before you edit this file, read about how Towny handles
+# Before you edit this file, read about how Towny handles 
 # language files:
 # https://github.com/TownyAdvanced/Towny/wiki/How-Towny-Works#multi-language.
 #

--- a/src/com/palmergames/bukkit/towny/command/PlotCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/PlotCommand.java
@@ -296,8 +296,19 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 					List<WorldCoord> selection = AreaSelectionUtil.selectWorldCoordArea(resident, new WorldCoord(world, Coord.parseCoord(player)), StringMgmt.remFirstArg(split), true);
 					
 					// Fast-fail if this is a single plot and it is already claimed.
-					if (selection.size() == 1 && selection.get(0).hasTownBlock() && selection.get(0).getTownBlock().hasResident() && !selection.get(0).getTownBlock().isForSale())
-						throw new TownyException(Translatable.of("msg_already_claimed", selection.get(0).getTownBlock().getResidentOrNull()));
+					if (selection.size() == 1 && selection.get(0).hasTownBlock() && selection.get(0).getTownBlock().hasResident() && !selection.get(0).getTownBlock().isForSale()) {
+						final Translatable message = Translatable.of("msg_already_claimed", selection.get(0).getTownBlock().getResidentOrNull());
+
+						// Add extra message if the player has permission to evict 
+						if (player.hasPermission(PermissionNodes.TOWNY_COMMAND_PLOT_EVICT.getNode())) {
+							try {
+								plotTestOwner(resident, selection.get(0).getTownBlock());
+								message.append(Translatable.of("msg_plot_claim_consider_evict_instead"));
+							} catch (TownyException ignored) {}
+						}
+						
+						throw new TownyException(message);
+					}
 					
 					// Filter to just plots that are for sale.
 					selection = AreaSelectionUtil.filterPlotsForSale(selection);

--- a/src/com/palmergames/bukkit/towny/tasks/PlotClaim.java
+++ b/src/com/palmergames/bukkit/towny/tasks/PlotClaim.java
@@ -248,23 +248,6 @@ public class PlotClaim extends Thread {
 
 						// Update any caches for this WorldCoord
 						plugin.updateCache(worldCoord);
-					} else if (player.hasPermission(PermissionNodes.TOWNY_COMMAND_PLOT_ASMAYOR.getNode())) {
-						//Plot isn't for sale but re-possessing for town.
-
-						if (TownyEconomyHandler.isActive() && !town.getAccount().payTo(0.0, owner, "Plot - Buy Back"))
-							throw new TownyException(Translatable.of("msg_town_no_money_purchase_plot"));
-
-						TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_buy_resident_plot", town.getName(), owner.getName(), 0.0));
-						townBlock.setResident(resident);
-
-						// Set the plot permissions to mirror the towns.
-						//townBlock.setType(townBlock.getType());
-
-						owner.save();
-						group.save();
-						// Update the townBlock data file so it's no longer using custom settings.
-						townBlock.save();
-						
 					} else {
 						//Should never reach here.
 						throw new AlreadyRegisteredException(Translatable.of("msg_already_claimed", owner.getName()).forLocale(player));
@@ -335,21 +318,6 @@ public class PlotClaim extends Thread {
 
 					// Update any caches for this WorldCoord
 					plugin.updateCache(worldCoord);
-					return true;
-				} else if (player.hasPermission(PermissionNodes.TOWNY_COMMAND_PLOT_ASMAYOR.getNode())) {
-					//Plot isn't for sale but re-possessing for town.
-
-					TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_buy_resident_plot", town.getName(), owner.getName(), 0.0));
-					townBlock.setResident(null);
-					townBlock.setPlotPrice(-1);
-
-					// Set the plot permissions to mirror the towns.
-					townBlock.setType(townBlock.getType());
-					
-					owner.save();
-					// Update the townBlock data file so it's no longer using custom settings.
-					townBlock.save();
-
 					return true;
 				} else {
 					//Should never reach here.


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Removes the logic for buying a plot back to the town when a mayor runs /plot claim on an owned plot that isn't for sale in favour of the better /plot evict command. The buyback functionality was already broken for a while since plots that aren't for sale are filtered out before the claim process starts.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
