### PR TITLE
Add an option to disable the mysql backup warning

### DIFF
--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -3523,5 +3523,9 @@ public class TownySettings {
 	public static boolean isDeletingOldResidentsRemovingTownOnly() {
 		return getBoolean(ConfigNodes.RES_SETTINGS_DELETE_OLD_RESIDENTS_REMOVE_TOWN_ONLY);
 	}
+	
+	public static boolean disableMySQLBackupWarning() {
+		return DatabaseConfig.getBoolean(DatabaseConfig.DATABASE_SQL_DISABLE_BACKUP_WARNING);
+	}
 }
 

--- a/src/com/palmergames/bukkit/towny/db/DatabaseConfig.java
+++ b/src/com/palmergames/bukkit/towny/db/DatabaseConfig.java
@@ -31,7 +31,9 @@ public enum DatabaseConfig {
 	DATABASE_SQL_DISABLE_BACKUP_WARNING("database.sql.disable_backup_warning", 
 			"false",
 			"",
-			"# Disables the warning when a backup is made about not all Towny data being backed up when mysql is in use."),
+			"# Disables the warning when a backup is made about not all Towny data being backed up when mysql is in use.",
+			"# Set this to true when you fully understand what not having flatfile backups means, if your mysql database were to become unusable and you have not configured your own backup solution."),
+
 
 	DATABASE_POOLING_HEADER(
 		"database.sql.pooling",

--- a/src/com/palmergames/bukkit/towny/db/DatabaseConfig.java
+++ b/src/com/palmergames/bukkit/towny/db/DatabaseConfig.java
@@ -6,6 +6,7 @@ import com.palmergames.bukkit.towny.exceptions.initialization.TownyInitException
 import com.palmergames.util.FileMgmt;
 
 import java.nio.file.Path;
+import java.util.Locale;
 
 public enum DatabaseConfig {
 	DATABASE(
@@ -27,6 +28,10 @@ public enum DatabaseConfig {
 	DATABASE_USERNAME("database.sql.username", "root"),
 	DATABASE_PASSWORD("database.sql.password", ""),
 	DATABASE_FLAGS("database.sql.flags", "?verifyServerCertificate=false&useSSL=false&useUnicode=true&characterEncoding=utf-8"),
+	DATABASE_SQL_DISABLE_BACKUP_WARNING("database.sql.disable_backup_warning", 
+			"false",
+			"",
+			"# Disables the warning when a backup is made about not all Towny data being backed up when mysql is in use."),
 
 	DATABASE_POOLING_HEADER(
 		"database.sql.pooling",
@@ -41,7 +46,7 @@ public enum DatabaseConfig {
 
 	private final String Root;
 	private final String Default;
-	private String[] comments;
+	private final String[] comments;
 
 	DatabaseConfig(String root, String def, String... comments) {
 
@@ -147,4 +152,7 @@ public enum DatabaseConfig {
 		}
 	}
 
+	public static boolean getBoolean(DatabaseConfig node) {
+		return Boolean.parseBoolean(databaseConfig.getString(node.getRoot().toLowerCase(Locale.ROOT), node.getDefault()));
+	}
 }

--- a/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
@@ -147,7 +147,7 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 			plugin.getLogger().info("***** Only Snapshots & Regen files in plugins/Towny/data/ will be backed up!");
 			plugin.getLogger().info("***** This does not include your residents/towns/nations.");
 			plugin.getLogger().info("***** Make sure you have scheduled a backup in MySQL too!!!");
-			plugin.getLogger().info("***** If you already have backups or accept the risk, this message can be disabled in the database config");
+			plugin.getLogger().info("***** If you already have backups or accept the risk, this message can be disabled in the database config.");
 		}
 		
 		String backupType = TownySettings.getFlatFileBackupType();

--- a/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
@@ -142,12 +142,14 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 	@Override
 	public boolean backup() throws IOException {
 
-		if (!TownySettings.getSaveDatabase().equalsIgnoreCase("flatfile")) {
+		if (!TownySettings.getSaveDatabase().equalsIgnoreCase("flatfile") && !TownySettings.disableMySQLBackupWarning()) {
 			plugin.getLogger().info("***** Warning *****");
-			plugin.getLogger().info("***** Only Snapshots & Regen files in towny\\data\\ will be backed up!");
+			plugin.getLogger().info("***** Only Snapshots & Regen files in plugins/Towny/data/ will be backed up!");
 			plugin.getLogger().info("***** This does not include your residents/towns/nations.");
 			plugin.getLogger().info("***** Make sure you have scheduled a backup in MySQL too!!!");
+			plugin.getLogger().info("***** If you already have backups or accept the risk, this message can be disabled in the database config");
 		}
+		
 		String backupType = TownySettings.getFlatFileBackupType();
 		String newBackupFolder = backupFolderPath + File.separator + BACKUP_DATE_FORMAT.format(System.currentTimeMillis());
 		FileMgmt.checkOrCreateFolders(rootFolderPath, rootFolderPath + File.separator + "backup");


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Adds an option that allows MySQL users to disable the warning that's shown when a backup is made.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
