### PR TITLE
Fix /ta unclaim causing an NPE

### DIFF
--- a/src/com/palmergames/bukkit/towny/tasks/TownClaim.java
+++ b/src/com/palmergames/bukkit/towny/tasks/TownClaim.java
@@ -79,7 +79,9 @@ public class TownClaim implements Runnable {
 			runUnclaimAll();
 
 		if (successfulRun) {
-			town.save();
+			if (town != null)
+				town.save();
+			
 			plugin.resetCache();
 			sendFeedback();
 		}
@@ -229,7 +231,7 @@ public class TownClaim implements Runnable {
 			// the Town can pay for the new runningCost total amount. 
 			// All of this was already determined in the TownCommand class but a player
 			// might be trying something tricky before accepting the confirmation.
-			if (unclaimRefund < 0 && !town.getAccount().canPayFromHoldings(Math.abs(runningRefund))) {
+			if (unclaimRefund < 0 && town != null && !town.getAccount().canPayFromHoldings(Math.abs(runningRefund))) {
 				runningRefund = runningRefund - unclaimRefund;
 				insufficientFunds = insufficientFunds + Math.abs(unclaimRefund);
 				throw new TownyException(""); // This empty-messaged TownyException means that the player will not see a Error message every time they cannot pay.


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
/ta unclaim provides a null town which causes an NPE when trying to save it.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
