### PR TITLE
Allow overclaimed towns to have their land stolen from them.

### DIFF
--- a/resources/lang/en-US.yml
+++ b/resources/lang/en-US.yml
@@ -1899,3 +1899,30 @@ msg_err_you_need_x_to_pay: "You need %s to pay."
 
 #Shown when someone tries to deposit/withdraw 0 amounts.
 msg_err_amount_must_be_greater_than_zero: "Amount must be greater than zero."
+
+#Message shown when taking over claims is disabled on a server.
+msg_err_taking_over_claims_is_not_enabled: "Taking over claims is not enabled on this server."
+
+#Messages shown when taking over a claim is not allowed because the town is not overclaimed.
+msg_err_this_townblock_cannot_be_taken_over: "This TownBlock cannot be taken over, the town that it belongs to is not overclaimed."
+
+#Message shown when taking over a claim would also set the homeblock because the town has no claims.
+msg_err_you_cannot_make_this_your_homeblock: "You cannot make this claim because it would make this TownBlock your homeblock, which is not allowed."
+
+#Message shown when taking over a claim is stopped by another plugin.
+msg_err_another_plugin_cancelled_takeover: "Another plugin has stopped your takeover of this land."
+
+#Confirmation shown when taking over a claim.
+confirmation_you_are_about_to_take_over_a_claim: "You are about to take over a claim belonging to %s for the cost: %s. Did you want to continue?"
+
+#Warning message shown when a town is beginning to claim close to their limit, and the takeoverclaim feature is active.
+msg_warning_you_are_almost_out_of_townblocks: "Warning: You have nearly used up your available townblocks for claiming. If you lose a resident you will be at risk of your town being able to have townblocks stolen by other towns."
+
+#Warning message shown on login when a town is overclaimed and at risk of falling victim to the takeoverclaim feature.
+msg_warning_your_town_is_overclaimed: "Warning: Your town is overclaimed. While you have too many townblocks claimed, it will be possible for other towns to takeover plots of your town, consider unclaiming some land."
+
+#Chunk Notification slug, shown when entering a plot that can be stolen.
+chunk_notification_takeover_available: " <red>[TakeoverClaim Available]"
+
+#Message shown when a takeover claim would cut a town into two sections.
+msg_err_you_cannot_over_claim_would_cut_into_two: "You cannot take over this plot, because doing so would split the town into two segments. You will have to overclaim from a different direction."

--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -372,6 +372,7 @@ permissions:
             towny.command.town.reslist: true
             towny.command.town.say: true
             towny.command.town.set.*: true
