### PR TITLE
Make sure we aren't paying negative amounts to a Nation bank account during tax time.

### DIFF
--- a/src/com/palmergames/bukkit/towny/object/economy/BankAccount.java
+++ b/src/com/palmergames/bukkit/towny/object/economy/BankAccount.java
@@ -114,7 +114,7 @@ public class BankAccount extends Account {
 	@Override
 	public boolean canPayFromHoldings(double amount) {
 		if (isBankrupt())
-			return addDebt(amount);
+			return getTownDebt() + amount > getDebtCap();
 		else
 			return super.canPayFromHoldings(amount);
 	}

--- a/src/com/palmergames/bukkit/towny/object/economy/BankAccount.java
+++ b/src/com/palmergames/bukkit/towny/object/economy/BankAccount.java
@@ -114,7 +114,7 @@ public class BankAccount extends Account {
 	@Override
 	public boolean canPayFromHoldings(double amount) {
 		if (isBankrupt())
-			return getTownDebt() + amount > getDebtCap();
+			return getTownDebt() + amount <= getDebtCap();
 		else
 			return super.canPayFromHoldings(amount);
 	}

--- a/src/com/palmergames/bukkit/towny/object/economy/BankAccount.java
+++ b/src/com/palmergames/bukkit/towny/object/economy/BankAccount.java
@@ -112,6 +112,14 @@ public class BankAccount extends Account {
 	}
 
 	@Override
+	public boolean canPayFromHoldings(double amount) {
+		if (isBankrupt())
+			return addDebt(amount);
+		else
+			return super.canPayFromHoldings(amount);
+	}
+
+	@Override
 	public double getHoldingBalance(boolean setCache) {
 		double balance = isBankrupt() ? balance = getTownDebt() * -1 : TownyEconomyHandler.getBalance(getName(), getBukkitWorld());
 		if (setCache)

--- a/src/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
@@ -213,7 +213,7 @@ public class DailyTimerTask extends TownyTimerTask {
 					if (nation.getBankCap() != 0 && taxAmount + nation.getAccount().getHoldingBalance() > nation.getBankCap())
 						taxAmount = nation.getBankCap() - nation.getAccount().getHoldingBalance();
 					
-					if (taxAmount == 0)
+					if (taxAmount <= 0)
 						continue;
 					
 					if (town.getAccount().canPayFromHoldings(taxAmount)) {


### PR DESCRIPTION


<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Bankrupt towns' balances would return a negative amount when a nation had % tax enabled.

This called the payTo() function with a negative amount for the collector which then hits Vault with a negative deposit (which we are warned not to do.)

Solution:
Don't pay a nation tax if the amount is less than or equal to zero.

Also added is an override to BankAcount for canPayFromHoldings() that tests if a town is able to pay with debt.


____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

Closes #6540.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
