### PR TITLE
Fix invite objects holding a reference to command senders

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/InviteCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/InviteCommand.java
@@ -287,7 +287,7 @@ public class InviteCommand extends BaseCommand implements CommandExecutor {
 		Translatable object = null;
 		for (int i = (page - 1) * 10; i < iMax; i++) {
 			Invite invite = list.get(i);
-			String name = invite.getDirectSender().getName();
+			String name = invite.getSenderName();
 			
 			// If it's from the sender, do it differently
 			String output = null;

--- a/src/com/palmergames/bukkit/towny/invites/Invite.java
+++ b/src/com/palmergames/bukkit/towny/invites/Invite.java
@@ -2,6 +2,10 @@ package com.palmergames.bukkit.towny.invites;
 
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
 
 /**
  * An object that represents an invitation.
@@ -12,35 +16,48 @@ public interface Invite {
 	/**
 	 * Gets the sender of the invitation
 	 * 
-	 * @return - The {@link CommandSender} of the invitation.
+	 * @return The {@link CommandSender} of the invitation, or null if the sender is a player and not online.
 	 */
+	@Nullable
 	CommandSender getDirectSender();
+
+	/**
+	 * @return The sender's name, or 'CONSOLE' if the invitation was sent by console.
+	 */
+	@NotNull
+	String getSenderName();
+
+	/**
+	 * @return The sender's uuid, or {@code null} if the invitation was sent by console.
+	 */
+	@Nullable
+	UUID getSenderUUID();
 
 	/**
 	 * Gets the receiver of the invitation.
 	 * 
-	 * @return - The {@link InviteReceiver} object receiving the invite.
+	 * @return The {@link InviteReceiver} object receiving the invite.
 	 */
 	InviteReceiver getReceiver();
 
 	/**
 	 * Gets the sender of the invitation.
 	 * 
-	 * @return - The {@link InviteSender} object that sent the invite.
+	 * @return The {@link InviteSender} object that sent the invite.
 	 */
 	InviteSender getSender();
 
 	/**
 	 * Runs the accept code for the given invitation.
 	 * 
-	 * @throws TownyException - Sends errors back up to be processed by the caller.
+	 * @throws TownyException Sends errors back up to be processed by the caller.
 	 */
 	void accept() throws TownyException;
 
 	/**
 	 * Runs the reject code for the given invitation.
 	 * 
-	 * @param fromSender - Tells if invite was revoked (true) or declined (false).
+	 * @param fromSender Tells if invite was revoked (true) or declined (false).
 	 */
 	void decline(boolean fromSender);
 }

--- a/src/com/palmergames/bukkit/towny/object/inviteobjects/AbstractInvite.java
+++ b/src/com/palmergames/bukkit/towny/object/inviteobjects/AbstractInvite.java
@@ -3,26 +3,48 @@ package com.palmergames.bukkit.towny.object.inviteobjects;
 import com.palmergames.bukkit.towny.invites.Invite;
 import com.palmergames.bukkit.towny.invites.InviteReceiver;
 import com.palmergames.bukkit.towny.invites.InviteSender;
+import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
+import java.util.UUID;
 
-abstract class AbstractInvite<S extends InviteSender, R extends InviteReceiver>
-	implements Invite {
-
-	private final CommandSender directSender;
+abstract class AbstractInvite<S extends InviteSender, R extends InviteReceiver> implements Invite {
+	private final UUID senderUUID;
+	private final String senderName;
 	private final R receiver;
 	private final S sender;
 
-	AbstractInvite(CommandSender directSender, R receiver, S sender) {
-		this.directSender = directSender;
+	AbstractInvite(@NotNull CommandSender directSender, @NotNull R receiver, @NotNull S sender) {
+		this(directSender.getName(), directSender instanceof Player player ? player.getUniqueId() : null, receiver, sender);
+	}
+	
+	AbstractInvite(@NotNull String senderName, @Nullable UUID senderUUID, @NotNull R receiver, @NotNull S sender) {
+		this.senderName = senderName;
+		this.senderUUID = senderUUID;
 		this.receiver = receiver;
 		this.sender = sender;
 	}
-	
+
+	@Nullable
 	@Override
 	public CommandSender getDirectSender() {
-		return directSender;
+		return this.senderUUID == null ? Bukkit.getConsoleSender() : Bukkit.getPlayer(this.senderUUID);
+	}
+
+	@NotNull
+	@Override
+	public String getSenderName() {
+		return senderName;
+	}
+
+	@Nullable
+	@Override
+	public UUID getSenderUUID() {
+		return senderUUID;
 	}
 
 	@Override
@@ -38,8 +60,8 @@ abstract class AbstractInvite<S extends InviteSender, R extends InviteReceiver>
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
-		if (!(o instanceof AbstractInvite)) return false;
-		AbstractInvite<?, ?> that = (AbstractInvite<?, ?>) o;
+		if (!(o instanceof AbstractInvite<?, ?> that)) return false;
+
 		return Objects.equals(getDirectSender(), that.getDirectSender()) &&
 			Objects.equals(getReceiver(), that.getReceiver()) &&
 			Objects.equals(getSender(), that.getSender());

--- a/src/com/palmergames/bukkit/towny/object/inviteobjects/AbstractInvite.java
+++ b/src/com/palmergames/bukkit/towny/object/inviteobjects/AbstractInvite.java
@@ -62,7 +62,8 @@ abstract class AbstractInvite<S extends InviteSender, R extends InviteReceiver> 
 		if (this == o) return true;
 		if (!(o instanceof AbstractInvite<?, ?> that)) return false;
 
-		return Objects.equals(getDirectSender(), that.getDirectSender()) &&
+		return Objects.equals(getSenderName(), that.getSenderName()) &&
+			Objects.equals(getSenderUUID(), that.getSenderUUID()) &&
 			Objects.equals(getReceiver(), that.getReceiver()) &&
 			Objects.equals(getSender(), that.getSender());
 	}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Fixes invite objects holding a reference to a CommandSender which can cause the internal ServerPlayer to stick around
![image](https://user-images.githubusercontent.com/50800980/224560596-77b3c7d9-95c3-4576-b749-3c78b2b35976.png)

Should also make invite persistence across restarts easier to do, since we no longer need the CommandSender instance but just the name & uuid.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
