### PR TITLE
Update plugin.yml to use the proper name for MyWorlds

### DIFF
--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -9,7 +9,7 @@ description: >
     Resident-Town-Nation hierarchy combined with a grid based
     protection system, many features and an expansive API.
 
-softdepend: [MultiVerse,Multiverse-Core,XcraftGate,My Worlds,Citizens,PersonalWorlds,WormholeXTremeWorlds,Vault,Reserve,MultiWorld,TheNewChat,PlaceholderAPI,Essentials,Hyperverse,GroupManager,iConomy,LuckPerms]
+softdepend: [MultiVerse,Multiverse-Core,XcraftGate,My_Worlds,Citizens,PersonalWorlds,WormholeXTremeWorlds,Vault,Reserve,MultiWorld,TheNewChat,PlaceholderAPI,Essentials,Hyperverse,GroupManager,iConomy,LuckPerms]
 
 ############################################################
 # +------------------------------------------------------+ #


### PR DESCRIPTION
A long time ago plugins were no longer allowed to use spaces in names. It appears that Towny still soft-depends on my plugin MyWorlds with the space in the name, even though this was replaced with _ a long time ago.

This small PR fixes that issue, so that MyWorlds loads before Towny.

It's unsure if soft-depending on "My Worlds" will still properly make "My_Worlds" load before. At least with recent Paper plugin loading changes, its doubtful.

____
- [X] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