+            towny.command.town.takeoverclaim: true
             towny.command.town.toggle.*: true
             towny.command.town.withdraw: true
             towny.command.town.unclaim.*: true

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -191,7 +191,10 @@ public enum ConfigNodes {
 			"# A feature that allows towns which have too many townblocks claimed (overclaimed) ie: 120/100 TownBlocks, ",
 			"# to have their land stolen by other towns which are not overclaimed. Using this incentivises Towns to keep",
 			"# their residents from leaving, and will mean that mayors will be more careful about which land they choose",
-			"# to claim. It is highly recommended to only use this on servers where outposts are disabled, and requiring ",
+			"# to claim.",
+			"# Overclaiming does not allow a town to be split into two separate parts, requiring the Town that is stealing",
+			"# land to work from the outside inwards.",
+			"# It is highly recommended to only use this on servers where outposts are disabled, and requiring ",
 			"# a number of adjacent claims over 1 is enabled.",
 			"# Towns take land using /t takeoverclaim."),
 	TOWN_OVERCLAIMING_PREVENTED_BY_HOMEBLOCK_RADIUS(

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -182,6 +182,24 @@ public enum ConfigNodes {
 			"# set to 0 to disable limiting of claim radius value check.",
 			"# keep in mind that the default value of 4 is a radius, ",
 			"# and it will allow claiming 9x9 (80 plots) at once."),
+
+	TOWN_OVERCLAIMING_ROOT("town.overclaiming", "", "", ""),
+	TOWN_OVER_ALLOWED_CLAIM_LIMITS_ALLOWS_STEALING_LAND(
+			"town.overclaiming.being_overclaimed_allows_other_towns_to_steal_land",
+			"false",
+			"",
+			"# A feature that allows towns which have too many townblocks claimed (overclaimed) ie: 120/100 TownBlocks, ",
+			"# to have their land stolen by other towns which are not overclaimed. Using this incentivises Towns to keep",
+			"# their residents from leaving, and will mean that mayors will be more careful about which land they choose",
+			"# to claim. It is highly recommended to only use this on servers where outposts are disabled, and requiring ",
+			"# a number of adjacent claims over 1 is enabled.",
+			"# Towns take land using /t takeoverclaim."),
+	TOWN_OVERCLAIMING_PREVENTED_BY_HOMEBLOCK_RADIUS(
+			"town.overclaiming.overclaiming_prevented_by_homeblock_radius",
+			"true",
+			"",
+			"# While true, overclaiming is stopped by the min_distance_from_town_homeblock setting below.",
+			"# This prevents a town from having townblocks stolen surrounding their homeblocks."),
 	TOWN_LIMIT(
 			"town.town_limit",
 			"3000",
@@ -2239,6 +2257,12 @@ public enum ConfigNodes {
 			"# Warning: do not set this higher than the cost to claim a townblock.",
 			"# It is advised that you do not set this to the same price as claiming either, otherwise towns will get around using outposts to claim far away.",
 			"# Optionally, set this to a negative amount if you want towns to pay money to unclaim their land."),
+	ECO_PRICE_TAKEOVERCLAIM("economy.takeoverclaim","","",""),
+	ECO_PRICE_TAKEOVERCLAIM_PRICE(
+			"economy.takeoverclaim.price",
+			"100.0",
+			"",
+			"# The price to use /t takeoverclaim, when it has been enabled in the config at town.being_overclaimed_allows_other_towns_to_steal_land"),
 	ECO_PRICE_PURCHASED_BONUS_TOWNBLOCK(
 			"economy.new_expand.price_purchased_bonus_townblock",
 			"25.0",

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -1472,6 +1472,14 @@ public class TownySettings {
 		return getInt(ConfigNodes.TOWN_MAX_CLAIM_RADIUS_VALUE);
 	}
 
+	public static boolean isOverClaimingAllowingStolenLand() {
+		return getBoolean(ConfigNodes.TOWN_OVER_ALLOWED_CLAIM_LIMITS_ALLOWS_STEALING_LAND);
+	}
+
+	public static boolean isOverClaimingPreventedByHomeBlockRadius() {
+		return getBoolean(ConfigNodes.TOWN_OVERCLAIMING_PREVENTED_BY_HOMEBLOCK_RADIUS);
+	}
+
 	public static boolean isSellingBonusBlocks(Town town) {
 
 		return getMaxPurchasedBlocks(town) != 0;
@@ -1644,6 +1652,10 @@ public class TownySettings {
 	public static double getClaimRefundPrice() {
 		
 		return getDouble(ConfigNodes.ECO_PRICE_CLAIM_TOWNBLOCK_REFUND);
+	}
+
+	public static double getTakeoverClaimPrice() {
+		return getDouble(ConfigNodes.ECO_PRICE_TAKEOVERCLAIM_PRICE);
 	}
 
 	public static boolean getUnclaimedZoneSwitchRights() {

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -161,6 +161,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		"add",
 		"kick",
 		"spawn",
+		"takeoverclaim",
 		"claim",
 		"unclaim",
 		"withdraw",
@@ -773,6 +774,10 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 			checkPermOrThrow(player, PermissionNodes.TOWNY_COMMAND_TOWN_UNCLAIM.getNode());
 			catchRuinedTown(player);
 			parseTownUnclaimCommand(player, StringMgmt.remFirstArg(split));
+			break;
+		case "takeoverclaim":
+			catchRuinedTown(player);
+			parseTownTakeoverClaimCommand(player);
 			break;
 		case "online":
 			checkPermOrThrow(player, PermissionNodes.TOWNY_COMMAND_TOWN_ONLINE.getNode());
@@ -2485,7 +2490,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 			TownySettings.getMaxDistanceBetweenHomeblocks() > 0 ||
 			TownySettings.getMinDistanceBetweenHomeblocks() > 0) {
 				
-			final int distanceToNextNearestHomeblock = world.getMinDistanceFromOtherTowns(coord, town);
+			final int distanceToNextNearestHomeblock = world.getMinDistanceFromOtherTownsHomeBlocks(coord, town);
 			if (distanceToNextNearestHomeblock < TownySettings.getMinDistanceFromTownHomeblocks() ||
 				distanceToNextNearestHomeblock < TownySettings.getMinDistanceBetweenHomeblocks()) 
 				throw new TownyException(Translatable.of("msg_too_close2", Translatable.of("homeblock")));
@@ -2861,7 +2866,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 			TownySettings.getMinDistanceBetweenHomeblocks() > 0 ||
 			TownySettings.getNewTownMinDistanceFromTownHomeblocks() > 0) {
 			
-			final int distanceToNextNearestHomeblock = world.getMinDistanceFromOtherTowns(key);
+			final int distanceToNextNearestHomeblock = world.getMinDistanceFromOtherTownsHomeBlocks(key);
 			
 			int minDistance = TownySettings.getNewTownMinDistanceFromTownHomeblocks();
 			if (minDistance <= 0)
@@ -3883,6 +3888,85 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		}
 		// No cost to unclaim the land.
 		Bukkit.getScheduler().runTask(plugin, new TownClaim(plugin, player, town, null, false, false, false));
+	}
+
+	private void parseTownTakeoverClaimCommand(Player player) throws TownyException {
+		checkPermOrThrow(player, PermissionNodes.TOWNY_COMMAND_TOWN_TAKEOVERCLAIM.getNode());
+		catchRuinedTown(player);
+
+		if (!TownySettings.isOverClaimingAllowingStolenLand())
+			throw new TownyException(Translatable.of("msg_err_taking_over_claims_is_not_enabled"));
+
+		Town town = getTownFromPlayerOrThrow(player);
+
+		// Make sure this wouldn't end up becoming a homeblock.
+		if (town.getTownBlocks().size() == 0)
+			throw new TownyException(Translatable.of("msg_err_you_cannot_make_this_your_homeblock"));
+
+		WorldCoord wc = WorldCoord.parseWorldCoord(player);
+		if (TownyAPI.getInstance().isWilderness(wc))
+			throw new TownyException(Translatable.of("msg_not_own_place"));
+
+		// Make sure the town doesn't already own this land.
+		if (wc.getTownOrNull().equals(town))
+			throw new TownyException(Translatable.of("msg_already_claimed_1"));
+
+		// Make sure this is in a town which is overclaimed, allowing for stealing land.
+		if (!wc.canBeStolen())
+			throw new TownyException(Translatable.of("msg_err_this_townblock_cannot_be_taken_over"));
+
+		// Not enough available claims.
+		if (!town.hasUnlimitedClaims() && town.availableTownBlocks() < 1)
+			throw new TownyException(Translatable.of("msg_err_not_enough_blocks"));
+
+		// Not connected to the town stealing the land.
+		if (!isEdgeBlock(town, wc))
+			throw new TownyException(Translatable.of("msg_err_not_attached_edge"));
+
+		// Prevent straight line claims if configured, and the town has enough townblocks claimed, and this is not an outpost.
+		int minAdjacentBlocks = TownySettings.getMinAdjacentBlocks();
+		if (minAdjacentBlocks > 0 && town.getTownBlocks().size() > minAdjacentBlocks) {
+			// Only consider the first worldCoord, larger selection-claims will automatically "bubble" anyways.
+			int numAdjacent = numAdjacentTownOwnedTownBlocks(town, wc);
+			// The number of adjacement TBs is not enough and there is not a nearby outpost.
+			if (numAdjacent < minAdjacentBlocks && numAdjacentOutposts(town, wc) == 0)
+				throw new TownyException(Translatable.of("msg_min_adjacent_blocks", minAdjacentBlocks, numAdjacent));
+		}
+
+		// Prevent claiming that would cut off a section of a town from the main body. 
+		if (takeoverWouldCutATownIntoTwoSections(wc, town))
+			throw new TownyException(Translatable.of("msg_err_you_cannot_over_claim_would_cut_into_two"));
+
+		// Filter out stealing land that is too close to another Town's homeblock.
+		if (TownySettings.isOverClaimingPreventedByHomeBlockRadius() && AreaSelectionUtil.isTooCloseToHomeBlock(wc, town))
+			throw new TownyException(Translatable.of("msg_too_close2", Translatable.of("homeblock")));
+
+		if(BukkitTools.isEventCancelled(new TownPreClaimEvent(town, wc.getTownBlockOrNull(), player, false, false)))
+			throw new TownyException(Translatable.of("msg_err_another_plugin_cancelled_takeover"));
+
+		double cost = TownySettings.getTakeoverClaimPrice();
+		String costSlug = !TownyEconomyHandler.isActive() || cost <= 0 ? Translatable.of("msg_spawn_cost_free").forLocale(player) : TownyEconomyHandler.getFormattedBalance(cost);
+		String townName = wc.getTownOrNull().getName();
+		Confirmation.runOnAccept(() -> Bukkit.getScheduler().runTask(plugin, new TownClaim(plugin, player, town, Arrays.asList(wc), false, true, false)))
+			.setTitle(Translatable.of("confirmation_you_are_about_to_take_over_a_claim", townName, costSlug))
+			.setCost(new ConfirmationTransaction(() -> cost, town.getAccount(), "Takeover Claim (" + wc.toString() + ") from " + townName + "."))
+			.sendTo(player);
+	}
+
+	private boolean takeoverWouldCutATownIntoTwoSections(WorldCoord worldCoord, Town townOverClaiming) {
+		// If the surrounding townblocks has at least 2 townblocks owned by the
+		// overclaimed town and 1 plot that belongs to the wilderness or a third-town,
+		// we can assume that it will cause an orphaned townblock.
+		Town overclaimed = worldCoord.getTownOrNull();
+		List<WorldCoord> surroundingClaims = worldCoord.getCardinallyAdjacentWorldCoords(true);
+		long townOwned = surroundingClaims.stream().filter(wc -> wc.hasTown(overclaimed)).count();
+		if (townOwned < 2)
+			return false;
+
+		long wildOr3rdPartyOwned = surroundingClaims.stream()
+				.filter(wc -> !wc.hasTown(overclaimed) && !wc.hasTown(townOverClaiming))
+				.count();
+		return wildOr3rdPartyOwned > 0;
 	}
 
 	public static void parseTownMergeCommand(Player player, String[] args) throws TownyException {

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -3904,7 +3904,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 			throw new TownyException(Translatable.of("msg_err_you_cannot_make_this_your_homeblock"));
 
 		WorldCoord wc = WorldCoord.parseWorldCoord(player);
-		if (TownyAPI.getInstance().isWilderness(wc))
+		if (wc.isWilderness())
 			throw new TownyException(Translatable.of("msg_not_own_place"));
 
 		// Make sure the town doesn't already own this land.

--- a/src/com/palmergames/bukkit/towny/event/TownClaimEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/TownClaimEvent.java
@@ -2,6 +2,7 @@ package com.palmergames.bukkit.towny.event;
 
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.object.Resident;
+import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -48,5 +49,12 @@ public class TownClaimEvent extends Event  {
 	 */
 	public Resident getResident() {
 		return resident;
+	}
+
+	/**
+	 * @return the Town which claimed this TownBlock.
+	 */
+	public Town getTown() {
+		return resident.getTownOrNull();
 	}
 }

--- a/src/com/palmergames/bukkit/towny/object/Town.java
+++ b/src/com/palmergames/bukkit/towny/object/Town.java
@@ -879,6 +879,8 @@ public class Town extends Government implements TownBlockOwner {
 			// Remove the spawn point for this outpost.
 			if (townBlock.isOutpost() || isAnOutpost(townBlock.getCoord())) {
 				removeOutpostSpawn(townBlock.getCoord());
+				townBlock.setOutpost(false);
+				townBlock.save();
 			}
 			if (townBlock.isJail()) {
 				removeJail(townBlock.getJail());

--- a/src/com/palmergames/bukkit/towny/object/TownyWorld.java
+++ b/src/com/palmergames/bukkit/towny/object/TownyWorld.java
@@ -747,7 +747,7 @@ public class TownyWorld extends TownyObject {
 	/**
 	 * Checks the distance from the closest homeblock.
 	 * 
-	 * @deprecated since 0.98.6.26 use {@link #getMinDistanceFromOtherTownsHomeBlocks(Coord)} instead.
+	 * @deprecated since 0.99.0.2 use {@link #getMinDistanceFromOtherTownsHomeBlocks(Coord)} instead.
 	 * 
 	 * @param key - Coord to check from.
 	 * @return the distance to nearest towns homeblock.
@@ -770,7 +770,7 @@ public class TownyWorld extends TownyObject {
 	/**
 	 * Checks the distance from a another town's homeblock.
 	 * 
-	 * @deprecated since 0.98.6.26 use {@link #getMinDistanceFromOtherTownsHomeBlocks(Coord, Town)} instead.
+	 * @deprecated since 0.99.0.2 use {@link #getMinDistanceFromOtherTownsHomeBlocks(Coord, Town)} instead.
 	 * 
 	 * @param key - Coord to check from.
 	 * @param homeTown Players town

--- a/src/com/palmergames/bukkit/towny/object/TownyWorld.java
+++ b/src/com/palmergames/bukkit/towny/object/TownyWorld.java
@@ -747,23 +747,51 @@ public class TownyWorld extends TownyObject {
 	/**
 	 * Checks the distance from the closest homeblock.
 	 * 
+	 * @deprecated since 0.98.6.26 use {@link #getMinDistanceFromOtherTownsHomeBlocks(Coord)} instead.
+	 * 
 	 * @param key - Coord to check from.
 	 * @return the distance to nearest towns homeblock.
 	 */
+	@Deprecated
 	public int getMinDistanceFromOtherTowns(Coord key) {
+		return getMinDistanceFromOtherTownsHomeBlocks(key);
+	}
 
-		return getMinDistanceFromOtherTowns(key, null);
-
+	/**
+	 * Checks the distance from the closest homeblock.
+	 * 
+	 * @param key - Coord to check from.
+	 * @return the distance to nearest towns homeblock.
+	 */
+	public int getMinDistanceFromOtherTownsHomeBlocks(Coord key) {
+		return getMinDistanceFromOtherTownsHomeBlocks(key, null);
 	}
 
 	/**
 	 * Checks the distance from a another town's homeblock.
 	 * 
+	 * @deprecated since 0.98.6.26 use {@link #getMinDistanceFromOtherTownsHomeBlocks(Coord, Town)} instead.
+	 * 
 	 * @param key - Coord to check from.
 	 * @param homeTown Players town
 	 * @return the closest distance to another towns homeblock.
 	 */
+	@Deprecated
 	public int getMinDistanceFromOtherTowns(Coord key, Town homeTown) {
+		return getMinDistanceFromOtherTownsHomeBlocks(key, homeTown);
+	}
+
+	/**
+	 * Checks the distance from a another town's homeblock, or the distance to
+	 * another Town if homeTown is null.
+	 * 
+	 * @param key      Coord to check from.
+	 * @param homeTown The town belonging to a player, so that the town's own
+	 *                 homeblock is not returned, or null if this should apply to
+	 *                 any townblock, and not just homeblocks.
+	 * @return the closest distance to another towns homeblock.
+	 */
+	public int getMinDistanceFromOtherTownsHomeBlocks(Coord key, Town homeTown) {
 		double minSqr = -1;
 		final int keyX = key.getX();
 		final int keyZ = key.getZ();

--- a/src/com/palmergames/bukkit/towny/object/WorldCoord.java
+++ b/src/com/palmergames/bukkit/towny/object/WorldCoord.java
@@ -2,6 +2,7 @@ package com.palmergames.bukkit.towny.object;
 
 import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.TownyAPI;
+import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
 
@@ -338,5 +339,9 @@ public class WorldCoord extends Coord {
 			list.add(this.add(-1,1));
 		}
 		return list;
+	}
+
+	public boolean canBeStolen() {
+		return TownySettings.isOverClaimingAllowingStolenLand() && hasTownBlock() && getTownOrNull().isOverClaimed();
 	}
 }

--- a/src/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
+++ b/src/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
@@ -110,6 +110,7 @@ public enum PermissionNodes {
 		TOWNY_COMMAND_TOWN_OUTPOST_LIST("towny.command.town.outpost.list"),
 		TOWNY_COMMAND_TOWN_NEW("towny.command.town.new"),
 		TOWNY_COMMAND_TOWN_LEAVE("towny.command.town.leave"),
+		TOWNY_COMMAND_TOWN_TAKEOVERCLAIM("towny.command.town.takeoverclaim"),
 		TOWNY_COMMAND_TOWN_RECLAIM("towny.command.town.reclaim"),
 		TOWNY_COMMAND_TOWN_WITHDRAW("towny.command.town.withdraw"),
 		TOWNY_COMMAND_TOWN_DEPOSIT("towny.command.town.deposit"),

--- a/src/com/palmergames/bukkit/towny/tasks/OnPlayerLogin.java
+++ b/src/com/palmergames/bukkit/towny/tasks/OnPlayerLogin.java
@@ -19,6 +19,8 @@ import com.palmergames.bukkit.towny.permissions.TownyPerms;
 import com.palmergames.bukkit.towny.utils.ResidentUtil;
 import com.palmergames.bukkit.towny.utils.TownRuinUtil;
 import com.palmergames.bukkit.util.BukkitTools;
+import com.palmergames.bukkit.util.Colors;
+
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.event.ClickEvent;
 import org.bukkit.Bukkit;
@@ -160,6 +162,10 @@ public class OnPlayerLogin implements Runnable {
 					} else
 						warningMessage(resident, town, nation);
 				}
+				
+				// Send a message warning of being overclaimed while the takeoverclaims feature is enabled.
+				if (TownySettings.isOverClaimingAllowingStolenLand() && town.getTownBlocks().size() > town.getMaxTownBlocks())
+					TownyMessaging.sendMsg(resident, Translatable.literal(Colors.Red).append(Translatable.of("msg_warning_your_town_is_overclaimed")));
 				
 				// Send a message warning of ruined status and time until deletion.
 				if (town.isRuined())

--- a/src/com/palmergames/bukkit/towny/utils/AreaSelectionUtil.java
+++ b/src/com/palmergames/bukkit/towny/utils/AreaSelectionUtil.java
@@ -340,7 +340,6 @@ public class AreaSelectionUtil {
 	 * Returns a list containing only townblocks that can be claimed.
 	 * Filters out townblocks too close to other town homeblocks as set in the config.
 	 * 
-
 	 * @param selection List&lt;WorldCoord&gt; of coordinates
 	 * @param town Town to check distance from
 	 * @return List of {@link WorldCoord}
@@ -349,14 +348,25 @@ public class AreaSelectionUtil {
 
 		List<WorldCoord> out = new ArrayList<>();
 		for (WorldCoord worldCoord : selection)
-			if (worldCoord.getTownyWorld().getMinDistanceFromOtherTowns(worldCoord, town) >= TownySettings.getMinDistanceFromTownHomeblocks()) {
+			if (!isTooCloseToHomeBlock(worldCoord, town)) {
 				out.add(worldCoord);
 			} else {
 				TownyMessaging.sendDebugMsg("AreaSelectionUtil:filterInvalidProximity - Coord: " + worldCoord + " too close to another town's homeblock." );
 			}
 		return out;
 	}
-	
+
+	/**
+	 * Is the WorldCoord too close to another town's HomeBlock.
+	 * 
+	 * @param wc WorldCoord to check distance from.
+	 * @param town Town whos homeblock we don't have to account for.
+	 * @return true if the WorldCoord is too close to a homeblock.
+	 */
+	public static boolean isTooCloseToHomeBlock(WorldCoord wc, Town town) {
+		return wc.getTownyWorld().getMinDistanceFromOtherTownsHomeBlocks(wc, town) < TownySettings.getMinDistanceFromTownHomeblocks();
+	}
+
 	/**
 	 * Returns a list containing only wilderness townblocks.
 	 * 

--- a/src/com/palmergames/bukkit/towny/utils/OutpostUtil.java
+++ b/src/com/palmergames/bukkit/towny/utils/OutpostUtil.java
@@ -43,7 +43,7 @@ public class OutpostUtil {
 			throw new TownyException(Translatable.of("msg_max_outposts_own", maxOutposts));
 
 		// Outposts can have a minimum required distance from homeblocks. 
-		if (world.getMinDistanceFromOtherTowns(key) < TownySettings.getMinDistanceFromTownHomeblocks())
+		if (world.getMinDistanceFromOtherTownsHomeBlocks(key) < TownySettings.getMinDistanceFromTownHomeblocks())
 			throw new TownyException(Translatable.of("msg_too_close2", Translatable.of("homeblock")));
 
 		int maxDistance = TownySettings.getMaxDistanceForOutpostsFromTown();


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

Adds WorldCoord#canBeStolen
Adds new config option allowing over-claimed town (ie 120/100 townblocks) to have their land taken from them.
  - Config option explains that outposts should be disabled, a number of adjacent townblocks > 1 should be set.
  - Does not work on outposts, or when new towns are being made.
Adds new config option setting the price of taking over a claim.

Adds new `/t takeoverclaim` command that initiates stealing a single townblock.

Adds warning messages 
  - claiming that approaches the limit (and when losing a resident would put you in real danger.)
  - logging in while overclaimed.
  - losing a resident that puts you into overclaimed status.

Deprecates a couple of TownyWorld distance checks and replaces them with new methods with better names.
  - getMinDistanceFromOtherTowns(Coord)
  - getMinDistanceFromOtherTowns(Coord, Town)

Has the ability to prevent a town being cut in two, using a simple test of the surrounding plots.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
```
  - New Config Option: town.overclaiming.being_overclaimed_allows_other_towns_to_steal_land
    - Default: false
    - A feature that allows towns which have too many townblocks claimed (overclaimed) ie: 120/100 TownBlocks,
      to have their land stolen by other towns which are not overclaimed. Using this incentivises Towns to keep
      their residents from leaving, and will mean that mayors will be more careful about which land they choose
      to claim. It is highly recommended to only use this on servers where outposts are disabled, and requiring
      a number of adjacent claims over 1 is enabled. Towns take land using /t takeoverclaim.
  - New Config Option: town.overclaiming.overclaiming_prevented_by_homeblock_radius
    - Default: true
    - While true, overclaiming is stopped by the min_distance_from_town_homeblock setting below.
    - This prevents a town from having townblocks stolen surrounding their homeblocks.
  - New Config Option: economy.takeoverclaim.price
    - Default: 100.0
    - The price to use /t takeoverclaim, when it has been enabled in the config 
      at town.being_overclaimed_allows_other_towns_to_steal_land
```

```
  - New Command: /town takeoverclaim
    - Used to a mayor to take over land from an overclaimed town, when allowed in the config.
    - Towns are considered overclaimed if their townblocks are more than they are allowed, ie: TownBlocks 120/100.
```

```
  - New Permission Node: towny.command.town.takeoverclaim
    - Child Node of towny.command.town.*
    - No adjustments need to be made to the townyperms.yml.
```
____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #6564.

____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
