### PR TITLE
Add remove town only option to resident purge

### DIFF
--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -2052,6 +2052,11 @@ public enum ConfigNodes {
 			"false",
 			"",
 			"# When true only residents who have no town will be deleted."),
+	RES_SETTINGS_DELETE_OLD_RESIDENTS_REMOVE_TOWN_ONLY(
+			"resident_settings.delete_old_residents.only_remove_town",
+			"false",
+			"",
+			"# When true players will be removed from their town and become a nomad instead of being fully deleted."),
 	RES_SETTING_DEFAULT_TOWN_NAME(
 			"resident_settings.default_town_name",
 			"",

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -3501,5 +3501,9 @@ public class TownySettings {
 	public static int getMinAdjacentBlocks() {
 		return Math.min(3, getInt(ConfigNodes.TOWN_MIN_ADJACENT_BLOCKS));
 	}
+	
+	public static boolean isDeletingOldResidentsRemovingTownOnly() {
+		return getBoolean(ConfigNodes.RES_SETTINGS_DELETE_OLD_RESIDENTS_REMOVE_TOWN_ONLY);
+	}
 }
 

--- a/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -2132,7 +2132,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		try {
 			int days = Integer.parseInt(split[0]);
 			Confirmation.runOnAccept(() -> 
-				new ResidentPurge(plugin, sender, TimeTools.getMillis(days + "d"), townless, town).start()
+				Bukkit.getScheduler().runTaskAsynchronously(plugin, new ResidentPurge(plugin, sender, TimeTools.getMillis(days + "d"), townless, town))
 			).sendTo(sender);
 		} catch (NumberFormatException e) {
 			throw new TownyException(Translatable.of("msg_error_must_be_int"));

--- a/src/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
@@ -76,8 +76,7 @@ public class DailyTimerTask extends TownyTimerTask {
 		 * If enabled, remove old residents who haven't logged in for the configured number of days.
 		 */	
 		if (TownySettings.isDeletingOldResidents()) {
-			// Run a purge in it's own thread
-			new ResidentPurge(plugin, null, TownySettings.getDeleteTime() * 1000, TownySettings.isDeleteTownlessOnly(), null).start();
+			Bukkit.getScheduler().runTaskAsynchronously(plugin, new ResidentPurge(plugin, null, TownySettings.getDeleteTime() * 1000, TownySettings.isDeleteTownlessOnly(), null));
 		}
 		
 		//Clean up unused NPC residents

--- a/src/com/palmergames/bukkit/towny/tasks/ResidentPurge.java
+++ b/src/com/palmergames/bukkit/towny/tasks/ResidentPurge.java
@@ -2,6 +2,7 @@ package com.palmergames.bukkit.towny.tasks;
 
 import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.TownyMessaging;
+import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
@@ -17,29 +18,34 @@ import java.util.List;
  * @author ElgarL
  * 
  */
-public class ResidentPurge extends Thread {
+public class ResidentPurge implements Runnable {
 
-	final Towny plugin;
+	private final Towny plugin;
 	private final CommandSender sender;
-	final long deleteTime;
-	final boolean townless;
-	final Town town;
+	private final long deleteTime;
+	private final boolean townless;
+	private final Town town;
+	private final boolean removeTown;
 
 	/**
-	 * @param plugin reference to Towny
-	 * @param sender reference to CommandSender
-	 * @param deleteTime time at which resident is purged (long)
-	 * @param townless if resident should be 'Townless'
+	 * @param plugin Reference to Towny.
+	 * @param sender Reference to CommandSender, or {@code null} to send messages to the console.
+	 * @param deleteTime The time in milliseconds for which a resident needs to be offline for to be deleted.
+	 * @param townless Whether only residents without a town will be deleted
+	 * @param town If non-null, only residents from the given town will be purged.
+	 * @param removeTown Whether    
 	 */
-	public ResidentPurge(Towny plugin, CommandSender sender, long deleteTime, boolean townless, @Nullable Town town) {
-
-		super();
+	public ResidentPurge(Towny plugin, CommandSender sender, long deleteTime, boolean townless, @Nullable Town town, boolean removeTown) {
 		this.plugin = plugin;
 		this.deleteTime = deleteTime;
-		this.setPriority(NORM_PRIORITY);
 		this.townless = townless;
 		this.sender = sender;
 		this.town = town;
+		this.removeTown = removeTown;
+	}
+	
+	public ResidentPurge(Towny plugin, CommandSender sender, long deleteTime, boolean townless, @Nullable Town town) {
+		this(plugin, sender, deleteTime, townless, town, TownySettings.isDeletingOldResidentsRemovingTownOnly());
 	}
 
 	@Override
@@ -57,12 +63,17 @@ public class ResidentPurge extends Thread {
 		}
 		for (Resident resident : residentList) {
 			if (!resident.isNPC() && (System.currentTimeMillis() - resident.getLastOnline() > (this.deleteTime)) && !BukkitTools.isOnline(resident.getName())) {
-				if (townless && resident.hasTown()) {
+				if (townless && resident.hasTown())
 					continue;
-				}
+				
 				count++;
+				
 				message(Translatable.of("msg_deleting_resident", resident.getName()));
-				townyUniverse.getDataSource().removeResident(resident);
+				
+				if (removeTown)
+					resident.removeTown();
+				else
+					townyUniverse.getDataSource().removeResident(resident);
 			}
 		}
 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
Adds resident_settings.delete_old_residents.only_remove_town
Default: false
When true players will be removed from their town and become a nomad instead of being fully deleted.

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #6506

____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
