### PR TITLE
Add option to stop protected mobs from entering empty boats in Towns.

### DIFF
--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1617,6 +1617,12 @@ public enum ConfigNodes {
 			"# PigZombie, Sheep, Skeleton, Slime, Spider, Squid, WaterMob, Wolf, Zombie",
 			"",
 			"# Protect living entities within a town's boundaries from being killed by players or mobs."),
+	PROT_MOB_TYPES_BOAT_THEFT(
+			"protection.mob_types_protected_from_boat_theft",
+			"false",
+			"",
+			"# When set to true, the above mob_types will be protected when they are in a town, from being able to enter empty boats.",
+			"# This protects the mobs from being stolen using boats."),
 	PROT_MOB_TYPES_MOB_VS_MOB_BYPASS(
 			"protection.are_mob_types_protected_against_mobs",
 			"true",

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -3527,5 +3527,10 @@ public class TownySettings {
 	public static boolean disableMySQLBackupWarning() {
 		return DatabaseConfig.getBoolean(DatabaseConfig.DATABASE_SQL_DISABLE_BACKUP_WARNING);
 	}
+
+	public static boolean isTownyPreventingProtectedMobsEnteringBoatsInTown() {
+		return getBoolean(ConfigNodes.PROT_MOB_TYPES_BOAT_THEFT);
+	}
+
 }
 

--- a/src/com/palmergames/bukkit/towny/listeners/TownyVehicleListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyVehicleListener.java
@@ -1,6 +1,8 @@
 package com.palmergames.bukkit.towny.listeners;
 
 import org.bukkit.Material;
+import org.bukkit.entity.Boat;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Minecart;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -153,6 +155,35 @@ public class TownyVehicleListener implements Listener {
 				if (TownySettings.isSwitchMaterial(vehicle, event.getVehicle().getLocation()))
 					event.setCancelled(!TownyActionEventExecutor.canSwitch(player, event.getVehicle().getLocation(), vehicle));
 			}
-		}	
+		} 
+
+		/*
+		 * Dealing with a Boat being entered by a protected mob type.
+		 */
+		if (event.getVehicle() instanceof Boat boat && EntityTypeUtil.isInstanceOfAny(TownySettings.getProtectedEntityTypes(), event.getEntered())) {
+
+			// Dealing with an empty boat.
+			if (boat.isEmpty()) {
+				// No driver, don't allow someone pushing a boat into a entity to steal the entity.
+				event.setCancelled(true);
+				System.out.println("Cancelled empty boat entrance.");
+				return;
+			}
+			// Dealing with a boat with one passenger.
+			Entity rider = boat.getPassengers().stream().findFirst().get();
+			System.out.println("rider = " + rider.getName());
+			// If it is driven by a player check for destroy permissions.
+			if (rider instanceof Player player) {
+				System.out.println("Cancelled player boat entrance.");
+				event.setCancelled(!TownyActionEventExecutor.canDestroy(player, event.getVehicle().getLocation(), Material.GRASS_BLOCK));
+				System.out.println("Cancelled player boat entrance.");
+				return;
+			}
+			
+			System.out.println("Cancelled entity boat entrance.");
+			// It is another non-player in the boat, probably being pushed around by a player.
+			event.setCancelled(true);
+			return;
+		}
 	}
 }

--- a/src/com/palmergames/bukkit/towny/listeners/TownyVehicleListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyVehicleListener.java
@@ -158,32 +158,17 @@ public class TownyVehicleListener implements Listener {
 		} 
 
 		/*
-		 * Dealing with a Boat being entered by a protected mob type.
+		 * Dealing with an empty Boat being entered by a protected mob type, inside of a Town.
 		 */
-		if (event.getVehicle() instanceof Boat boat && EntityTypeUtil.isInstanceOfAny(TownySettings.getProtectedEntityTypes(), event.getEntered())) {
-
-			// Dealing with an empty boat.
-			if (boat.isEmpty()) {
-				// No driver, don't allow someone pushing a boat into a entity to steal the entity.
-				event.setCancelled(true);
-				System.out.println("Cancelled empty boat entrance.");
-				return;
-			}
-			// Dealing with a boat with one passenger.
-			Entity rider = boat.getPassengers().stream().findFirst().get();
-			System.out.println("rider = " + rider.getName());
-			// If it is driven by a player check for destroy permissions.
-			if (rider instanceof Player player) {
-				System.out.println("Cancelled player boat entrance.");
-				event.setCancelled(!TownyActionEventExecutor.canDestroy(player, event.getVehicle().getLocation(), Material.GRASS_BLOCK));
-				System.out.println("Cancelled player boat entrance.");
-				return;
-			}
-			
-			System.out.println("Cancelled entity boat entrance.");
-			// It is another non-player in the boat, probably being pushed around by a player.
+		if (TownySettings.isTownyPreventingProtectedMobsEnteringBoatsInTown() 
+			&& event.getVehicle() instanceof Boat boat && isProtectedMobEnteringEmptyBoatInTown(boat, event.getEntered())) {
 			event.setCancelled(true);
 			return;
 		}
+	}
+
+	private boolean isProtectedMobEnteringEmptyBoatInTown(Boat boat, Entity entity) {
+		return boat.isEmpty() && !TownyAPI.getInstance().isWilderness(entity.getLocation())
+				&& EntityTypeUtil.isInstanceOfAny(TownySettings.getProtectedEntityTypes(), entity);
 	}
 }


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->

```
  - New Config Option: protection.mob_types_protected_from_boat_theft
    - Default: false
    - When set to true, the above mob_types will be protected when they are in a town, from being able to enter empty boats.
    - This protects the mobs from being stolen using boats.
```
____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #6554 

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
