### PR TITLE
Change format used for backup file names

### DIFF
--- a/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
@@ -84,6 +84,7 @@ import java.util.zip.ZipFile;
  * @author ElgarL
  */
 public abstract class TownyDatabaseHandler extends TownyDataSource {
+	public static final SimpleDateFormat BACKUP_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
 	final String rootFolderPath;
 	final String dataFolderPath;
 	final String settingsFolderPath;
@@ -148,8 +149,7 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 			plugin.getLogger().info("***** Make sure you have scheduled a backup in MySQL too!!!");
 		}
 		String backupType = TownySettings.getFlatFileBackupType();
-		long t = System.currentTimeMillis();
-		String newBackupFolder = backupFolderPath + File.separator + new SimpleDateFormat("yyyy-MM-dd HH-mm").format(t) + " - " + t;
+		String newBackupFolder = backupFolderPath + File.separator + BACKUP_DATE_FORMAT.format(System.currentTimeMillis());
 		FileMgmt.checkOrCreateFolders(rootFolderPath, rootFolderPath + File.separator + "backup");
 		switch (backupType.toLowerCase()) {
 		case "folder": {

--- a/src/com/palmergames/util/FileMgmt.java
+++ b/src/com/palmergames/util/FileMgmt.java
@@ -1,6 +1,7 @@
 package com.palmergames.util;
 
 import com.palmergames.bukkit.towny.Towny;
+import com.palmergames.bukkit.towny.db.TownyDatabaseHandler;
 import com.palmergames.bukkit.towny.regen.PlotBlockData;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
@@ -20,6 +21,7 @@ import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -365,34 +367,44 @@ public final class FileMgmt {
 			writeLock.lock();
 
 			TreeSet<Long> deleted = new TreeSet<>();
-			if (backupsDir.isDirectory()) {
-				File[] children = backupsDir.listFiles();
-				if (children != null) {
-					for (File child : children) {
-						try {
-							String filename = child.getName();
-							if (child.isFile()) {
-								if (filename.contains("."))
-									filename = filename.split("\\.")[0];
-							}
-							String[] tokens = filename.split(" ");
-							String lastToken = tokens[tokens.length - 1];
-							long timeMade = Long.parseLong(lastToken);
-
-							if (timeMade >= 0) {
-								long age = System.currentTimeMillis() - timeMade;
-								if (age >= deleteAfter) {
-									deleteFile(child);
-									deleted.add(age);
-								}
-							}
-						} catch (Exception e) {
-							// Ignore file as it doesn't follow the backup format.
-						}
+			if (!backupsDir.isDirectory())
+				return false;
+			
+			File[] children = backupsDir.listFiles();
+			if (children == null)
+				return true;
+			
+			for (File child : children) {
+				if (child.isDirectory())
+					continue;
+				
+				String fileName = child.getName();
+							
+				long timeMade;
+							
+				try {
+					timeMade = TownyDatabaseHandler.BACKUP_DATE_FORMAT.parse(fileName).getTime();
+				} catch (ParseException pe) {
+					try {
+						// The file name does not match the new date format, attempt legacy format
+						String[] tokens = fileName.split("\\.")[0].split(" ");
+						String lastToken = tokens[tokens.length - 1];
+						timeMade = Long.parseLong(lastToken);
+					} catch (Exception e) {
+						// Ignore file as it doesn't follow the backup format.
+						Towny.getPlugin().getLogger().warning("File '" + fileName + "' in the backup folder does not match any format recognized by Towny, it will not be automatically deleted.");
+						continue;
 					}
 				}
-			} else
-				return false;
+
+				if (timeMade >= 0) {
+					long age = System.currentTimeMillis() - timeMade;
+					if (age >= deleteAfter) {
+						deleteFile(child);
+						deleted.add(age);
+					}
+				}
+			}
 
 			if (deleted.size() > 0) {
 				Towny.getPlugin().getLogger().info(String.format("Deleting %d Old Backups (%s).", deleted.size(), (deleted.size() > 1 ? String.format("%d-%d days old", TimeUnit.MILLISECONDS.toDays(deleted.first()), TimeUnit.MILLISECONDS.toDays(deleted.last())) : String.format("%d days old", TimeUnit.MILLISECONDS.toDays(deleted.first())))));


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Changes the date format used for backup file names to iso 8601 and removes having the full timestamp part of the file name by using the DateFormat#parse method to get the time as a long.
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
