### PR TITLE
Allow Spawn Events to be Un-Cancelled

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/event/NationSpawnEvent.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/event/NationSpawnEvent.java
@@ -27,7 +27,7 @@ public class NationSpawnEvent extends SpawnEvent {
 	 * @param from The location the player is teleporting from.
 	 * @param to The location the player is going to.
 	 */
-	public NationSpawnEvent(Player player, Location from, Location to) {
+	public NationSpawnEvent(Player player, Location from, Location to, boolean cancelled, String cancelMessage) {
 		super(player, from, to);
 		
 		TownBlock fromTownBlock = WorldCoord.parseWorldCoord(from).getTownBlockOrNull();
@@ -37,6 +37,9 @@ public class NationSpawnEvent extends SpawnEvent {
 			fromNation = fromTownBlock.getTownOrNull().getNationOrNull();
 		if (toTownBlock != null)
 			toNation = toTownBlock.getTownOrNull().getNationOrNull();
+		
+		setCancelled(cancelled);
+		setCancelMessage(cancelMessage);
 	}
 
 	/**

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/event/TownSpawnEvent.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/event/TownSpawnEvent.java
@@ -16,11 +16,13 @@ public class TownSpawnEvent extends SpawnEvent {
 	private final Town fromTown;
 	private final Town toTown;
 	
-	public TownSpawnEvent(Player player, Location from, Location to) {
+	public TownSpawnEvent(Player player, Location from, Location to, boolean cancelled, String cancelMessage) {
 		super(player, from, to);
 
 		fromTown = WorldCoord.parseWorldCoord(from).getTownOrNull();
 		toTown = WorldCoord.parseWorldCoord(to).getTownOrNull();
+		setCancelled(cancelled);
+		setCancelMessage(cancelMessage);
 	}
 
 	/**

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/event/teleport/ResidentSpawnEvent.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/event/teleport/ResidentSpawnEvent.java
@@ -17,11 +17,13 @@ public class ResidentSpawnEvent extends SpawnEvent {
 	private final Town fromTown;
 	private final Town toTown;
 	
-	public ResidentSpawnEvent(Player player, Location from, Location to) {
+	public ResidentSpawnEvent(Player player, Location from, Location to, boolean cancelled, String cancelMessage) {
 		super(player, from, to);
 		
 		fromTown = WorldCoord.parseWorldCoord(from).getTownOrNull();
 		toTown = WorldCoord.parseWorldCoord(to).getTownOrNull();
+		setCancelled(cancelled);
+		setCancelMessage(cancelMessage);
 	}
 
 	/**

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/SpawnInfo.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/SpawnInfo.java
@@ -1,0 +1,30 @@
+package com.palmergames.bukkit.towny.object;
+
+import com.palmergames.bukkit.towny.object.spawnlevel.NationSpawnLevel;
+import com.palmergames.bukkit.towny.object.spawnlevel.TownSpawnLevel;
+
+public class SpawnInfo {
+	public boolean eventCancelled;
+	public String eventCancellationMessage;
+	public Town town;
+	public Nation nation;
+	public double travelCost;
+	public TownSpawnLevel townSpawnLevel;
+	public NationSpawnLevel nationSpawnLevel;
+	public Resident resident;
+	public int cooldown;
+
+
+	public SpawnInfo() {
+		this.eventCancelled = false;
+		this.eventCancellationMessage = null;
+		this.town = null;
+		this.nation = null;
+		this.travelCost = 0;
+		townSpawnLevel = null;
+		nationSpawnLevel = null;
+		resident = null;
+		cooldown = 0;
+	}
+	
+}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/SpawnInformation.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/SpawnInformation.java
@@ -3,27 +3,24 @@ package com.palmergames.bukkit.towny.object;
 import com.palmergames.bukkit.towny.object.spawnlevel.NationSpawnLevel;
 import com.palmergames.bukkit.towny.object.spawnlevel.TownSpawnLevel;
 
-public class SpawnInfo {
+/**
+ * This is an internal class used by towny to pass-around info related to spawning
+ */
+public class SpawnInformation {
 	public boolean eventCancelled;
 	public String eventCancellationMessage;
-	public Town town;
-	public Nation nation;
 	public double travelCost;
 	public TownSpawnLevel townSpawnLevel;
 	public NationSpawnLevel nationSpawnLevel;
-	public Resident resident;
 	public int cooldown;
 
 
-	public SpawnInfo() {
+	public SpawnInformation() {
 		this.eventCancelled = false;
 		this.eventCancellationMessage = null;
-		this.town = null;
-		this.nation = null;
 		this.travelCost = 0;
 		townSpawnLevel = null;
 		nationSpawnLevel = null;
-		resident = null;
 		cooldown = 0;
 	}
 	

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/SpawnInformation.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/SpawnInformation.java
@@ -19,9 +19,9 @@ public class SpawnInformation {
 		this.eventCancelled = false;
 		this.eventCancellationMessage = null;
 		this.travelCost = 0;
-		townSpawnLevel = null;
-		nationSpawnLevel = null;
-		cooldown = 0;
+		this.townSpawnLevel = null;
+		this.nationSpawnLevel = null;
+		this.cooldown = 0;
 	}
 	
 }

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/SpawnUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/SpawnUtil.java
@@ -65,7 +65,7 @@ public class SpawnUtil {
 	public static void sendToTownySpawn(Player player, String[] split, TownyObject townyObject, String notAffordMSG, boolean outpost, boolean ignoreWarn, SpawnType spawnType) throws TownyException {
 
 		// Get resident while testing they aren't on a cooldown or jailed.
-		final Resident resident = getResident(player);;
+		Resident resident = getResident(player);;
 
 		// Set up town and nation variables.
 		final Town town = switch (spawnType) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/SpawnUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/SpawnUtil.java
@@ -9,7 +9,7 @@ import com.palmergames.bukkit.towny.event.SpawnEvent;
 import com.palmergames.bukkit.towny.event.TownSpawnEvent;
 import com.palmergames.bukkit.towny.event.teleport.ResidentSpawnEvent;
 import com.palmergames.bukkit.towny.event.teleport.UnjailedResidentTeleportEvent;
-import com.palmergames.bukkit.towny.object.SpawnInfo;
+import com.palmergames.bukkit.towny.object.SpawnInformation;
 import com.palmergames.bukkit.towny.object.Translatable;
 import com.palmergames.bukkit.towny.object.economy.Account;
 import com.palmergames.bukkit.towny.object.spawnlevel.NationSpawnLevel;
@@ -64,10 +64,27 @@ public class SpawnUtil {
 	 */
 	public static void sendToTownySpawn(Player player, String[] split, TownyObject townyObject, String notAffordMSG, boolean outpost, boolean ignoreWarn, SpawnType spawnType) throws TownyException {
 
-		//Get spawn information. This is a simple utility class which allows us to pass data into the lambda below
-		SpawnInfo spawnInfo = getSpawnInformation(player, split, townyObject, notAffordMSG, outpost, ignoreWarn, spawnType);
-		
-		getSpawnLoc(player, spawnInfo.town, spawnInfo.nation, spawnType, outpost, split).thenAccept(spawnLoc -> {
+		// Get resident while testing they aren't on a cooldown or jailed.
+		final Resident resident = getResident(player);;
+
+		// Set up town and nation variables.
+		final Town town = switch (spawnType) {
+			case RESIDENT -> resident.getTownOrNull();
+			case TOWN -> (Town) townyObject;
+			default -> null;
+		};
+
+		final Nation nation = spawnType == SpawnType.NATION ? (Nation) townyObject : null;
+
+		// Is this an admin spawning?
+		final boolean isTownyAdmin = isTownyAdmin(player);
+
+		//Get spawn information object. This allows us to pass data into the lambda below
+		final SpawnInformation spawnInfo = getSpawnInformation(
+			player, split, townyObject, notAffordMSG, outpost, ignoreWarn, spawnType, 
+			resident, town, nation, isTownyAdmin);
+
+		getSpawnLoc(player, town, nation, spawnType, outpost, split).thenAccept(spawnLoc -> {
 			// Fire a cancellable event right before a player would actually pay.
 			// Throws a TownyException if the event is cancelled.
 			try {
@@ -81,55 +98,40 @@ public class SpawnUtil {
 			if (spawnInfo.travelCost > 0) {
 				// Get paymentMsg for the money.csv and the Account being paid.
 				final String paymentMsg = getPaymentMsg(spawnInfo.townSpawnLevel, spawnInfo.nationSpawnLevel, spawnType);
-				final Account payee = TownySettings.isTownSpawnPaidToTown() ? getPayee(spawnInfo.town, spawnInfo.nation, spawnType) : EconomyAccount.SERVER_ACCOUNT;
-				initiateCostedSpawn(player, spawnInfo.resident, spawnLoc, spawnInfo.travelCost, payee, paymentMsg, ignoreWarn, spawnInfo.cooldown);
+				final Account payee = TownySettings.isTownSpawnPaidToTown() ? getPayee(town, nation, spawnType) : EconomyAccount.SERVER_ACCOUNT;
+				initiateCostedSpawn(player, resident, spawnLoc, spawnInfo.travelCost, payee, paymentMsg, ignoreWarn, spawnInfo.cooldown);
 				// No Cost so skip confirmation system.
 			} else
 				initiateSpawn(player, spawnLoc, spawnInfo.cooldown);
 		});
 	}
 
-	private static SpawnInfo getSpawnInformation(Player player, String[] split, TownyObject townyObject, String notAffordMSG, boolean outpost, boolean ignoreWarn, SpawnType spawnType) {
-		SpawnInfo spawnInformation = new SpawnInfo();
+	private static SpawnInformation getSpawnInformation(Player player, String[] split, TownyObject townyObject, String notAffordMSG, boolean outpost, boolean ignoreWarn, SpawnType spawnType, Resident resident, Town town, Nation nation, boolean isTownyAdmin) {
+		SpawnInformation spawnInformation = new SpawnInformation();
 		try {
-			// Get resident while testing they aren't on a cooldown or jailed.
-			spawnInformation.resident = getResident(player);;
-
-			// Set up town and nation variables.
-			spawnInformation.town = switch (spawnType) {
-				case RESIDENT -> spawnInformation.resident.getTownOrNull();
-				case TOWN -> (Town) townyObject;
-				default -> null;
-			};
-
-			spawnInformation.nation = spawnType == SpawnType.NATION ? (Nation) townyObject : null;
-
-			// Is this an admin spawning?
-			boolean isTownyAdmin = isTownyAdmin(player);
-
 			// Set up either the townSpawnLevel or nationSpawnLevel variable.
 			// This determines whether a spawn is considered town, nation, public, allied, admin via TownSpawnLevel and NationSpawnLevel objects.
 			// Accounts for costs, permission, config settings and messages.
 			spawnInformation.townSpawnLevel = switch (spawnType) {
 				case RESIDENT -> isTownyAdmin ? TownSpawnLevel.ADMIN : TownSpawnLevel.TOWN_RESIDENT;
-				case TOWN -> isTownyAdmin ? TownSpawnLevel.ADMIN : getTownSpawnLevel(player, spawnInformation.resident, spawnInformation.town, outpost, split.length == 0);
+				case TOWN -> isTownyAdmin ? TownSpawnLevel.ADMIN : getTownSpawnLevel(player, resident, town, outpost, split.length == 0);
 				default -> null;
 			};
 
-			spawnInformation.nationSpawnLevel = spawnType == SpawnType.NATION ? isTownyAdmin ? NationSpawnLevel.ADMIN : getNationSpawnLevel(player, spawnInformation.resident, spawnInformation.nation, split.length == 0) : null;
+			spawnInformation.nationSpawnLevel = spawnType == SpawnType.NATION ? isTownyAdmin ? NationSpawnLevel.ADMIN : getNationSpawnLevel(player, resident, nation, split.length == 0) : null;
 
 			spawnInformation.cooldown = player.hasPermission(PermissionNodes.TOWNY_SPAWN_ADMIN_NOCOOLDOWN.getNode()) ? 0 : spawnInformation.townSpawnLevel != null ? spawnInformation.townSpawnLevel.getCooldown() : spawnInformation.nationSpawnLevel.getCooldown();
 
 			// Prevent spawn travel while in the config's disallowed zones.
 			// Throws a TownyException if the player is disallowed.
 			if (!isTownyAdmin)
-				testDisallowedZones(player, spawnInformation.resident, spawnType, TownySettings.getDisallowedTownSpawnZones());
+				testDisallowedZones(player, resident, spawnType, TownySettings.getDisallowedTownSpawnZones());
 
 			// Get cost required to spawn.
-			spawnInformation.travelCost= getTravelCost(player, spawnInformation.town, spawnInformation.nation, spawnInformation.townSpawnLevel, spawnInformation.nationSpawnLevel, spawnType);
+			spawnInformation.travelCost= getTravelCost(player, town, nation, spawnInformation.townSpawnLevel, spawnInformation.nationSpawnLevel, spawnType);
 			
 			// Don't allow if they cannot pay.
-			if (spawnInformation.travelCost > 0 && !spawnInformation.resident.getAccount().canPayFromHoldings(spawnInformation.travelCost))
+			if (spawnInformation.travelCost > 0 && !resident.getAccount().canPayFromHoldings(spawnInformation.travelCost))
 				throw new TownyException(notAffordMSG);
 
 		} catch (TownyException te) {
@@ -566,7 +568,7 @@ public class SpawnUtil {
 	 * @param spawnLoc  Location being spawned to.
 	 * @throws TownyException when the event is cancelled.
 	 */
-	private static void sendSpawnEvent(Player player, SpawnType spawnType, Location spawnLoc, SpawnInfo spawnInformation) throws TownyException {
+	private static void sendSpawnEvent(Player player, SpawnType spawnType, Location spawnLoc, SpawnInformation spawnInformation) throws TownyException {
 		BukkitTools.ifCancelledThenThrow(getSpawnEvent(player, spawnType, spawnLoc, spawnInformation));
 	}
 	
@@ -578,7 +580,7 @@ public class SpawnUtil {
 	 * @param spawnLoc  Location that the player will spawn at.
 	 * @return SpawnEvent to be called.
 	 */
-	private static SpawnEvent getSpawnEvent(Player player, SpawnType spawnType, Location spawnLoc, SpawnInfo spawnInfo) {
+	private static SpawnEvent getSpawnEvent(Player player, SpawnType spawnType, Location spawnLoc, SpawnInformation spawnInfo) {
 		return switch(spawnType) {
 		case RESIDENT -> new ResidentSpawnEvent(player, player.getLocation(), spawnLoc, spawnInfo.eventCancelled, spawnInfo.eventCancellationMessage);
 		case TOWN -> new TownSpawnEvent(player, player.getLocation(), spawnLoc, spawnInfo.eventCancelled, spawnInfo.eventCancellationMessage);


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
- With current Towny code, plugin developers cannot un-cancel spawn events .... because where spawn is restricted by towny config, the code throws the required exception (*e.g. throw new TownyException("spawn not allowed")*) before it reaches the line where the SpawnEvent is fired.
- Un-Cancelling spawn events is something that SiegeWar now needs to do, because since SW2.0.0, peaceful towns cannot always maintain a free public spawn, which is a big problem for peaceful shopkeepers.
- This PR adds the code to do it.

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Towny Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
