### PR TITLE
Make campfire water bottle protection a bit better

### DIFF
--- a/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
@@ -12,6 +12,7 @@ import com.palmergames.bukkit.towny.object.TownyWorld;
 import com.palmergames.bukkit.towny.regen.TownyRegenAPI;
 import com.palmergames.bukkit.towny.regen.block.BlockLocation;
 import com.palmergames.bukkit.towny.tasks.MobRemovalTimerTask;
+import com.palmergames.bukkit.towny.utils.BorderUtil;
 import com.palmergames.bukkit.towny.utils.CombatUtil;
 import com.palmergames.bukkit.towny.utils.EntityTypeUtil;
 import com.palmergames.bukkit.util.BukkitTools;
@@ -550,9 +551,15 @@ public class TownyEntityListener implements Listener {
 
 			/* Protect campfires from SplashWaterBottles. Uses a destroy test. */
 			case SPLASH_POTION -> {
-				if (event.getBlock().getType() != Material.CAMPFIRE && ((ThrownPotion) event.getEntity()).getShooter() instanceof Player)
+				final ThrownPotion potion = (ThrownPotion) event.getEntity();
+				// Check that the affected block is a campfire and that a water bottle (no effects) was used.
+				if (event.getBlock().getType() != Material.CAMPFIRE || !potion.getEffects().isEmpty())
 					return;
-				event.setCancelled(!TownyActionEventExecutor.canDestroy((Player) ((ThrownPotion) event.getEntity()).getShooter(), event.getBlock().getLocation(), Material.CAMPFIRE));
+				
+				if (potion.getShooter() instanceof BlockProjectileSource bps)
+					event.setCancelled(!BorderUtil.allowedMove(bps.getBlock(), event.getBlock()));
+				else if (potion.getShooter() instanceof Player player)
+					event.setCancelled(!TownyActionEventExecutor.canDestroy(player, event.getBlock().getLocation(), Material.CAMPFIRE));
 			}
 			
 			default -> {}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Fixes an exception when a non-player entity causes an EntityChangeBlockEvent using a splash potion on a non-campfire block. Also improves the protection by adding a check for dispensers using BorderUtil.
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
