### PR TITLE
Bukkit enum eradication futureproofing

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -588,7 +588,7 @@ public enum ConfigNodes {
 			"# You can adjust this setting for an existing world using /townyworld toggle revertentityexpl"),
 	NWS_PLOT_MANAGEMENT_WILD_ENTITY_REVERT_LIST(
 			"new_world_settings.plot_management.wild_revert_on_mob_explosion.entities",			
-			"CREEPER,ENDER_CRYSTAL,ENDER_DRAGON,FIREBALL,SMALL_FIREBALL,FIREBALL,PRIMED_TNT,MINECART_TNT,WITHER,WITHER_SKULL",
+			"CREEPER,ENDER_CRYSTAL,ENDER_DRAGON,FIREBALL,SMALL_FIREBALL,TNT,TNT_MINECART,WITHER,WITHER_SKULL",
 			"",
 			"# The list of entities whose explosions should be reverted."),
 	NWS_PLOT_MANAGEMENT_WILD_MOB_REVERT_TIME(

--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -588,7 +588,7 @@ public enum ConfigNodes {
 			"# You can adjust this setting for an existing world using /townyworld toggle revertentityexpl"),
 	NWS_PLOT_MANAGEMENT_WILD_ENTITY_REVERT_LIST(
 			"new_world_settings.plot_management.wild_revert_on_mob_explosion.entities",			
-			"CREEPER,ENDER_CRYSTAL,ENDER_DRAGON,FIREBALL,SMALL_FIREBALL,LARGE_FIREBALL,PRIMED_TNT,MINECART_TNT,WITHER,WITHER_SKULL",
+			"CREEPER,ENDER_CRYSTAL,ENDER_DRAGON,FIREBALL,SMALL_FIREBALL,FIREBALL,PRIMED_TNT,MINECART_TNT,WITHER,WITHER_SKULL",
 			"",
 			"# The list of entities whose explosions should be reverted."),
 	NWS_PLOT_MANAGEMENT_WILD_MOB_REVERT_TIME(

--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -512,7 +512,7 @@ public enum ConfigNodes {
 			"false"),
 	NWS_PLOT_MANAGEMENT_ENTITY_DELETE(
 			"new_world_settings.plot_management.entity_delete.unclaim_delete",
-			"ENDER_CRYSTAL",
+			"end_crystal",
 			"",
 			"# These entities will be deleted upon a plot being unclaimed.",
 			"# Valid EntityTypes can be found here: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/EntityType.html"),
@@ -588,7 +588,7 @@ public enum ConfigNodes {
 			"# You can adjust this setting for an existing world using /townyworld toggle revertentityexpl"),
 	NWS_PLOT_MANAGEMENT_WILD_ENTITY_REVERT_LIST(
 			"new_world_settings.plot_management.wild_revert_on_mob_explosion.entities",			
-			"CREEPER,ENDER_CRYSTAL,ENDER_DRAGON,FIREBALL,SMALL_FIREBALL,TNT,TNT_MINECART,WITHER,WITHER_SKULL",
+			"CREEPER,END_CRYSTAL,ENDER_DRAGON,FIREBALL,SMALL_FIREBALL,TNT,TNT_MINECART,WITHER,WITHER_SKULL",
 			"",
 			"# The list of entities whose explosions should be reverted."),
 	NWS_PLOT_MANAGEMENT_WILD_MOB_REVERT_TIME(

--- a/Towny/src/main/java/com/palmergames/bukkit/config/migration/WorldMigrationAction.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/migration/WorldMigrationAction.java
@@ -1,12 +1,11 @@
 package com.palmergames.bukkit.config.migration;
 
 import com.palmergames.bukkit.towny.object.TownyWorld;
-import com.palmergames.util.StringMgmt;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
@@ -14,53 +13,61 @@ public enum WorldMigrationAction {
 	UPDATE_WORLD_BLOCK_IGNORE(((townyWorld, change) -> {
 		if (change.type == MigrationType.REPLACE)
 			townyWorld.setPlotManagementIgnoreIds(replaceAll(townyWorld.getPlotManagementIgnoreIds().stream()
-					.map(mat -> mat.name())
+					.map(mat -> mat.getKey().getKey())
 					.collect(Collectors.toList()), change.key, change.value));
 		else
-			townyWorld.setPlotManagementIgnoreIds(splitMats(StringMgmt.join(townyWorld.getPlotManagementIgnoreIds(), ",") + change.value));
+			townyWorld.setPlotManagementIgnoreIds(splitMats(townyWorld.getPlotManagementIgnoreIds().stream().map(type -> type.getKey().toString()).collect(Collectors.joining(",")) + change.value));
 	})),
 	UPDATE_WORLD_DELETE_MAYOR(((townyWorld, change) -> {
 		if (change.type == MigrationType.REPLACE)
 			townyWorld.setPlotManagementMayorDelete(replaceAll(townyWorld.getPlotManagementMayorDelete().stream()
-					.map(mat -> mat.name())
+					.map(mat -> mat.getKey().getKey())
 					.collect(Collectors.toList()), change.key, change.value));
 		else
-			townyWorld.setPlotManagementMayorDelete(splitMats(StringMgmt.join(townyWorld.getPlotManagementMayorDelete(), ",") + change.value));
+			townyWorld.setPlotManagementMayorDelete(splitMats(townyWorld.getPlotManagementMayorDelete().stream().map(type -> type.getKey().toString()).collect(Collectors.joining(",")) + change.value));
 	})),
 	UPDATE_WORLD_UNCLAIM_DELETE(((townyWorld, change) -> {
 		if (change.type == MigrationType.REPLACE)
 			townyWorld.setPlotManagementDeleteIds(replaceAll(townyWorld.getPlotManagementDeleteIds().stream()
-					.map(mat -> mat.name())
+					.map(mat -> mat.getKey().getKey())
 					.collect(Collectors.toList()), change.key, change.value));
 		else
-			townyWorld.setPlotManagementDeleteIds(splitMats(StringMgmt.join(townyWorld.getPlotManagementDeleteIds(), ",") + change.value));
+			townyWorld.setPlotManagementDeleteIds(splitMats(townyWorld.getPlotManagementDeleteIds().stream().map(type -> type.getKey().toString()).collect(Collectors.joining(",")) + change.value));
 	})),
 	UPDATE_WILDERNESS_IGNORE_MATS(((townyWorld, change) -> {
 		if (change.type == MigrationType.REPLACE)
 			townyWorld.setUnclaimedZoneIgnore(replaceAll(townyWorld.getUnclaimedZoneIgnoreMaterials().stream()
-					.map(mat -> mat.name())
+					.map(mat -> mat.getKey().getKey())
 					.collect(Collectors.toList()), change.key, change.value));
 		else
-			townyWorld.setUnclaimedZoneIgnore(splitMats(StringMgmt.join(townyWorld.getUnclaimedZoneIgnoreMaterials(), ",") + change.value));
+			townyWorld.setUnclaimedZoneIgnore(splitMats(townyWorld.getUnclaimedZoneIgnoreMaterials().stream().map(type -> type.getKey().toString()).collect(Collectors.joining(",")) + change.value));
 	})),
 	UPDATE_WORLD_EXPLOSION_REVERT_BLOCKS(((townyWorld, change) -> {
 		if (change.type == MigrationType.REPLACE)
 			townyWorld.setPlotManagementWildRevertMaterials(replaceAll(townyWorld.getPlotManagementWildRevertBlocks().stream()
-					.map(mat -> mat.name())
+					.map(mat -> mat.getKey().getKey())
 					.collect(Collectors.toList()), change.key, change.value));
 		else
-			townyWorld.setPlotManagementWildRevertMaterials(splitMats(StringMgmt.join(townyWorld.getPlotManagementWildRevertBlocks(), ",") + change.value));
+			townyWorld.setPlotManagementWildRevertMaterials(splitMats(townyWorld.getPlotManagementWildRevertBlocks().stream().map(type -> type.getKey().toString()).collect(Collectors.joining(",")) + change.value));
 	})),
 	UPDATE_WORLD_EXPLOSION_REVERT_ENTITIES(((townyWorld, change) -> {
 		if (change.type == MigrationType.REPLACE)
 			townyWorld.setPlotManagementWildRevertEntities(replaceAll(townyWorld.getPlotManagementWildRevertEntities().stream()
-					.map(type -> type.name())
+					.map(type -> type.getKey().getKey())
 					.collect(Collectors.toList()), change.key, change.value));
 		else
-			townyWorld.setPlotManagementWildRevertEntities(splitMats(StringMgmt.join(townyWorld.getPlotManagementWildRevertEntities(), ",") + change.value));
-	}));
+			townyWorld.setPlotManagementWildRevertEntities(splitMats(townyWorld.getPlotManagementWildRevertEntities().stream().map(type -> type.getKey().toString()).collect(Collectors.joining(",")) + change.value));
+	})),
+	UPDATE_WORLD_UNCLAIM_REVERT_ENTITIES((((townyWorld, change) -> {
+		if (change.type == MigrationType.REPLACE)
+			townyWorld.setUnclaimDeleteEntityTypes(replaceAll(townyWorld.getUnclaimDeleteEntityTypes().stream()
+				.map(type -> type.getKey().getKey())
+				.collect(Collectors.toList()), change.key, change.value));
+		else
+			townyWorld.setUnclaimDeleteEntityTypes(splitMats(townyWorld.getUnclaimDeleteEntityTypes().stream().map(type -> type.getKey().toString()).collect(Collectors.joining(",")) + change.value));
+	})));
 	
-	BiConsumer<TownyWorld, Change> action;
+	final BiConsumer<TownyWorld, Change> action;
 	
 	WorldMigrationAction(BiConsumer<TownyWorld, Change> action) {
 		this.action = action;
@@ -76,7 +83,13 @@ public enum WorldMigrationAction {
 	
 	private static List<String> replaceAll(List<String> list, String oldValue, String newValue) {
 		List<String> toReplace = new ArrayList<>(list);
-		Collections.replaceAll(toReplace, oldValue, newValue);
+		
+		ListIterator<String> iterator = toReplace.listIterator();
+		while (iterator.hasNext()) {
+			if (iterator.next().equalsIgnoreCase(oldValue))
+				iterator.set(newValue);
+		}
+
 		return toReplace;
 	}
 }

--- a/Towny/src/main/java/com/palmergames/bukkit/config/migration/WorldMigrationAction.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/migration/WorldMigrationAction.java
@@ -1,6 +1,8 @@
 package com.palmergames.bukkit.config.migration;
 
 import com.palmergames.bukkit.towny.object.TownyWorld;
+import org.bukkit.Material;
+import org.bukkit.entity.EntityType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -13,7 +15,7 @@ public enum WorldMigrationAction {
 	UPDATE_WORLD_BLOCK_IGNORE(((townyWorld, change) -> {
 		if (change.type == MigrationType.REPLACE)
 			townyWorld.setPlotManagementIgnoreIds(replaceAll(townyWorld.getPlotManagementIgnoreIds().stream()
-					.map(mat -> mat.getKey().getKey())
+					.map(WorldMigrationAction::matName)
 					.collect(Collectors.toList()), change.key, change.value));
 		else
 			townyWorld.setPlotManagementIgnoreIds(splitMats(townyWorld.getPlotManagementIgnoreIds().stream().map(type -> type.getKey().toString()).collect(Collectors.joining(",")) + change.value));
@@ -21,7 +23,7 @@ public enum WorldMigrationAction {
 	UPDATE_WORLD_DELETE_MAYOR(((townyWorld, change) -> {
 		if (change.type == MigrationType.REPLACE)
 			townyWorld.setPlotManagementMayorDelete(replaceAll(townyWorld.getPlotManagementMayorDelete().stream()
-					.map(mat -> mat.getKey().getKey())
+					.map(WorldMigrationAction::matName)
 					.collect(Collectors.toList()), change.key, change.value));
 		else
 			townyWorld.setPlotManagementMayorDelete(splitMats(townyWorld.getPlotManagementMayorDelete().stream().map(type -> type.getKey().toString()).collect(Collectors.joining(",")) + change.value));
@@ -29,7 +31,7 @@ public enum WorldMigrationAction {
 	UPDATE_WORLD_UNCLAIM_DELETE(((townyWorld, change) -> {
 		if (change.type == MigrationType.REPLACE)
 			townyWorld.setPlotManagementDeleteIds(replaceAll(townyWorld.getPlotManagementDeleteIds().stream()
-					.map(mat -> mat.getKey().getKey())
+					.map(WorldMigrationAction::matName)
 					.collect(Collectors.toList()), change.key, change.value));
 		else
 			townyWorld.setPlotManagementDeleteIds(splitMats(townyWorld.getPlotManagementDeleteIds().stream().map(type -> type.getKey().toString()).collect(Collectors.joining(",")) + change.value));
@@ -37,7 +39,7 @@ public enum WorldMigrationAction {
 	UPDATE_WILDERNESS_IGNORE_MATS(((townyWorld, change) -> {
 		if (change.type == MigrationType.REPLACE)
 			townyWorld.setUnclaimedZoneIgnore(replaceAll(townyWorld.getUnclaimedZoneIgnoreMaterials().stream()
-					.map(mat -> mat.getKey().getKey())
+					.map(WorldMigrationAction::matName)
 					.collect(Collectors.toList()), change.key, change.value));
 		else
 			townyWorld.setUnclaimedZoneIgnore(splitMats(townyWorld.getUnclaimedZoneIgnoreMaterials().stream().map(type -> type.getKey().toString()).collect(Collectors.joining(",")) + change.value));
@@ -45,7 +47,7 @@ public enum WorldMigrationAction {
 	UPDATE_WORLD_EXPLOSION_REVERT_BLOCKS(((townyWorld, change) -> {
 		if (change.type == MigrationType.REPLACE)
 			townyWorld.setPlotManagementWildRevertMaterials(replaceAll(townyWorld.getPlotManagementWildRevertBlocks().stream()
-					.map(mat -> mat.getKey().getKey())
+					.map(WorldMigrationAction::matName)
 					.collect(Collectors.toList()), change.key, change.value));
 		else
 			townyWorld.setPlotManagementWildRevertMaterials(splitMats(townyWorld.getPlotManagementWildRevertBlocks().stream().map(type -> type.getKey().toString()).collect(Collectors.joining(",")) + change.value));
@@ -53,7 +55,7 @@ public enum WorldMigrationAction {
 	UPDATE_WORLD_EXPLOSION_REVERT_ENTITIES(((townyWorld, change) -> {
 		if (change.type == MigrationType.REPLACE)
 			townyWorld.setPlotManagementWildRevertEntities(replaceAll(townyWorld.getPlotManagementWildRevertEntities().stream()
-					.map(type -> type.getKey().getKey())
+					.map(WorldMigrationAction::entityName)
 					.collect(Collectors.toList()), change.key, change.value));
 		else
 			townyWorld.setPlotManagementWildRevertEntities(splitMats(townyWorld.getPlotManagementWildRevertEntities().stream().map(type -> type.getKey().toString()).collect(Collectors.joining(",")) + change.value));
@@ -61,7 +63,7 @@ public enum WorldMigrationAction {
 	UPDATE_WORLD_UNCLAIM_REVERT_ENTITIES((((townyWorld, change) -> {
 		if (change.type == MigrationType.REPLACE)
 			townyWorld.setUnclaimDeleteEntityTypes(replaceAll(townyWorld.getUnclaimDeleteEntityTypes().stream()
-				.map(type -> type.getKey().getKey())
+				.map(WorldMigrationAction::entityName)
 				.collect(Collectors.toList()), change.key, change.value));
 		else
 			townyWorld.setUnclaimDeleteEntityTypes(splitMats(townyWorld.getUnclaimDeleteEntityTypes().stream().map(type -> type.getKey().toString()).collect(Collectors.joining(",")) + change.value));
@@ -91,5 +93,13 @@ public enum WorldMigrationAction {
 		}
 
 		return toReplace;
+	}
+	
+	private static String matName(Material material) {
+		return material.getKey().getKey(); // Material.DIRT -> minecraft:dirt -> dirt
+	}
+	
+	private static String entityName(EntityType entity) {
+		return entity.getKey().getKey();
 	}
 }

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -2275,7 +2275,7 @@ public class TownySettings {
 	}
 
 	public static Collection<Material> getRevertOnUnclaimWhitelistMaterials() {
-		return toMaterialEnumSet(getStrArr(ConfigNodes.NWS_PLOT_MANAGEMENT_REVERT_WHITELIST));
+		return toMaterialSet(getStrArr(ConfigNodes.NWS_PLOT_MANAGEMENT_REVERT_WHITELIST));
 	}
 
 	public static boolean isTownRespawning() {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -382,7 +382,7 @@ public class TownySettings {
 			if (ItemLists.GROUPS.contains(matName)) {
 				switchUseMaterials.addAll(ItemLists.getGrouping(matName));
 			} else {
-				Material material = Material.matchMaterial(matName);
+				Material material = BukkitTools.matchRegistry(Registry.MATERIAL, matName);
 				if (material != null)
 					switchUseMaterials.add(material);
 			}
@@ -398,7 +398,7 @@ public class TownySettings {
 			if (ItemLists.GROUPS.contains(matName)) {
 				itemUseMaterials.addAll(ItemLists.getGrouping(matName));
 			} else {
-				Material material = Material.matchMaterial(matName);
+				Material material = BukkitTools.matchRegistry(Registry.MATERIAL, matName);
 				if (material != null)
 					itemUseMaterials.add(material);
 			}
@@ -427,7 +427,7 @@ public class TownySettings {
 			if (ItemLists.GROUPS.contains(materialName.toUpperCase(Locale.ROOT))) {
 				materials.addAll(ItemLists.getGrouping(materialName.toUpperCase(Locale.ROOT)));
 			} else {
-				Material material = Material.matchMaterial(materialName.toUpperCase(Locale.ROOT));
+				Material material = BukkitTools.matchRegistry(Registry.MATERIAL, materialName);
 				if (material != null)
 					materials.add(material);
 			}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -33,6 +33,7 @@ import com.palmergames.util.TimeTools;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
 import org.bukkit.entity.EntityType;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -41,8 +42,8 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -98,8 +99,8 @@ public class TownySettings {
 	private static final SortedMap<Integer, TownLevel> configTownLevel = Collections.synchronizedSortedMap(new TreeMap<>(Collections.reverseOrder()));
 	private static final SortedMap<Integer, NationLevel> configNationLevel = Collections.synchronizedSortedMap(new TreeMap<>(Collections.reverseOrder()));
 	
-	private static final EnumSet<Material> itemUseMaterials = EnumSet.noneOf(Material.class);
-	private static final EnumSet<Material> switchUseMaterials = EnumSet.noneOf(Material.class);
+	private static final Set<Material> itemUseMaterials = new HashSet<>();
+	private static final Set<Material> switchUseMaterials = new HashSet<>();
 	private static final List<Class<?>> protectedMobs = new ArrayList<>();
 	
 	private static final Map<NamespacedKey, Consumer<CommentedConfiguration>> CONFIG_RELOAD_LISTENERS = new HashMap<>();
@@ -404,20 +405,27 @@ public class TownySettings {
 		}
 	}
 
-	public static EnumSet<EntityType> toEntityTypeEnumSet(List<String> entityList) {
-		EnumSet<EntityType> entities = EnumSet.noneOf(EntityType.class);
+	public static Set<EntityType> toEntityTypeSet(List<String> entityList) {
+		Set<EntityType> entities = new HashSet<>();
+		
 		for (String entityName : entityList) {
 			try {
-				entities.add(EntityType.valueOf(entityName.toUpperCase(Locale.ROOT)));
+				EntityType type = Registry.ENTITY_TYPE.match(entityName);
+				if (type != null)
+					entities.add(type);
 			} catch (IllegalArgumentException ignored) {}
 		}
 
 		return entities;
 	}
 
-	public static EnumSet<Material> toMaterialEnumSet(List<String> materialList) {
-		EnumSet<Material> materials = EnumSet.noneOf(Material.class);
+	public static Collection<Material> toMaterialSet(List<String> materialList) {
+		Set<Material> materials = new HashSet<>();
+		
 		for (String materialName : materialList) {
+			if (materialName.isEmpty())
+				continue;
+			
 			if (ItemLists.GROUPS.contains(materialName.toUpperCase(Locale.ROOT))) {
 				materials.addAll(ItemLists.getGrouping(materialName.toUpperCase(Locale.ROOT)));
 			} else {
@@ -505,11 +513,11 @@ public class TownySettings {
 
 		String[] strArray = getString(node.getRoot().toLowerCase(Locale.ROOT), node.getDefault()).split(",");
 		List<String> list = new ArrayList<>();
-		if (strArray.length > 0) {
-			for (String aStrArray : strArray)
-				if (aStrArray != null)
-					list.add(aStrArray.trim());
-		}
+		
+		for (String string : strArray)
+			if (string != null && !string.isEmpty())
+				list.add(string.trim());
+		
 		return list;
 	}
 
@@ -1605,9 +1613,9 @@ public class TownySettings {
 		return getFireSpreadBypassMaterials().contains(mat);
 	}
 	
-	public static EnumSet<Material> getUnclaimedZoneIgnoreMaterials() {
+	public static Collection<Material> getUnclaimedZoneIgnoreMaterials() {
 
-		return toMaterialEnumSet(getStrArr(ConfigNodes.UNCLAIMED_ZONE_IGNORE));
+		return toMaterialSet(getStrArr(ConfigNodes.UNCLAIMED_ZONE_IGNORE));
 	}
 	
 	public static List<Class<?>> getProtectedEntityTypes() {
@@ -2223,9 +2231,9 @@ public class TownySettings {
 		return getBoolean(ConfigNodes.NWS_PLOT_MANAGEMENT_DELETE_ENABLE);
 	}
 
-	public static EnumSet<Material> getPlotManagementDeleteIds() {
+	public static Collection<Material> getPlotManagementDeleteIds() {
 
-		return toMaterialEnumSet(getStrArr(ConfigNodes.NWS_PLOT_MANAGEMENT_DELETE));
+		return toMaterialSet(getStrArr(ConfigNodes.NWS_PLOT_MANAGEMENT_DELETE));
 	}
 
 	public static boolean isUsingPlotManagementMayorDelete() {
@@ -2233,9 +2241,9 @@ public class TownySettings {
 		return getBoolean(ConfigNodes.NWS_PLOT_MANAGEMENT_MAYOR_DELETE_ENABLE);
 	}
 
-	public static EnumSet<Material> getPlotManagementMayorDelete() {
+	public static Collection<Material> getPlotManagementMayorDelete() {
 
-		return toMaterialEnumSet(getStrArr(ConfigNodes.NWS_PLOT_MANAGEMENT_MAYOR_DELETE));
+		return toMaterialSet(getStrArr(ConfigNodes.NWS_PLOT_MANAGEMENT_MAYOR_DELETE));
 	}
 
 	public static boolean isUsingPlotManagementRevert() {
@@ -2263,9 +2271,9 @@ public class TownySettings {
 		return getBoolean(ConfigNodes.NWS_PLOT_MANAGEMENT_WILD_BLOCK_REVERT_ENABLE);
 	}
 
-	public static EnumSet<Material> getPlotManagementIgnoreIds() {
+	public static Collection<Material> getPlotManagementIgnoreIds() {
 
-		return toMaterialEnumSet(getStrArr(ConfigNodes.NWS_PLOT_MANAGEMENT_REVERT_IGNORE));
+		return toMaterialSet(getStrArr(ConfigNodes.NWS_PLOT_MANAGEMENT_REVERT_IGNORE));
 	}
 
 	public static Collection<Material> getRevertOnUnclaimWhitelistMaterials() {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -409,11 +409,9 @@ public class TownySettings {
 		Set<EntityType> entities = new HashSet<>();
 		
 		for (String entityName : entityList) {
-			try {
-				EntityType type = Registry.ENTITY_TYPE.match(entityName);
-				if (type != null)
-					entities.add(type);
-			} catch (IllegalArgumentException ignored) {}
+			EntityType type = Registry.ENTITY_TYPE.match(entityName);
+			if (type != null)
+				entities.add(type);
 		}
 
 		return entities;

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -409,7 +409,7 @@ public class TownySettings {
 		Set<EntityType> entities = new HashSet<>();
 		
 		for (String entityName : entityList) {
-			EntityType type = Registry.ENTITY_TYPE.match(entityName);
+			EntityType type = BukkitTools.matchRegistry(Registry.ENTITY_TYPE, entityName);
 			if (type != null)
 				entities.add(type);
 		}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/PlotCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/PlotCommand.java
@@ -75,7 +75,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/PlotCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/PlotCommand.java
@@ -404,7 +404,7 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 
 		BukkitTools.ifCancelledThenThrow(new PlotPreClearEvent(townBlock));
 
-		Set<Material> materialsToDelete = townBlock.getWorld().getPlotManagementMayorDelete();
+		Collection<Material> materialsToDelete = townBlock.getWorld().getPlotManagementMayorDelete();
 		if (materialsToDelete.isEmpty())
 			return;
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownyWorldCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownyWorldCommand.java
@@ -425,12 +425,7 @@ public class TownyWorldCommand extends BaseCommand implements CommandExecutor {
 					TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_invalid_input", "/townyworld set wildignore OAK_SAPLING GOLD_ORE IRON_ORE"));
 				else
 					try {
-						List<String> mats = new ArrayList<>();
-						for (String s : StringMgmt.remFirstArg(split)) {
-							String matName = BukkitTools.matchMaterialName(s);
-							if (matName != null)
-								mats.add(matName);
-						}
+						List<String> mats = Arrays.asList(StringMgmt.remFirstArg(split));
 						globalWorld.setUnclaimedZoneIgnore(mats);
 
 						plugin.resetCache();

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/event/executors/TownyActionEventExecutor.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/event/executors/TownyActionEventExecutor.java
@@ -3,6 +3,7 @@ package com.palmergames.bukkit.towny.event.executors;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 
 import com.palmergames.bukkit.towny.event.damage.TownBlockExplosionTestEvent;
 import com.palmergames.bukkit.towny.object.TownBlock;
@@ -187,7 +188,7 @@ public class TownyActionEventExecutor {
 		if (isNotCampfire(block))
 			block = block.getRelative(BlockFace.DOWN);
 		
-		return !TownySettings.isFireSpreadBypassMaterial(block.getType().name());
+		return !TownySettings.isFireSpreadBypassMaterial(block.getType().getKey().getKey().toUpperCase(Locale.ROOT)); // TODO proper key
 	}
 	
 	/**

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/event/executors/TownyActionEventExecutor.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/event/executors/TownyActionEventExecutor.java
@@ -184,7 +184,7 @@ public class TownyActionEventExecutor {
 	}
 	
 	private static boolean isNotFireSpreadBypassMat(Block block) {
-		if (ItemLists.CAMPFIRES.contains(block.getType()))
+		if (isNotCampfire(block))
 			block = block.getRelative(BlockFace.DOWN);
 		
 		return !TownySettings.isFireSpreadBypassMaterial(block.getType().name());

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/event/executors/TownyActionEventExecutor.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/event/executors/TownyActionEventExecutor.java
@@ -184,12 +184,9 @@ public class TownyActionEventExecutor {
 	}
 	
 	private static boolean isNotFireSpreadBypassMat(Block block) {
-		switch (block.getType()) {
-			case CAMPFIRE:
-				break;
-			default:
-				block = block.getRelative(BlockFace.DOWN);
-		}
+		if (ItemLists.CAMPFIRES.contains(block.getType()))
+			block = block.getRelative(BlockFace.DOWN);
+		
 		return !TownySettings.isFireSpreadBypassMaterial(block.getType().name());
 	}
 	

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
@@ -395,8 +395,8 @@ public class TownyBlockListener implements Listener {
 	 */
 	@EventHandler(ignoreCancelled = true)
 	public void onSculkSpread(BlockSpreadEvent event) {
-		String sourceName = event.getSource().getType().name();
-		if (!sourceName.startsWith("SCULK"))
+		String sourceName = event.getSource().getType().getKey().getKey();
+		if (!sourceName.startsWith("sculk"))
 			return;
 
 		if (plugin.isError()) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
@@ -21,6 +21,7 @@ import com.palmergames.bukkit.util.ItemLists;
 
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Creature;
@@ -61,7 +62,6 @@ import org.bukkit.event.hanging.HangingBreakEvent;
 import org.bukkit.event.hanging.HangingBreakEvent.RemoveCause;
 import org.bukkit.event.hanging.HangingPlaceEvent;
 import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionEffectType;
 import org.bukkit.projectiles.BlockProjectileSource;
 
 import java.util.ArrayList;
@@ -159,7 +159,7 @@ public class TownyEntityListener implements Listener {
 	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
 	public void onAxolotlTarget(EntityTargetLivingEntityEvent event) {
 		if (event.getEntity() instanceof Mob attacker &&
-			attacker.getType().name().equals("AXOLOTL") &&
+			attacker.getType().getKey().equals(NamespacedKey.minecraft("axolotl")) &&
 			event.getTarget() instanceof Mob defender &&
 			CombatUtil.preventDamageCall(attacker, defender, DamageCause.ENTITY_ATTACK)) {
 			attacker.setMemory(MemoryKey.HAS_HUNTING_COOLDOWN, true);
@@ -226,7 +226,7 @@ public class TownyEntityListener implements Listener {
 		if (!TownyAPI.getInstance().isTownyWorld(event.getEntity().getWorld()))
 			return;
 		
-		if (!event.getEntity().getCustomEffects().stream().anyMatch(effect -> effect.getType().equals(PotionEffectType.HARM)))
+		if (event.getEntity().getCustomEffects().stream().noneMatch(effect -> effect.getType().getKey().equals(NamespacedKey.minecraft("instant_damage"))))
 			return;
 
 		if (!(event.getEntity().getSource() instanceof Player) || !(event.getEntity().getSource() instanceof DragonFireball))

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
@@ -16,6 +16,7 @@ import com.palmergames.bukkit.towny.utils.BorderUtil;
 import com.palmergames.bukkit.towny.utils.CombatUtil;
 import com.palmergames.bukkit.towny.utils.EntityTypeUtil;
 import com.palmergames.bukkit.util.BukkitTools;
+import com.palmergames.bukkit.util.EntityLists;
 import com.palmergames.bukkit.util.ItemLists;
 
 import org.bukkit.Location;
@@ -524,51 +525,39 @@ public class TownyEntityListener implements Listener {
 			}
 		}
 
-		switch (event.getEntity().getType()) {
-			case ENDERMAN -> {
-				if (townyWorld.isEndermanProtect())
-					event.setCancelled(true);
-			}
-
+		final EntityType type = event.getEntityType();
+		
+		if (type == EntityType.ENDERMAN) {
+			if (townyWorld.isEndermanProtect())
+				event.setCancelled(true);
+		} else if (EntityLists.BOATS.contains(type)) {
 			/* Protect lily pads. */
-			case BOAT, CHEST_BOAT -> {
-				if (!event.getBlock().getType().equals(Material.LILY_PAD))
-					return;
-				
-				final List<Entity> passengers = event.getEntity().getPassengers();
-				
-				if (!passengers.isEmpty() && passengers.get(0) instanceof Player player)
-					// Test if the player can break here.
-					event.setCancelled(!TownyActionEventExecutor.canDestroy(player, event.getBlock()));
-				else if (!TownyAPI.getInstance().isWilderness(event.getBlock()))
-					// Protect townland from non-player-ridden boats. (Maybe someone is pushing a boat?)
-					event.setCancelled(true);
-			}
+			if (!event.getBlock().getType().equals(Material.LILY_PAD))
+				return;
 
-			case RAVAGER -> {
-				if (townyWorld.isDisableCreatureTrample())
-					event.setCancelled(true);
-			}
+			final List<Entity> passengers = event.getEntity().getPassengers();
 
-			case WITHER -> {
-				List<Block> allowed = TownyActionEventExecutor.filterExplodableBlocks(Collections.singletonList(event.getBlock()), event.getBlock().getType(), event.getEntity(), event);
-				event.setCancelled(allowed.isEmpty());
-			}
+			if (!passengers.isEmpty() && passengers.get(0) instanceof Player player)
+				// Test if the player can break here.
+				event.setCancelled(!TownyActionEventExecutor.canDestroy(player, event.getBlock()));
+			else if (!TownyAPI.getInstance().isWilderness(event.getBlock()))
+				// Protect townland from non-player-ridden boats. (Maybe someone is pushing a boat?)
+				event.setCancelled(true);
+		} else if (type == EntityType.RAVAGER) {
+			if (townyWorld.isDisableCreatureTrample())
+				event.setCancelled(true);
+		} else if (type == EntityType.WITHER) {
+			List<Block> allowed = TownyActionEventExecutor.filterExplodableBlocks(Collections.singletonList(event.getBlock()), event.getBlock().getType(), event.getEntity(), event);
+			event.setCancelled(allowed.isEmpty());
+		} else if (event.getEntity() instanceof ThrownPotion potion) {
+			// Check that the affected block is a campfire and that a water bottle (no effects) was used.
+			if (event.getBlock().getType() != Material.CAMPFIRE || !potion.getEffects().isEmpty())
+				return;
 
-			/* Protect campfires from SplashWaterBottles. Uses a destroy test. */
-			case SPLASH_POTION -> {
-				final ThrownPotion potion = (ThrownPotion) event.getEntity();
-				// Check that the affected block is a campfire and that a water bottle (no effects) was used.
-				if (event.getBlock().getType() != Material.CAMPFIRE || !potion.getEffects().isEmpty())
-					return;
-				
-				if (potion.getShooter() instanceof BlockProjectileSource bps)
-					event.setCancelled(!BorderUtil.allowedMove(bps.getBlock(), event.getBlock()));
-				else if (potion.getShooter() instanceof Player player)
-					event.setCancelled(!TownyActionEventExecutor.canDestroy(player, event.getBlock().getLocation(), Material.CAMPFIRE));
-			}
-			
-			default -> {}
+			if (potion.getShooter() instanceof BlockProjectileSource bps)
+				event.setCancelled(!BorderUtil.allowedMove(bps.getBlock(), event.getBlock()));
+			else if (potion.getShooter() instanceof Player player)
+				event.setCancelled(!TownyActionEventExecutor.canDestroy(player, event.getBlock().getLocation(), Material.CAMPFIRE));
 		}
 	}
 
@@ -714,13 +703,13 @@ public class TownyEntityListener implements Listener {
 
 	private boolean attachedToRegeneratingBlock(Entity hanging) {
 		// Prevent an item_frame or painting from breaking if it is attached to something which will be regenerated.
-		return ItemLists.HANGING_ENTITIES.contains(hanging.getType().name()) && 
+		return EntityLists.HANGING.contains(hanging) && 
 			TownyRegenAPI.hasProtectionRegenTask(new BlockLocation(hanging.getLocation().add(hanging.getFacing().getOppositeFace().getDirection())));
 	}
 
 	private boolean itemFrameBrokenByBoatExploit(Entity hanging) {
 		// This workaround prevent boats from destroying item_frames, detailed in https://hub.spigotmc.org/jira/browse/SPIGOT-3999.
-		if (ItemLists.ITEM_FRAMES.contains(hanging.getType().name())) {
+		if (EntityLists.ITEM_FRAMES.contains(hanging)) {
 			Block block = hanging.getLocation().add(hanging.getFacing().getOppositeFace().getDirection()).getBlock();
 			if (block.isLiquid() || block.isEmpty())
 				return false;

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyInventoryListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyInventoryListener.java
@@ -52,32 +52,31 @@ public class TownyInventoryListener implements Listener {
 		if (event.getInventory().getHolder() instanceof EditGUI editGUI) {
 			
 			ItemMeta meta = event.getCurrentItem().getItemMeta();
-			switch (event.getCurrentItem().getType()) {
-				case LIME_WOOL:
-					if (meta.getDisplayName().equals(Colors.LightGreen + ChatColor.BOLD + "Save")) {
-						editGUI.saveChanges();
-					} else {
-						meta.setDisplayName(Colors.Red + ChatColor.BOLD + Colors.strip(meta.getDisplayName()));
-						event.getCurrentItem().setType(Material.RED_WOOL);
-					}
-					break;
-				case RED_WOOL:
-					if (meta.getDisplayName().equals(Colors.Red + ChatColor.BOLD + "Back")) {
-						editGUI.exitScreen();
-					} else if (meta.getDisplayName().equals(Colors.Red + ChatColor.BOLD + "Delete")) {
-						editGUI.deleteResident();
-					} else {
-						meta.setDisplayName(Colors.Gray + ChatColor.BOLD + Colors.strip(meta.getDisplayName()));
-						event.getCurrentItem().setType(Material.GRAY_WOOL);
-					}
-					break;
-				case GRAY_WOOL:
-					meta.setDisplayName(Colors.LightGreen + ChatColor.BOLD + Colors.strip(meta.getDisplayName()));
-					event.getCurrentItem().setType(Material.LIME_WOOL);
-					break;
-				default:
-					return;
-			}
+			if (meta == null)
+				return;
+			
+			Material type = event.getCurrentItem().getType();
+			if (type == Material.LIME_WOOL) {
+				if (meta.getDisplayName().equals(Colors.LightGreen + ChatColor.BOLD + "Save")) {
+					editGUI.saveChanges();
+				} else {
+					meta.setDisplayName(Colors.Red + ChatColor.BOLD + Colors.strip(meta.getDisplayName()));
+					event.getCurrentItem().setType(Material.RED_WOOL);
+				}
+			} else if (type == Material.RED_WOOL) {
+				if (meta.getDisplayName().equals(Colors.Red + ChatColor.BOLD + "Back")) {
+					editGUI.exitScreen();
+				} else if (meta.getDisplayName().equals(Colors.Red + ChatColor.BOLD + "Delete")) {
+					editGUI.deleteResident();
+				} else {
+					meta.setDisplayName(Colors.Gray + ChatColor.BOLD + Colors.strip(meta.getDisplayName()));
+					event.getCurrentItem().setType(Material.GRAY_WOOL);
+				}
+			} else if (type == Material.GRAY_WOOL) {
+				meta.setDisplayName(Colors.LightGreen + ChatColor.BOLD + Colors.strip(meta.getDisplayName()));
+				event.getCurrentItem().setType(Material.LIME_WOOL);
+			} else 
+				return;
 			
 			event.getCurrentItem().setItemMeta(meta);			
 			editGUI.playClickSound(player);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -430,7 +430,7 @@ public class TownyPlayerListener implements Listener {
 				/*
 				 * Catches hoes taking dirt from Rooted Dirt blocks.
 				 */
-				if (clickedMat.name().equals("ROOTED_DIRT") && item.name().toLowerCase().contains("_hoe"))
+				if (clickedMat.getKey().equals(NamespacedKey.minecraft("rooted_dirt")) && ItemLists.HOES.contains(item))
 					event.setCancelled(!TownyActionEventExecutor.canDestroy(player, clickedBlock));
 
 				/*
@@ -474,8 +474,8 @@ public class TownyPlayerListener implements Listener {
 				ItemLists.HARVESTABLE_BERRIES.contains(clickedMat) ||
 				ItemLists.REDSTONE_INTERACTABLES.contains(clickedMat) ||
 				ItemLists.CANDLES.contains(clickedMat) ||
-				clickedMat.name().equals("TURTLE_EGG") ||
-				clickedMat.name().equals("CHISELED_BOOKSHELF") ||
+				clickedMat.getKey().equals(NamespacedKey.minecraft("turtle_egg")) ||
+				clickedMat.getKey().equals(NamespacedKey.minecraft("chiseled_bookshelf")) ||
 				clickedMat == Material.BEACON || clickedMat == Material.DRAGON_EGG || 
 				clickedMat == Material.COMMAND_BLOCK){
 				
@@ -1308,7 +1308,7 @@ public class TownyPlayerListener implements Listener {
 			return;
 		
 		if (event.hasItem()
-				&& event.getPlayer().getInventory().getItemInMainHand().getType().name().equalsIgnoreCase(TownySettings.getTool()) 
+				&& event.getPlayer().getInventory().getItemInMainHand().getType().getKey().getKey().equalsIgnoreCase(TownySettings.getTool()) 
 				&& plugin.hasPlayerMode(event.getPlayer(), "infotool")
 				&& TownyUniverse.getInstance().getPermissionSource().isTownyAdmin(event.getPlayer())
 				&& event.getClickedBlock() != null) {
@@ -1327,7 +1327,7 @@ public class TownyPlayerListener implements Listener {
 						org.bukkit.block.data.type.Door door = (org.bukkit.block.data.type.Door) block.getBlockData();
 						TownyMessaging.sendMessage(player, Arrays.asList(
 								ChatTools.formatTitle("Door Info"),
-								ChatTools.formatCommand("", "Door Type", "", block.getType().name()),
+								ChatTools.formatCommand("", "Door Type", "", block.getType().getKey().toString()),
 								ChatTools.formatCommand("", "hinged on ", "", String.valueOf(door.getHinge())),
 								ChatTools.formatCommand("", "isOpen", "", String.valueOf(door.isOpen())),
 								ChatTools.formatCommand("", "getFacing", "", door.getFacing().name())
@@ -1335,7 +1335,7 @@ public class TownyPlayerListener implements Listener {
 					} else {
 						TownyMessaging.sendMessage(player, Arrays.asList(
 								ChatTools.formatTitle("Block Info"),
-								ChatTools.formatCommand("", "Material", "", block.getType().name()),								      
+								ChatTools.formatCommand("", "Material", "", block.getType().getKey().toString()),								      
 								ChatTools.formatCommand("", "MaterialData", "", block.getBlockData().getAsString())
 								));
 					}
@@ -1358,7 +1358,7 @@ public class TownyPlayerListener implements Listener {
 			return;
 
 		if (event.getRightClicked() != null
-				&& event.getPlayer().getInventory().getItemInMainHand().getType().name().equalsIgnoreCase(TownySettings.getTool())
+				&& event.getPlayer().getInventory().getItemInMainHand().getType().getKey().getKey().equalsIgnoreCase(TownySettings.getTool())
 				&& plugin.hasPlayerMode(event.getPlayer(), "infotool")
 				&& TownyUniverse.getInstance().getPermissionSource().isTownyAdmin(event.getPlayer())) {
 
@@ -1367,7 +1367,7 @@ public class TownyPlayerListener implements Listener {
 				TownyMessaging.sendMessage(event.getPlayer(), Arrays.asList(
 						ChatTools.formatTitle("Entity Info"),
 						ChatTools.formatCommand("", "Entity Class", "", entity.getType().getEntityClass().getSimpleName()),
-						ChatTools.formatCommand("", "Entity Type", "", entity.getType().name() + " (" + entity.getType().getKey() + ")")
+						ChatTools.formatCommand("", "Entity Type", "", entity.getType().getKey().toString())
 						));
 
 				event.setCancelled(true);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -41,6 +41,7 @@ import com.palmergames.bukkit.towny.utils.MinecraftVersion;
 import com.palmergames.bukkit.towny.utils.ResidentUtil;
 import com.palmergames.bukkit.util.BukkitTools;
 import com.palmergames.bukkit.util.ChatTools;
+import com.palmergames.bukkit.util.EntityLists;
 import com.palmergames.bukkit.util.ItemLists;
 import com.palmergames.util.StringMgmt;
 
@@ -640,60 +641,21 @@ public class TownyPlayerListener implements Listener {
 			Player player = event.getPlayer();
 			Material mat = null;
 			ActionType actionType = ActionType.DESTROY;
+			EntityType entityType = event.getRightClicked().getType();
 			
 			// PlayerInventory#getItem(EquipmentSlot) does not exist on <1.16, so this has to be used
 			Material item = event.getHand().equals(EquipmentSlot.HAND) ? event.getPlayer().getInventory().getItemInMainHand().getType() : event.getPlayer().getInventory().getItemInOffHand().getType();
 
 			/*
 			 * The following will get us a Material substituted in for an Entity so that we can run permission tests.
-			 * Anything not in the switch will leave the block null.
 			 */
-			switch (event.getRightClicked().getType()) {
-				/*
-				 * First are tested with a Destroy perm check.
-				 */
-				case PUFFERFISH:
-				case TROPICAL_FISH:
-				case SALMON:
-				case COD:
-				case ITEM_FRAME:
-				case GLOW_ITEM_FRAME:
-				case PAINTING:
-				case LEASH_HITCH:
-				case MINECART_COMMAND:
-				case MINECART_TNT:
-				case MINECART_MOB_SPAWNER:
-				case TADPOLE:
-				case AXOLOTL:
-					mat = EntityTypeUtil.parseEntityToMaterial(event.getRightClicked().getType());
-					break;
-				/*
-				 * These two block the dying of sheep and wolf's collars.
-				 */
-				case SHEEP:
-				case WOLF:
-					if (item != null) {
-						if (ItemLists.DYES.contains(item)) {
-							mat = item;
-							break;
-						}
-					}	
-				/*
-				 * Afterwards they will remain as Switch perm checks.
-				 */
-				case MINECART_CHEST:
-				case MINECART_FURNACE:
-				case MINECART_HOPPER:
-				case CHEST_BOAT:
-					mat = EntityTypeUtil.parseEntityToMaterial(event.getRightClicked().getType());
-					actionType = ActionType.SWITCH;
-					break;
-				/*
-				 * Don't set {@code mat} for other entity types.
-				 */
-				default:
-				    break;
-			}
+			if (EntityLists.SWITCH_PROTECTED.contains(entityType)) {
+				mat = EntityTypeUtil.parseEntityToMaterial(entityType);
+				actionType = ActionType.SWITCH;
+			} else if (EntityLists.DYEABLE.contains(entityType) && ItemLists.DYES.contains(item))
+				mat = item;
+			else if (EntityLists.RIGHT_CLICK_PROTECTED.contains(entityType))
+				mat = EntityTypeUtil.parseEntityToMaterial(entityType);
 
 			/*
 			 * A material has been substitued correctly in place of one of the above EntityTypes.

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyVehicleListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyVehicleListener.java
@@ -1,8 +1,10 @@
 package com.palmergames.bukkit.towny.listeners;
 
+import com.palmergames.bukkit.util.EntityLists;
 import org.bukkit.Material;
 import org.bukkit.entity.Boat;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Minecart;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -61,25 +63,13 @@ public class TownyVehicleListener implements Listener {
 		 * Note: Player-lit-TNT and Fireballs are considered Players by the API in this instance.
 		 */
 		if (event.getAttacker() instanceof Player player) {
+			final EntityType vehicleType = event.getVehicle().getType();
 			
 			/*
 			 * Substitute a Material for the Entity so we can run a destroy test against it.
-			 * Any entity not in the switch statement will leave vehicle null and no test will occur.
+			 * Any entity not in the vehicle entity list will leave vehicle null and no test will occur.
 			 */
-			Material vehicle = switch (event.getVehicle().getType()) {
-				case MINECART:
-				case MINECART_FURNACE:
-				case MINECART_HOPPER:
-				case MINECART_CHEST:
-				case MINECART_MOB_SPAWNER:
-				case MINECART_COMMAND:
-				case MINECART_TNT:
-				case BOAT:
-				case CHEST_BOAT:
-					yield EntityTypeUtil.parseEntityToMaterial(event.getVehicle().getType());
-				default:
-					yield null;
-			};
+			Material vehicle = EntityLists.VEHICLES.contains(vehicleType) ? EntityTypeUtil.parseEntityToMaterial(vehicleType) : null;
 
 			if (vehicle != null) {
 				//Make decision on whether this is allowed using the PlayerCache and then a cancellable event.
@@ -130,25 +120,18 @@ public class TownyVehicleListener implements Listener {
 			return;
 
 		if (event.getEntered() instanceof Player player) {
+			EntityType vehicleType = event.getVehicle().getType();
 
 			/*
 			 * Substitute a Material for the Entity so we can run a switch test against it.
-			 * Any entity not in the switch statement will leave vehicle null and no test will occur.
+			 * Any entity not in the entity lists will leave vehicle null and no test will occur.
 			 */
-			Material vehicle = switch (event.getVehicle().getType()) {
-				case MINECART:
-				case BOAT:
-				case CHEST_BOAT:
-					yield EntityTypeUtil.parseEntityToMaterial(event.getVehicle().getType());
-				case HORSE:
-				case STRIDER:
-				case PIG:
-				case DONKEY:
-				case MULE:
-					yield Material.SADDLE;
-				default:
-					yield null;
-			};
+			Material vehicle = null;
+			
+			if (EntityLists.VEHICLES.contains(vehicleType))
+				vehicle = EntityTypeUtil.parseEntityToMaterial(vehicleType);
+			else if (EntityLists.MOUNTABLE.contains(vehicleType))
+				vehicle = Material.SADDLE;
 
 			if (vehicle != null) {
 				//Make decision on whether this is allowed using the PlayerCache and then a cancellable event.

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownBlockData.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownBlockData.java
@@ -71,7 +71,7 @@ public class TownBlockData {
 		this.allowedBlocks.addAll(allowedBlocks);
 	}
 
-	// These bridge methods were added during 0.99.0.*
+	// These bridge methods were added during 0.99.2.*
 	@SuppressWarnings({"unused", "unchecked"})
 	private void setItemUseIds$$bridge$$public(EnumSet<?> itemUseIds) {
 		setItemUseIds((Collection<Material>) itemUseIds);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownBlockData.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownBlockData.java
@@ -72,19 +72,19 @@ public class TownBlockData {
 	}
 
 	// These bridge methods were added during 0.99.0.*
-	@SuppressWarnings("unused")
-	private void setItemUseIds$$bridge$$public(EnumSet<Material> itemUseIds) {
-		setItemUseIds(itemUseIds);
+	@SuppressWarnings({"unused", "unchecked"})
+	private void setItemUseIds$$bridge$$public(EnumSet<?> itemUseIds) {
+		setItemUseIds((Collection<Material>) itemUseIds);
 	}
 
-	@SuppressWarnings("unused")
-	private void setSwitchIds$$bridge$$public(EnumSet<Material> switchIds) {
-		setSwitchIds(switchIds);
+	@SuppressWarnings({"unused", "unchecked"})
+	private void setSwitchIds$$bridge$$public(EnumSet<?> switchIds) {
+		setSwitchIds((Collection<Material>) switchIds);
 	}
 
-	@SuppressWarnings("unused")
-	private void setAllowedBlocks$$bridge$$public(EnumSet<Material> allowedBlocks) {
-		setAllowedBlocks(allowedBlocks);
+	@SuppressWarnings({"unused", "unchecked"})
+	private void setAllowedBlocks$$bridge$$public(EnumSet<?> allowedBlocks) {
+		setAllowedBlocks((Collection<Material>) allowedBlocks);
 	}
 
 	public void setTax(double tax) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownBlockData.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownBlockData.java
@@ -5,16 +5,18 @@ import com.palmergames.bukkit.towny.TownySettings;
 
 import org.bukkit.Material;
 
+ import java.util.Collection;
  import java.util.EnumSet;
+ import java.util.HashSet;
  import java.util.Set;
 
 public class TownBlockData {
 	private String mapKey = "+";
 	private double cost = 0.0;
 	private double tax = 0.0;
-	private EnumSet<Material> itemUseIds = EnumSet.noneOf(Material.class); // List of item names that will trigger an item use test.
-	private EnumSet<Material> switchIds = EnumSet.noneOf(Material.class); // List of item names that will trigger a switch test.
-	private EnumSet<Material> allowedBlocks = EnumSet.noneOf(Material.class); // List of item names that will always be allowed.
+	private final Set<Material> itemUseIds = new HashSet<>(); // List of item names that will trigger an item use test.
+	private final Set<Material> switchIds = new HashSet<>(); // List of item names that will trigger a switch test.
+	private final Set<Material> allowedBlocks = new HashSet<>(); // List of item names that will always be allowed.
 	
 	public String getMapKey() {
 		return mapKey;
@@ -54,16 +56,35 @@ public class TownBlockData {
 		return allowedBlocks;
 	}
 	
-	public void setItemUseIds(EnumSet<Material> itemUseIds) {
-		this.itemUseIds = EnumSet.copyOf(itemUseIds);
+	public void setItemUseIds(Collection<Material> itemUseIds) {
+		this.itemUseIds.clear();
+		this.itemUseIds.addAll(itemUseIds);
 	}
 	
-	public void setSwitchIds(EnumSet<Material> switchIds) {
-		this.switchIds = EnumSet.copyOf(switchIds);
+	public void setSwitchIds(Collection<Material> switchIds) {
+		this.switchIds.clear();
+		this.switchIds.addAll(switchIds);
 	}
 	
-	public void setAllowedBlocks(EnumSet<Material> allowedBlocks) {
-		this.allowedBlocks = EnumSet.copyOf(allowedBlocks);
+	public void setAllowedBlocks(Collection<Material> allowedBlocks) {
+		this.allowedBlocks.clear();
+		this.allowedBlocks.addAll(allowedBlocks);
+	}
+
+	// These bridge methods were added during 0.99.0.*
+	@SuppressWarnings("unused")
+	private void setItemUseIds$$bridge$$public(EnumSet<Material> itemUseIds) {
+		setItemUseIds(itemUseIds);
+	}
+
+	@SuppressWarnings("unused")
+	private void setSwitchIds$$bridge$$public(EnumSet<Material> switchIds) {
+		setSwitchIds(switchIds);
+	}
+
+	@SuppressWarnings("unused")
+	private void setAllowedBlocks$$bridge$$public(EnumSet<Material> allowedBlocks) {
+		setAllowedBlocks(allowedBlocks);
 	}
 
 	public void setTax(double tax) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownBlockTypeHandler.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownBlockTypeHandler.java
@@ -19,7 +19,6 @@ import org.jetbrains.annotations.Nullable;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -37,15 +36,14 @@ public final class TownBlockTypeHandler {
 		for (Field field : TownBlockType.class.getFields()) {
 			try {
 				TownBlockType type = (TownBlockType) field.get(null);
-				newData.put(type.getName().toLowerCase(), type);
+				newData.put(type.getName().toLowerCase(Locale.ROOT), type);
 			} catch (Exception ignored) {}
 		}
 		
 		applyConfigSettings(newData);
 		
 		// Overwrite any entries of our own built-in townblocktypes.
-		for (Map.Entry<String, TownBlockType> entry : newData.entrySet())
-			townBlockTypeMap.put(entry.getKey(), entry.getValue());
+		townBlockTypeMap.putAll(newData);
 		
 		BukkitTools.fireEvent(new TownBlockTypeRegisterEvent());
 		
@@ -119,9 +117,9 @@ public final class TownBlockTypeHandler {
 				double tax = parseDouble(type.getOrDefault("tax", 0.0).toString());
 				String mapKey = String.valueOf(type.getOrDefault("mapKey", "+"));
 
-				EnumSet<Material> itemUseIds = loadMaterialList("itemUseIds", String.valueOf(type.getOrDefault("itemUseIds", "")), name);
-				EnumSet<Material> switchIds = loadMaterialList("switchIds", String.valueOf(type.getOrDefault("switchIds", "")), name);
-				EnumSet<Material> allowedBlocks = loadMaterialList("allowedBlocks", String.valueOf(type.getOrDefault("allowedBlocks", "")), name);
+				Set<Material> itemUseIds = loadMaterialList("itemUseIds", String.valueOf(type.getOrDefault("itemUseIds", "")), name);
+				Set<Material> switchIds = loadMaterialList("switchIds", String.valueOf(type.getOrDefault("switchIds", "")), name);
+				Set<Material> allowedBlocks = loadMaterialList("allowedBlocks", String.valueOf(type.getOrDefault("allowedBlocks", "")), name);
 				
 				TownBlockType townBlockType = newData.get(name.toLowerCase());
 				TownBlockData data;
@@ -147,9 +145,9 @@ public final class TownBlockTypeHandler {
 		}
 	}
 	
-	private static EnumSet<Material> loadMaterialList(String listName, String materialList, String typeName) {
+	private static Set<Material> loadMaterialList(String listName, String materialList, String typeName) {
 		if (!materialList.isEmpty()) {
-			EnumSet<Material> set = EnumSet.noneOf(Material.class);
+			Set<Material> set = new HashSet<>();
 			for (String materialName : materialList.split(",")) {
 				if (ItemLists.GROUPS.contains(materialName)) {
 					set.addAll(ItemLists.getGrouping(materialName));
@@ -163,7 +161,7 @@ public final class TownBlockTypeHandler {
 			
 			return set;
 		} else
-			return EnumSet.noneOf(Material.class);
+			return new HashSet<>();
 	}
 
 	@Nullable

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownBlockTypeHandler.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownBlockTypeHandler.java
@@ -13,6 +13,7 @@ import com.palmergames.bukkit.util.ItemLists;
 import com.palmergames.util.StringMgmt;
 
 import org.bukkit.Material;
+import org.bukkit.Registry;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -166,7 +167,7 @@ public final class TownBlockTypeHandler {
 
 	@Nullable
 	private static Material matchMaterial(String materialName, String listName, String typeName) {
-		Material material = Material.matchMaterial(materialName);
+		Material material = BukkitTools.matchRegistry(Registry.MATERIAL, materialName);
 		if (material == null)
 			TownyMessaging.sendDebugMsg(String.format("Could not find a material named '%s' while loading the " + listName + " list for the %s type.", materialName, typeName));
 		

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownyWorld.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownyWorld.java
@@ -446,8 +446,7 @@ public class TownyWorld extends TownyObject {
 	}
 
 	public void setPlotManagementDeleteIds(List<String> plotManagementDeleteIds) {
-		this.plotManagementDeleteIds.clear();
-		this.plotManagementDeleteIds.addAll(TownySettings.toMaterialSet(plotManagementDeleteIds));
+		this.plotManagementDeleteIds = new HashSet<>(TownySettings.toMaterialSet(plotManagementDeleteIds));
 	}
 
 	public Collection<Material> getPlotManagementMayorDelete() {
@@ -464,8 +463,7 @@ public class TownyWorld extends TownyObject {
 	}
 
 	public void setPlotManagementMayorDelete(List<String> plotManagementMayorDelete) {
-		this.plotManagementMayorDelete.clear();
-		this.plotManagementMayorDelete.addAll(TownySettings.toMaterialSet(plotManagementMayorDelete));
+		this.plotManagementMayorDelete = new HashSet<>(TownySettings.toMaterialSet(plotManagementMayorDelete));
 	}
 
 	public boolean isUnclaimedBlockAllowedToRevert(Material mat) {
@@ -489,8 +487,7 @@ public class TownyWorld extends TownyObject {
 	}
 
 	public void setPlotManagementIgnoreIds(List<String> plotManagementIgnoreIds) {
-		this.plotManagementIgnoreIds.clear();
-		this.plotManagementIgnoreIds.addAll(TownySettings.toMaterialSet(plotManagementIgnoreIds));
+		this.plotManagementIgnoreIds = new HashSet<>(TownySettings.toMaterialSet(plotManagementIgnoreIds));
 	}
 
 	public Collection<Material> getRevertOnUnclaimWhitelistMaterials() {
@@ -636,8 +633,7 @@ public class TownyWorld extends TownyObject {
 	}
 
 	public void setPlotManagementWildRevertMaterials(List<String> mats) {
-		blockExplosionProtection = new HashSet<>();
-		blockExplosionProtection.addAll(TownySettings.toMaterialSet(mats));
+		blockExplosionProtection = new HashSet<>(TownySettings.toMaterialSet(mats));
 	}
 
 	public Collection<Material> getPlotManagementWildRevertBlocks() {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownyWorld.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownyWorld.java
@@ -558,7 +558,7 @@ public class TownyWorld extends TownyObject {
 	public void setPlotManagementWildRevertEntities(List<String> entities) {
 		entityExplosionProtection = new HashSet<>();
 		
-		// If entities isn't empty and the first string isn't entirely uppercase, convert the legacy names to the entitytype enum names.
+		// If entities isn't empty and the first string isn't entirely uppercase, convert the legacy names to the entity's key.
 		if (entities.size() > 0 && !StringMgmt.isAllUpperCase(entities))
 			convertLegacyEntityNames(entities);
 		
@@ -570,7 +570,7 @@ public class TownyWorld extends TownyObject {
 			String entity = entities.get(i);
 			for (EntityType type : Registry.ENTITY_TYPE) {
 				if (type.getEntityClass() != null && type.getEntityClass().getSimpleName().equalsIgnoreCase(entity)) {
-					entities.set(i, type.name());
+					entities.set(i, type.getKey().toString());
 					break;
 				}					
 			}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownyWorld.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownyWorld.java
@@ -13,6 +13,7 @@ import com.palmergames.util.StringMgmt;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.Registry;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
@@ -22,7 +23,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -36,27 +36,27 @@ public class TownyWorld extends TownyObject {
 	private HashMap<String, Town> towns = new HashMap<>();
 
 	private boolean isDeletingEntitiesOnUnclaim = TownySettings.isDeletingEntitiesOnUnclaim();
-	private EnumSet<EntityType> unclaimDeleteEntityTypes = null;
+	private Set<EntityType> unclaimDeleteEntityTypes = null;
 	
 	private boolean isUsingPlotManagementDelete = TownySettings.isUsingPlotManagementDelete();
-	private EnumSet<Material> plotManagementDeleteIds = null;
+	private Set<Material> plotManagementDeleteIds = null;
 	
 	private boolean isUsingPlotManagementMayorDelete = TownySettings.isUsingPlotManagementMayorDelete();
-	private EnumSet<Material> plotManagementMayorDelete = null;
+	private Set<Material> plotManagementMayorDelete = null;
 	
 	private boolean isUsingPlotManagementRevert = TownySettings.isUsingPlotManagementRevert();
-	private EnumSet<Material> plotManagementIgnoreIds = null;
+	private Set<Material> plotManagementIgnoreIds = null;
 	private Set<Material> revertOnUnclaimWhitelistMaterials = null;
 
 	private boolean isUsingPlotManagementWildEntityRevert = TownySettings.isUsingPlotManagementWildEntityRegen();	
 	private long plotManagementWildRevertDelay = TownySettings.getPlotManagementWildRegenDelay();
-	private EnumSet<EntityType> entityExplosionProtection = null;
-	private EnumSet<Material> plotManagementWildRevertBlockWhitelist = null;
+	private Set<EntityType> entityExplosionProtection = null;
+	private Set<Material> plotManagementWildRevertBlockWhitelist = null;
 	
 	private boolean isUsingPlotManagementWildBlockRevert = TownySettings.isUsingPlotManagementWildBlockRegen();
-	private EnumSet<Material> blockExplosionProtection = null;
+	private Set<Material> blockExplosionProtection = null;
 	
-	private EnumSet<Material> unclaimedZoneIgnoreBlockMaterials = null;
+	private Set<Material> unclaimedZoneIgnoreBlockMaterials = null;
 	private Boolean unclaimedZoneBuild = null, unclaimedZoneDestroy = null,
 			unclaimedZoneSwitch = null, unclaimedZoneItemUse = null;
 
@@ -401,7 +401,7 @@ public class TownyWorld extends TownyObject {
 		return isDeletingEntitiesOnUnclaim;
 	}
 
-	public EnumSet<EntityType> getUnclaimDeleteEntityTypes() {
+	public Collection<EntityType> getUnclaimDeleteEntityTypes() {
 		if (unclaimDeleteEntityTypes == null)
 			setUnclaimDeleteEntityTypes(TownySettings.getUnclaimDeleteEntityTypes());
 
@@ -409,7 +409,7 @@ public class TownyWorld extends TownyObject {
 	}
 
 	public void setUnclaimDeleteEntityTypes(List<String> entityTypes) {
-		this.unclaimDeleteEntityTypes = TownySettings.toEntityTypeEnumSet(entityTypes);
+		this.unclaimDeleteEntityTypes = TownySettings.toEntityTypeSet(entityTypes);
 	}
 
 	public void setUsingPlotManagementMayorDelete(boolean using) {
@@ -432,7 +432,7 @@ public class TownyWorld extends TownyObject {
 		return isUsingPlotManagementRevert;
 	}
 
-	public EnumSet<Material> getPlotManagementDeleteIds() {
+	public Collection<Material> getPlotManagementDeleteIds() {
 
 		if (plotManagementDeleteIds == null)
 			return TownySettings.getPlotManagementDeleteIds();
@@ -446,11 +446,11 @@ public class TownyWorld extends TownyObject {
 	}
 
 	public void setPlotManagementDeleteIds(List<String> plotManagementDeleteIds) {
-
-		this.plotManagementDeleteIds = TownySettings.toMaterialEnumSet(plotManagementDeleteIds);
+		this.plotManagementDeleteIds.clear();
+		this.plotManagementDeleteIds.addAll(TownySettings.toMaterialSet(plotManagementDeleteIds));
 	}
 
-	public EnumSet<Material> getPlotManagementMayorDelete() {
+	public Collection<Material> getPlotManagementMayorDelete() {
 
 		if (plotManagementMayorDelete == null)
 			return TownySettings.getPlotManagementMayorDelete();
@@ -464,8 +464,8 @@ public class TownyWorld extends TownyObject {
 	}
 
 	public void setPlotManagementMayorDelete(List<String> plotManagementMayorDelete) {
-
-		this.plotManagementMayorDelete = TownySettings.toMaterialEnumSet(plotManagementMayorDelete);
+		this.plotManagementMayorDelete.clear();
+		this.plotManagementMayorDelete.addAll(TownySettings.toMaterialSet(plotManagementMayorDelete));
 	}
 
 	public boolean isUnclaimedBlockAllowedToRevert(Material mat) {
@@ -476,7 +476,7 @@ public class TownyWorld extends TownyObject {
 		return !isPlotManagementIgnoreIds(mat);
 	}
 	
-	public EnumSet<Material> getPlotManagementIgnoreIds() {
+	public Collection<Material> getPlotManagementIgnoreIds() {
 		
 		if (plotManagementIgnoreIds == null)
 			return TownySettings.getPlotManagementIgnoreIds();
@@ -489,8 +489,8 @@ public class TownyWorld extends TownyObject {
 	}
 
 	public void setPlotManagementIgnoreIds(List<String> plotManagementIgnoreIds) {
-
-		this.plotManagementIgnoreIds = TownySettings.toMaterialEnumSet(plotManagementIgnoreIds);
+		this.plotManagementIgnoreIds.clear();
+		this.plotManagementIgnoreIds.addAll(TownySettings.toMaterialSet(plotManagementIgnoreIds));
 	}
 
 	public Collection<Material> getRevertOnUnclaimWhitelistMaterials() {
@@ -501,7 +501,7 @@ public class TownyWorld extends TownyObject {
 	}
 
 	public void setRevertOnUnclaimWhitelistMaterials(List<String> revertOnUnclaimWhitelistMaterials) {
-		this.revertOnUnclaimWhitelistMaterials = new HashSet<>(TownySettings.toMaterialEnumSet(revertOnUnclaimWhitelistMaterials));
+		this.revertOnUnclaimWhitelistMaterials = new HashSet<>(TownySettings.toMaterialSet(revertOnUnclaimWhitelistMaterials));
 	}
 
 	public boolean isRevertOnUnclaimWhitelistMaterial(Material mat) {
@@ -559,19 +559,19 @@ public class TownyWorld extends TownyObject {
 	}
 
 	public void setPlotManagementWildRevertEntities(List<String> entities) {
-		entityExplosionProtection = EnumSet.noneOf(EntityType.class);
+		entityExplosionProtection = new HashSet<>();
 		
 		// If entities isn't empty and the first string isn't entirely uppercase, convert the legacy names to the entitytype enum names.
 		if (entities.size() > 0 && !StringMgmt.isAllUpperCase(entities))
 			convertLegacyEntityNames(entities);
 		
-		entityExplosionProtection.addAll(TownySettings.toEntityTypeEnumSet(entities));
+		entityExplosionProtection.addAll(TownySettings.toEntityTypeSet(entities));
 	}
 	
 	private void convertLegacyEntityNames(List<String> entities) {
 		for (int i = 0; i < entities.size(); i++) {
 			String entity = entities.get(i);
-			for (EntityType type : EntityType.values()) {
+			for (EntityType type : Registry.ENTITY_TYPE) {
 				if (type.getEntityClass() != null && type.getEntityClass().getSimpleName().equalsIgnoreCase(entity)) {
 					entities.set(i, type.name());
 					break;
@@ -580,7 +580,7 @@ public class TownyWorld extends TownyObject {
 		}
 	}
 
-	public EnumSet<EntityType> getPlotManagementWildRevertEntities() {
+	public Collection<EntityType> getPlotManagementWildRevertEntities() {
 
 		if (entityExplosionProtection == null)
 			setPlotManagementWildRevertEntities(TownySettings.getWildExplosionProtectionEntities());
@@ -598,15 +598,11 @@ public class TownyWorld extends TownyObject {
 	}
 
 	public void setPlotManagementWildRevertBlockWhitelist(List<String> mats) {
-
-		plotManagementWildRevertBlockWhitelist = EnumSet.noneOf(Material.class);
-
-		for (Material mat : TownySettings.toMaterialEnumSet(mats))
-			plotManagementWildRevertBlockWhitelist.add(mat);
-
+		plotManagementWildRevertBlockWhitelist = new HashSet<>();
+		plotManagementWildRevertBlockWhitelist.addAll(TownySettings.toMaterialSet(mats));
 	}
 
-	public EnumSet<Material> getPlotManagementWildRevertBlockWhitelist() {
+	public Collection<Material> getPlotManagementWildRevertBlockWhitelist() {
 
 		if (plotManagementWildRevertBlockWhitelist == null)
 			setPlotManagementWildRevertBlockWhitelist(TownySettings.getWildExplosionRevertBlockWhitelist());
@@ -640,15 +636,11 @@ public class TownyWorld extends TownyObject {
 	}
 
 	public void setPlotManagementWildRevertMaterials(List<String> mats) {
-
-		blockExplosionProtection = EnumSet.noneOf(Material.class);
-
-		for (Material mat : TownySettings.toMaterialEnumSet(mats))
-			blockExplosionProtection.add(mat);
-
+		blockExplosionProtection = new HashSet<>();
+		blockExplosionProtection.addAll(TownySettings.toMaterialSet(mats));
 	}
 
-	public EnumSet<Material> getPlotManagementWildRevertBlocks() {
+	public Collection<Material> getPlotManagementWildRevertBlocks() {
 
 		if (blockExplosionProtection == null)
 			setPlotManagementWildRevertMaterials(TownySettings.getWildExplosionProtectionBlocks());
@@ -667,12 +659,12 @@ public class TownyWorld extends TownyObject {
 
 	public void setUnclaimedZoneIgnore(List<String> unclaimedZoneIgnoreIds) {
 		if (unclaimedZoneIgnoreIds == null)
-			this.unclaimedZoneIgnoreBlockMaterials = TownySettings.getUnclaimedZoneIgnoreMaterials();
+			this.unclaimedZoneIgnoreBlockMaterials = new HashSet<>(TownySettings.getUnclaimedZoneIgnoreMaterials());
 		else
-			this.unclaimedZoneIgnoreBlockMaterials = TownySettings.toMaterialEnumSet(unclaimedZoneIgnoreIds);
+			this.unclaimedZoneIgnoreBlockMaterials = new HashSet<>(TownySettings.toMaterialSet(unclaimedZoneIgnoreIds));
 	}
 	
-	public EnumSet<Material> getUnclaimedZoneIgnoreMaterials() {
+	public Collection<Material> getUnclaimedZoneIgnoreMaterials() {
 
 		if (unclaimedZoneIgnoreBlockMaterials == null)
 			return TownySettings.getUnclaimedZoneIgnoreMaterials();

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/gui/EditGUI.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/gui/EditGUI.java
@@ -7,7 +7,12 @@ import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.utils.PermissionGUIUtil;
 import com.palmergames.bukkit.towny.utils.PermissionGUIUtil.SetPermissionType;
 
+import org.bukkit.Material;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Arrays;
+import java.util.Optional;
 
 public class EditGUI extends PermissionGUI {
 	private final Resident editor;
@@ -24,12 +29,19 @@ public class EditGUI extends PermissionGUI {
 	 */
 	public void saveChanges() {
 		SetPermissionType[] newTypes = new SetPermissionType[4];
+		Arrays.fill(newTypes, SetPermissionType.UNSET);
+		
 		for (int i = 0; i < 4; i++) {
-			switch (getInventory().getItem(PermissionGUIUtil.getWoolSlots()[i]).getType()) {
-				case LIME_WOOL -> newTypes[i] = SetPermissionType.SET;
-				case RED_WOOL -> newTypes[i] = SetPermissionType.NEGATED;
-				default -> newTypes[i] = SetPermissionType.UNSET;
-			}
+			final Material type = Optional.ofNullable(getInventory().getItem(PermissionGUIUtil.getWoolSlots()[i])).map(ItemStack::getType).orElse(null);
+			if (type == null)
+				continue;
+			
+			if (type == Material.LIME_WOOL)
+				newTypes[i] = SetPermissionType.SET;
+			else if (type == Material.RED_WOOL)
+				newTypes[i] = SetPermissionType.NEGATED;
+			else if (type == Material.GRAY_WOOL)
+				newTypes[i] = SetPermissionType.UNSET;
 		}
 
 		if (getTownBlock().hasPlotObjectGroup())

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/regen/NeedsPlaceholder.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/regen/NeedsPlaceholder.java
@@ -1,23 +1,40 @@
 package com.palmergames.bukkit.towny.regen;
 
+import com.palmergames.util.JavaUtil;
 import org.bukkit.Material;
 
-import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Set;
 
 public class NeedsPlaceholder {
 
-	private static EnumSet<Material> needsPlaceholder = EnumSet.of(
-			Material.SAND, Material.GRAVEL,
-			Material.REDSTONE_WIRE, Material.COMPARATOR,
-			Material.OAK_SAPLING, Material.SPRUCE_SAPLING,
-			Material.BIRCH_SAPLING, Material.SPRUCE_SAPLING,
-			Material.JUNGLE_SAPLING, Material.ACACIA_SAPLING,
-			Material.DARK_OAK_SAPLING, Material.BROWN_MUSHROOM,
-			Material.RED_MUSHROOM, Material.WHEAT, Material.REDSTONE_TORCH,
-			Material.REDSTONE_WALL_TORCH, Material.SNOW, Material.OAK_WALL_SIGN,
-			Material.SPRUCE_WALL_SIGN, Material.DARK_OAK_WALL_SIGN,
-			Material.BIRCH_WALL_SIGN, Material.ACACIA_WALL_SIGN,
-			Material.JUNGLE_WALL_SIGN);
+	private static final Set<Material> needsPlaceholder = JavaUtil.make(() -> {
+		Set<Material> materials = new HashSet<>();
+		materials.add(Material.SAND);
+		materials.add(Material.GRAVEL);
+		materials.add(Material.REDSTONE_WIRE);
+		materials.add(Material.COMPARATOR);
+		materials.add(Material.OAK_SAPLING);
+		materials.add(Material.SPRUCE_SAPLING);
+		materials.add(Material.BIRCH_SAPLING);
+		materials.add(Material.JUNGLE_SAPLING);
+		materials.add(Material.ACACIA_SAPLING);
+		materials.add(Material.DARK_OAK_SAPLING);
+		materials.add(Material.BROWN_MUSHROOM);
+		materials.add(Material.RED_MUSHROOM);
+		materials.add(Material.WHEAT);
+		materials.add(Material.REDSTONE_TORCH);
+		materials.add(Material.REDSTONE_WALL_TORCH);
+		materials.add(Material.SNOW);
+		materials.add(Material.OAK_WALL_SIGN);
+		materials.add(Material.SPRUCE_WALL_SIGN);
+		materials.add(Material.DARK_OAK_WALL_SIGN);
+		materials.add(Material.BIRCH_WALL_SIGN);
+		materials.add(Material.ACACIA_WALL_SIGN);
+		materials.add(Material.JUNGLE_WALL_SIGN);
+		
+		return materials;
+	});
 
 	public static boolean contains(Material material) {
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
@@ -598,11 +598,16 @@ public class TownyRegenAPI {
 	/**
 	 * @deprecated since 0.98.5.0 use {@link WorldCoordMaterialRemover#queueDeleteWorldCoordMaterials(WorldCoord, Collection)} instead.
 	 * @param townBlock TownBlock to remove from.
-	 * @param materialEnumSet Material EnumSet to remove.
+	 * @param materials Material collection to remove.
 	 */
 	@Deprecated
-	public static void deleteMaterialsFromTownBlock(TownBlock townBlock, EnumSet<Material> materialEnumSet) {
-		WorldCoordMaterialRemover.queueDeleteWorldCoordMaterials(townBlock.getWorldCoord(), materialEnumSet);
+	public static void deleteMaterialsFromTownBlock(TownBlock townBlock, Collection<Material> materials) {
+		WorldCoordMaterialRemover.queueDeleteWorldCoordMaterials(townBlock.getWorldCoord(), materials);
+	}
+
+	@Deprecated
+	private static void deleteMaterialsFromTownBlock$$bridge$$public(TownBlock townBlock, EnumSet<Material> materialEnumSet) {
+		deleteMaterialsFromTownBlock(townBlock, materialEnumSet);
 	}
 
 	/**

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/regen/TownyRegenAPI.java
@@ -606,8 +606,9 @@ public class TownyRegenAPI {
 	}
 
 	@Deprecated
-	private static void deleteMaterialsFromTownBlock$$bridge$$public(TownBlock townBlock, EnumSet<Material> materialEnumSet) {
-		deleteMaterialsFromTownBlock(townBlock, materialEnumSet);
+	@SuppressWarnings("unchecked")
+	private static void deleteMaterialsFromTownBlock$$bridge$$public(TownBlock townBlock, EnumSet<?> materialEnumSet) {
+		deleteMaterialsFromTownBlock(townBlock, (Collection<Material>) materialEnumSet);
 	}
 
 	/**

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/CombatUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/CombatUtil.java
@@ -20,8 +20,10 @@ import com.palmergames.bukkit.towny.object.WorldCoord;
 import com.palmergames.bukkit.towny.object.TownyPermission.ActionType;
 import com.palmergames.bukkit.util.BukkitTools;
 
+import com.palmergames.bukkit.util.EntityLists;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.HumanEntity;
@@ -195,30 +197,13 @@ public class CombatUtil {
 				 * Protect specific entity interactions (faked with Materials).
 				 * Requires destroy permissions in either the Wilderness or in Town-Claimed land.
 				 */
-				Material material = switch (defendingEntity.getType()) {
-					/*
-					 * Below are the entities we specifically want to protect with this test.
-					 * Any other entity will mean that block is still null and will not be
-					 * tested with a destroy test.
-					 */
-					case ITEM_FRAME:
-					case GLOW_ITEM_FRAME:
-					case PAINTING:
-					case ARMOR_STAND:
-					case ENDER_CRYSTAL:
-					case MINECART:
-					case MINECART_CHEST:
-					case MINECART_FURNACE:
-					case MINECART_COMMAND:
-					case MINECART_HOPPER:
-						yield EntityTypeUtil.parseEntityToMaterial(defendingEntity.getType());
-					default:
-						yield null;
-				};
+				if (EntityLists.DESTROY_PROTECTED.contains(defendingEntity)) {
+					Material material = EntityTypeUtil.parseEntityToMaterial(defendingEntity.getType());
 
-				if (material != null) {
-					//Make decision on whether this is allowed using the PlayerCache and then a cancellable event.
-					return !TownyActionEventExecutor.canDestroy(attackingPlayer, defendingEntity.getLocation(), material);
+					if (material != null) {
+						//Make decision on whether this is allowed using the PlayerCache and then a cancellable event.
+						return !TownyActionEventExecutor.canDestroy(attackingPlayer, defendingEntity.getLocation(), material);
+					}
 				}
 			}
 
@@ -291,7 +276,7 @@ public class CombatUtil {
 					}
 				}
 				
-				if (attackingEntity.getType().name().equals("AXOLOTL") && EntityTypeUtil.isInstanceOfAny(TownySettings.getProtectedEntityTypes(), defendingEntity)) {
+				if (attackingEntity.getType().getKey().equals(NamespacedKey.minecraft("axolotl")) && EntityTypeUtil.isInstanceOfAny(TownySettings.getProtectedEntityTypes(), defendingEntity)) {
 					return true;
 				}
 			}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/EntityTypeUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/EntityTypeUtil.java
@@ -2,10 +2,14 @@ package com.palmergames.bukkit.towny.utils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.palmergames.bukkit.towny.TownySettings;
+import com.palmergames.util.JavaUtil;
 import org.bukkit.Material;
+import org.bukkit.Registry;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.jetbrains.annotations.NotNull;
@@ -40,6 +44,37 @@ public class EntityTypeUtil {
 			EntityType.MINECART_TNT,
 			EntityType.PRIMED_TNT,
 			EntityType.ENDER_CRYSTAL);
+	
+	// TODO account for older versions not having certain constants
+	/**
+	 * A mapping of various entity types to their corresponding material
+	 */
+	private static final Map<EntityType, Material> ENTITY_TYPE_MATERIAL_MAP = JavaUtil.make(() -> {
+		Map<EntityType, Material> map = new HashMap<>();
+		map.put(EntityType.AXOLOTL, Material.AXOLOTL_BUCKET);
+		map.put(EntityType.COD, Material.COD);
+		map.put(EntityType.SALMON, Material.SALMON);
+		map.put(EntityType.PUFFERFISH, Material.PUFFERFISH);
+		map.put(EntityType.TROPICAL_FISH, Material.TROPICAL_FISH);
+		map.put(EntityType.TADPOLE, Material.TADPOLE_BUCKET);
+		map.put(EntityType.ITEM_FRAME, Material.ITEM_FRAME);
+		map.put(EntityType.GLOW_ITEM_FRAME, Material.GLOW_ITEM_FRAME);
+		map.put(EntityType.PAINTING, Material.PAINTING);
+		map.put(EntityType.ARMOR_STAND, Material.ARMOR_STAND);
+		map.put(EntityType.LEASH_HITCH, Material.LEAD);
+		map.put(EntityType.ENDER_CRYSTAL, Material.END_CRYSTAL);
+		map.put(EntityType.MINECART, Material.MINECART);
+		map.put(EntityType.MINECART_MOB_SPAWNER, Material.MINECART);
+		map.put(EntityType.MINECART_CHEST, Material.CHEST_MINECART);
+		map.put(EntityType.MINECART_FURNACE, Material.FURNACE_MINECART);
+		map.put(EntityType.MINECART_COMMAND, Material.COMMAND_BLOCK_MINECART);
+		map.put(EntityType.MINECART_HOPPER, Material.HOPPER_MINECART);
+		map.put(EntityType.MINECART_TNT, Material.TNT_MINECART);
+		map.put(EntityType.BOAT, Material.OAK_BOAT);
+		map.put(EntityType.CHEST_BOAT, Material.OAK_CHEST_BOAT);
+
+		return map;
+	});
 	
 	public static boolean isInstanceOfAny(List<Class<?>> classes, Object obj) {
 
@@ -81,29 +116,12 @@ public class EntityTypeUtil {
 	 */
 	@Nullable
 	public static Material parseEntityToMaterial(EntityType entityType) {
-		return switch (entityType) {
-			case AXOLOTL -> Material.AXOLOTL_BUCKET;
-			case COD -> Material.COD;
-			case SALMON -> Material.SALMON;
-			case PUFFERFISH -> Material.PUFFERFISH;
-			case TROPICAL_FISH -> Material.TROPICAL_FISH;
-			case TADPOLE -> Material.TADPOLE_BUCKET;
-			case ITEM_FRAME -> Material.ITEM_FRAME;
-			case GLOW_ITEM_FRAME -> Material.GLOW_ITEM_FRAME;
-			case PAINTING -> Material.PAINTING;
-			case ARMOR_STAND -> Material.ARMOR_STAND;
-			case LEASH_HITCH -> Material.LEAD;
-			case ENDER_CRYSTAL -> Material.END_CRYSTAL;
-			case MINECART, MINECART_MOB_SPAWNER -> Material.MINECART;
-			case MINECART_CHEST -> Material.CHEST_MINECART;
-			case MINECART_FURNACE -> Material.FURNACE_MINECART;
-			case MINECART_COMMAND -> Material.COMMAND_BLOCK_MINECART;
-			case MINECART_HOPPER -> Material.HOPPER_MINECART;
-			case MINECART_TNT -> Material.TNT_MINECART;
-			case BOAT -> Material.OAK_BOAT;
-			case CHEST_BOAT -> Material.OAK_CHEST_BOAT;
-			default -> null;
-		};
+		Material lookup = ENTITY_TYPE_MATERIAL_MAP.get(entityType);
+		if (lookup != null)
+			return lookup;
+		
+		// Attempt to lookup a material with the same name, if it doesn't exist it's null.
+		return Registry.MATERIAL.get(entityType.getKey());
 	}
 
 	/**

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/EntityTypeUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/EntityTypeUtil.java
@@ -61,10 +61,10 @@ public class EntityTypeUtil {
 		map.put(EntityType.GLOW_ITEM_FRAME, Material.GLOW_ITEM_FRAME);
 		map.put(EntityType.PAINTING, Material.PAINTING);
 		map.put(EntityType.ARMOR_STAND, Material.ARMOR_STAND);
-		map.put(EntityType.LEASH_HITCH, Material.LEAD);
+		map.put(EntityType.LEASH_HITCH, Material.LEAD); // TODO this is renamed to LEASH_KNOT
 		map.put(EntityType.ENDER_CRYSTAL, Material.END_CRYSTAL);
 		map.put(EntityType.MINECART, Material.MINECART);
-		map.put(EntityType.MINECART_MOB_SPAWNER, Material.MINECART);
+		map.put(EntityType.MINECART_MOB_SPAWNER, Material.MINECART); // TODO whole bunch of renames
 		map.put(EntityType.MINECART_CHEST, Material.CHEST_MINECART);
 		map.put(EntityType.MINECART_FURNACE, Material.FURNACE_MINECART);
 		map.put(EntityType.MINECART_COMMAND, Material.COMMAND_BLOCK_MINECART);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/EntityTypeUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/EntityTypeUtil.java
@@ -1,14 +1,15 @@
 package com.palmergames.bukkit.towny.utils;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import com.palmergames.bukkit.towny.TownySettings;
+import com.palmergames.bukkit.util.EntityLists;
 import com.palmergames.util.JavaUtil;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
@@ -18,60 +19,40 @@ import org.jetbrains.annotations.Nullable;
 import com.palmergames.bukkit.towny.TownyMessaging;
 
 public class EntityTypeUtil {
-	private static final List<EntityType> ExplosiveEntityTypes = Arrays.asList(
-			EntityType.CREEPER,
-			EntityType.DRAGON_FIREBALL, 
-			EntityType.FIREBALL, 
-			EntityType.SMALL_FIREBALL,
-			EntityType.FIREWORK,
-			EntityType.MINECART_TNT,
-			EntityType.PRIMED_TNT,
-			EntityType.WITHER,
-			EntityType.WITHER_SKULL,
-			EntityType.ENDER_CRYSTAL);
 	
-	private static final List<EntityType> ExplosivePVMEntityTypes = Arrays.asList(
-			EntityType.CREEPER,
-			EntityType.DRAGON_FIREBALL,
-			EntityType.FIREBALL,
-			EntityType.SMALL_FIREBALL,
-			EntityType.WITHER,
-			EntityType.WITHER_SKULL,
-			EntityType.ENDER_CRYSTAL);
+	/**
+	 * Used for debugging whether all entity types were mapped, should always equal the map size on the latest version.
+	 */
+	private static int attempted = 0;
 
-	private static final List<EntityType> ExplosivePVPEntityTypes = Arrays.asList(
-			EntityType.FIREWORK,
-			EntityType.MINECART_TNT,
-			EntityType.PRIMED_TNT,
-			EntityType.ENDER_CRYSTAL);
-	
-	// TODO account for older versions not having certain constants
 	/**
 	 * A mapping of various entity types to their corresponding material
 	 */
 	private static final Map<EntityType, Material> ENTITY_TYPE_MATERIAL_MAP = JavaUtil.make(() -> {
 		Map<EntityType, Material> map = new HashMap<>();
-		map.put(EntityType.AXOLOTL, Material.AXOLOTL_BUCKET);
-		map.put(EntityType.COD, Material.COD);
-		map.put(EntityType.SALMON, Material.SALMON);
-		map.put(EntityType.PUFFERFISH, Material.PUFFERFISH);
-		map.put(EntityType.TROPICAL_FISH, Material.TROPICAL_FISH);
-		map.put(EntityType.TADPOLE, Material.TADPOLE_BUCKET);
-		map.put(EntityType.ITEM_FRAME, Material.ITEM_FRAME);
-		map.put(EntityType.GLOW_ITEM_FRAME, Material.GLOW_ITEM_FRAME);
-		map.put(EntityType.PAINTING, Material.PAINTING);
-		map.put(EntityType.ARMOR_STAND, Material.ARMOR_STAND);
-		map.put(EntityType.LEASH_HITCH, Material.LEAD); // TODO this is renamed to LEASH_KNOT
-		map.put(EntityType.ENDER_CRYSTAL, Material.END_CRYSTAL);
-		map.put(EntityType.MINECART, Material.MINECART);
-		map.put(EntityType.MINECART_MOB_SPAWNER, Material.MINECART); // TODO whole bunch of renames
-		map.put(EntityType.MINECART_CHEST, Material.CHEST_MINECART);
-		map.put(EntityType.MINECART_FURNACE, Material.FURNACE_MINECART);
-		map.put(EntityType.MINECART_COMMAND, Material.COMMAND_BLOCK_MINECART);
-		map.put(EntityType.MINECART_HOPPER, Material.HOPPER_MINECART);
-		map.put(EntityType.MINECART_TNT, Material.TNT_MINECART);
-		map.put(EntityType.BOAT, Material.OAK_BOAT);
-		map.put(EntityType.CHEST_BOAT, Material.OAK_CHEST_BOAT);
+		register(map, "axolotl", "axolotl_bucket");
+		register(map, "cod", "cod");
+		register(map, "salmon", "salmon");
+		register(map, "pufferfish", "pufferfish");
+		register(map, "tropical_fish", "tropical_fish");
+		register(map, "tadpole", "tadpole_bucket");
+		register(map, "item_frame", "item_frame");
+		register(map, "glow_item_frame", "glow_item_frame");
+		register(map, "painting", "painting");
+		register(map, "armor_stand", "armor_stand");
+		register(map, "leash_knot", "lead");
+		register(map, "end_crystal", "end_crystal");
+		register(map, "minecart", "minecart");
+		register(map, "spawner_minecart", "minecart");
+		register(map, "chest_minecart", "chest_minecart");
+		register(map, "furnace_minecart", "furnace_minecart");
+		register(map, "command_block_minecart", "command_block_minecart");
+		register(map, "hopper_minecart", "hopper_minecart");
+		register(map, "tnt_minecart", "tnt_minecart");
+		register(map, "boat", "oak_boat");
+		register(map, "chest_boat", "oak_chest_boat");
+		
+		TownyMessaging.sendDebugMsg("[EntityTypeUtil] Attempted: " + attempted + " | Registered: " + map.size());
 
 		return map;
 	});
@@ -144,7 +125,7 @@ public class EntityTypeUtil {
 	 */
 	public static boolean isExplosive(EntityType entityType) {
 
-		return ExplosiveEntityTypes.contains(entityType);	
+		return EntityLists.EXPLOSIVE.contains(entityType);
 	}
 	
 	/**
@@ -155,7 +136,7 @@ public class EntityTypeUtil {
 	 */
 	public static boolean isPVPExplosive(EntityType entityType) {
 
-		return ExplosivePVPEntityTypes.contains(entityType);	
+		return EntityLists.PVP_EXPLOSIVE.contains(entityType);
 	}
 	
 	/**
@@ -166,6 +147,19 @@ public class EntityTypeUtil {
 	 */
 	public static boolean isPVMExplosive(EntityType entityType) {
 
-		return ExplosivePVMEntityTypes.contains(entityType);	
+		return EntityLists.PVE_EXPLOSIVE.contains(entityType);
+	}
+	
+	private static void register(Map<EntityType, Material> map, String name, String mat) {
+		attempted++;
+		EntityType type = Registry.ENTITY_TYPE.get(NamespacedKey.minecraft(name));
+		Material material = Registry.MATERIAL.get(NamespacedKey.minecraft(mat));
+
+		if (type == null || material == null) {
+			TownyMessaging.sendDebugMsg("[EntityTypeUtil] Could not map " + name + " to " + mat);
+			return;
+		}
+
+		map.put(type, material);
 	}
 }

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/PlayerCacheUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/PlayerCacheUtil.java
@@ -96,7 +96,7 @@ public class PlayerCacheUtil {
 			cache.updateCoord(worldCoord);
 
 			boolean result = cache.getCachePermission(material, action);
-			TownyMessaging.sendDebugMsg("New Cache created for " + player.getName() + " using " + material + ":" + action + ":" + status.name() + " = " + result);
+			TownyMessaging.sendDebugMsg("New Cache created for " + player.getName() + " using " + material.getKey() + ":" + action + ":" + status.name() + " = " + result);
 			return result;
 		}
 	}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/ResidentUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/ResidentUtil.java
@@ -139,7 +139,7 @@ public class ResidentUtil {
 		createTownyGUI(resident, items, name);
 	}
 	
-	// Bridge method added during 0.99.0.*
+	// Bridge method added during 0.99.2.*
 	@SuppressWarnings("unused")
 	private static void openGUIInventory$$bridge$$public(Resident resident, Set<Material> set, String name) {
 		openGUIInventory(resident, set, name);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/ResidentUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/ResidentUtil.java
@@ -1,6 +1,7 @@
 package com.palmergames.bukkit.towny.utils;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -130,12 +131,18 @@ public class ResidentUtil {
 		createTownyGUI(resident, items, name);
 	}
 	
-	public static void openGUIInventory(Resident resident, Set<Material> set, String name) {
+	public static void openGUIInventory(Resident resident, Collection<Material> set, String name) {
 		ArrayList<ItemStack> items = new ArrayList<>();
 		for (Material material : set)
 			items.add(new ItemStack(material));
 		
 		createTownyGUI(resident, items, name);
+	}
+	
+	// Bridge method added during 0.99.0.*
+	@SuppressWarnings("unused")
+	private static void openGUIInventory$$bridge$$public(Resident resident, Set<Material> set, String name) {
+		openGUIInventory(resident, set, name);
 	}
 	
 	public static void openSelectionGUI(Resident resident, SelectionGUI.SelectionType selectionType) {

--- a/Towny/src/main/java/com/palmergames/bukkit/util/BukkitTools.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/BukkitTools.java
@@ -351,7 +351,7 @@ public class BukkitTools {
 	@Nullable
 	public static String matchMaterialName(String name) {
 		Material mat = matchRegistry(Registry.MATERIAL, name);
-		return mat == null ? null : mat.name(); 
+		return mat == null ? null : mat.getKey().getKey().toUpperCase(Locale.ROOT); 
 	}
 
 	/**

--- a/Towny/src/main/java/com/palmergames/bukkit/util/EntityLists.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/EntityLists.java
@@ -18,7 +18,7 @@ public class EntityLists extends AbstractRegistryList<EntityType> {
 		return this.contains(entity.getType());
 	}
 	
-	public static final EntityLists VEHICLES = newBuilder().startsWith("minecart").endsWith("boat").build();
+	public static final EntityLists VEHICLES = newBuilder().startsWith("minecart").endsWith("boat").endsWith("raft").build();
 	
 	public static final EntityLists MOUNTABLE = newBuilder().add("horse", "strider", "pig", "donkey", "mule", "trader_llama", "camel").build();
 	
@@ -27,6 +27,12 @@ public class EntityLists extends AbstractRegistryList<EntityType> {
 	public static final EntityLists SWITCH_PROTECTED = newBuilder().add("minecart_chest", "minecart_furnace", "minecart_hopper", "chest_boat").build();
 	
 	public static final EntityLists RIGHT_CLICK_PROTECTED = newBuilder().add("tropical_fish", "salmon", "cod", "item_frame", "glow_item_frame", "painting", "leash_hitch", "command_block_minecart", "tnt_minecart", "spawner_minecart", "tadpole", "axolotl").build();
+	
+	public static final EntityLists ITEM_FRAMES = newBuilder().add("item_frame", "glow_item_frame").build();
+	
+	public static final EntityLists HANGING = newBuilder().add("item_frame", "glow_item_frame", "painting").build();
+	
+	public static final EntityLists BOATS = newBuilder().endsWith("boat").endsWith("raft").build();
 	
 	public static Builder<EntityType, EntityLists> newBuilder() {
 		return new Builder<>(Registry.ENTITY_TYPE, EntityType.class, EntityLists::new);

--- a/Towny/src/main/java/com/palmergames/bukkit/util/EntityLists.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/EntityLists.java
@@ -1,0 +1,34 @@
+package com.palmergames.bukkit.util;
+
+import com.palmergames.bukkit.towny.object.AbstractRegistryList;
+import org.bukkit.Registry;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+
+public class EntityLists extends AbstractRegistryList<EntityType> {
+
+	public EntityLists(Collection<EntityType> collection) {
+		super(Registry.ENTITY_TYPE, collection);
+	}
+	
+	public boolean contains(@NotNull Entity entity) {
+		return this.contains(entity.getType());
+	}
+	
+	public static final EntityLists VEHICLES = newBuilder().startsWith("minecart").endsWith("boat").build();
+	
+	public static final EntityLists MOUNTABLE = newBuilder().add("horse", "strider", "pig", "donkey", "mule", "trader_llama", "camel").build();
+	
+	public static final EntityLists DYEABLE = newBuilder().add("sheep", "wolf").build();
+	
+	public static final EntityLists SWITCH_PROTECTED = newBuilder().add("minecart_chest", "minecart_furnace", "minecart_hopper", "chest_boat").build();
+	
+	public static final EntityLists RIGHT_CLICK_PROTECTED = newBuilder().add("tropical_fish", "salmon", "cod", "item_frame", "glow_item_frame", "painting", "leash_hitch", "command_block_minecart", "tnt_minecart", "spawner_minecart", "tadpole", "axolotl").build();
+	
+	public static Builder<EntityType, EntityLists> newBuilder() {
+		return new Builder<>(Registry.ENTITY_TYPE, EntityType.class, EntityLists::new);
+	}
+}

--- a/Towny/src/main/java/com/palmergames/bukkit/util/EntityLists.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/EntityLists.java
@@ -28,6 +28,8 @@ public class EntityLists extends AbstractRegistryList<EntityType> {
 	
 	public static final EntityLists RIGHT_CLICK_PROTECTED = newBuilder().add("tropical_fish", "salmon", "cod", "item_frame", "glow_item_frame", "painting", "leash_hitch", "leash_knot", "command_block_minecart", "tnt_minecart", "spawner_minecart", "tadpole", "axolotl").build();
 	
+	public static final EntityLists DESTROY_PROTECTED = newBuilder().add("item_frame", "glow_item_frame", "painting", "armor_stand", "end_crystal", "minecart", "minecart_chest", "command_block_minecart", "minecart_hopper").build();
+	
 	public static final EntityLists ITEM_FRAMES = newBuilder().add("item_frame", "glow_item_frame").build();
 	
 	public static final EntityLists HANGING = newBuilder().add("item_frame", "glow_item_frame", "painting").build();

--- a/Towny/src/main/java/com/palmergames/bukkit/util/EntityLists.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/EntityLists.java
@@ -34,6 +34,12 @@ public class EntityLists extends AbstractRegistryList<EntityType> {
 	
 	public static final EntityLists BOATS = newBuilder().endsWith("boat").endsWith("raft").build();
 	
+	public static final EntityLists EXPLOSIVE = newBuilder().add("creeper").endsWith("fireball").add("firework_rocket", "tnt_minecart", "tnt", "wither", "wither_skull", "end_crystal").build();
+	
+	public static final EntityLists PVE_EXPLOSIVE = newBuilder().add("creeper").endsWith("fireball").add("wither", "wither_skull", "end_crystal").build();
+	
+	public static final EntityLists PVP_EXPLOSIVE = newBuilder().add("firework_rocket", "tnt_minecart", "tnt", "end_crystal").build();
+	
 	public static Builder<EntityType, EntityLists> newBuilder() {
 		return new Builder<>(Registry.ENTITY_TYPE, EntityType.class, EntityLists::new);
 	}

--- a/Towny/src/main/java/com/palmergames/bukkit/util/EntityLists.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/EntityLists.java
@@ -26,7 +26,7 @@ public class EntityLists extends AbstractRegistryList<EntityType> {
 	
 	public static final EntityLists SWITCH_PROTECTED = newBuilder().add("minecart_chest", "minecart_furnace", "minecart_hopper", "chest_boat").build();
 	
-	public static final EntityLists RIGHT_CLICK_PROTECTED = newBuilder().add("tropical_fish", "salmon", "cod", "item_frame", "glow_item_frame", "painting", "leash_hitch", "command_block_minecart", "tnt_minecart", "spawner_minecart", "tadpole", "axolotl").build();
+	public static final EntityLists RIGHT_CLICK_PROTECTED = newBuilder().add("tropical_fish", "salmon", "cod", "item_frame", "glow_item_frame", "painting", "leash_hitch", "leash_knot", "command_block_minecart", "tnt_minecart", "spawner_minecart", "tadpole", "axolotl").build();
 	
 	public static final EntityLists ITEM_FRAMES = newBuilder().add("item_frame", "glow_item_frame").build();
 	

--- a/Towny/src/main/java/com/palmergames/util/JavaUtil.java
+++ b/Towny/src/main/java/com/palmergames/util/JavaUtil.java
@@ -12,6 +12,7 @@ import java.nio.file.CopyOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 public class JavaUtil {
@@ -67,5 +68,9 @@ public class JavaUtil {
 		} catch (ClassNotFoundException e) {
 			return false;
 		}
+	}
+	
+	public static <T> T make(Supplier<T> supplier) {
+		return supplier.get();
 	}
 }

--- a/Towny/src/main/resources/config-migration.json
+++ b/Towny/src/main/resources/config-migration.json
@@ -492,7 +492,7 @@
     ]
   },
   {
-    "version": "0.99.2.2",
+    "version": "0.99.2.3",
     "changes": [
       {
         "type": "REPLACE",

--- a/Towny/src/main/resources/config-migration.json
+++ b/Towny/src/main/resources/config-migration.json
@@ -447,6 +447,12 @@
         "path": "new_world_settings.plot_management.revert_on_unclaim.block_ignore",
         "value": ",MOVING_PISTON",
         "worldAction": "UPDATE_WORLD_BLOCK_IGNORE"
+      },
+      {
+        "type": "APPEND",
+        "path": "new_world_settings.plot_management.wild_revert_on_mob_explosion.entities",
+        "value": "FIREBALL",
+        "worldAction": "UPDATE_WORLD_EXPLOSION_REVERT_ENTITIES"
       }
     ]
   }

--- a/Towny/src/main/resources/config-migration.json
+++ b/Towny/src/main/resources/config-migration.json
@@ -275,10 +275,11 @@
         "key": "TNTPrimed",
         "value": "PRIMED_TNT",
         "worldAction": "UPDATE_WORLD_EXPLOSION_REVERT_ENTITIES"
-      },{
+      },
+      {
         "type": "REPLACE",
         "path": "new_world_settings.plot_management.wild_revert_on_mob_explosion.entities",
-        "key": "ExplosiveMinecartl",
+        "key": "ExplosiveMinecart",
         "value": "MINECART_TNT",
         "worldAction": "UPDATE_WORLD_EXPLOSION_REVERT_ENTITIES"
       },
@@ -491,7 +492,7 @@
     ]
   },
   {
-    "version": "0.99.0.12",
+    "version": "0.99.2.2",
     "changes": [
       {
         "type": "REPLACE",

--- a/Towny/src/main/resources/config-migration.json
+++ b/Towny/src/main/resources/config-migration.json
@@ -449,9 +449,24 @@
         "worldAction": "UPDATE_WORLD_BLOCK_IGNORE"
       },
       {
-        "type": "APPEND",
+        "type": "REPLACE",
         "path": "new_world_settings.plot_management.wild_revert_on_mob_explosion.entities",
+        "key": "LARGE_FIREBALL",
         "value": "FIREBALL",
+        "worldAction": "UPDATE_WORLD_EXPLOSION_REVERT_ENTITIES"
+      },
+      {
+        "type": "REPLACE",
+        "path": "new_world_settings.plot_management.wild_revert_on_mob_explosion.entities",
+        "key": "PRIMED_TNT",
+        "value": "TNT",
+        "worldAction": "UPDATE_WORLD_EXPLOSION_REVERT_ENTITIES"
+      },
+      {
+        "type": "REPLACE",
+        "path": "new_world_settings.plot_management.wild_revert_on_mob_explosion.entities",
+        "key": "MINECART_TNT",
+        "value": "TNT_MINECART",
         "worldAction": "UPDATE_WORLD_EXPLOSION_REVERT_ENTITIES"
       }
     ]

--- a/Towny/src/main/resources/config-migration.json
+++ b/Towny/src/main/resources/config-migration.json
@@ -237,35 +237,75 @@
       {
         "type": "REPLACE",
         "path": "new_world_settings.plot_management.wild_revert_on_mob_explosion.entities",
-        "key": "Creeper,EnderCrystal,EnderDragon,Fireball,SmallFireball,LargeFireball,TNTPrimed,ExplosiveMinecart,Wither,WitherSkull",
-        "value": "CREEPER,ENDER_CRYSTAL,ENDER_DRAGON,FIREBALL,SMALL_FIREBALL,LARGE_FIREBALL,PRIMED_TNT,MINECART_TNT,WITHER,WITHER_SKULL",
+        "key": "Creeper",
+        "value": "CREEPER",
         "worldAction": "UPDATE_WORLD_EXPLOSION_REVERT_ENTITIES"
-      }
-    ]
-  },
-  {
-    "version": "0.98.0.3",
-    "changes": [
+      },
+      {
+        "type": "REPLACE",
+        "path": "new_world_settings.plot_management.wild_revert_on_mob_explosion.entities",
+        "key": "EnderCrystal",
+        "value": "ENDER_CRYSTAL",
+        "worldAction": "UPDATE_WORLD_EXPLOSION_REVERT_ENTITIES"
+      },
+      {
+        "type": "REPLACE",
+        "path": "new_world_settings.plot_management.wild_revert_on_mob_explosion.entities",
+        "key": "EnderDragon",
+        "value": "ENDER_DRAGON",
+        "worldAction": "UPDATE_WORLD_EXPLOSION_REVERT_ENTITIES"
+      },
+      {
+        "type": "REPLACE",
+        "path": "new_world_settings.plot_management.wild_revert_on_mob_explosion.entities",
+        "key": "Fireball",
+        "value": "FIREBALL",
+        "worldAction": "UPDATE_WORLD_EXPLOSION_REVERT_ENTITIES"
+      },
+      {
+        "type": "REPLACE",
+        "path": "new_world_settings.plot_management.wild_revert_on_mob_explosion.entities",
+        "key": "SmallFireball",
+        "value": "SMALL_FIREBALL",
+        "worldAction": "UPDATE_WORLD_EXPLOSION_REVERT_ENTITIES"
+      },
+      {
+        "type": "REPLACE",
+        "path": "new_world_settings.plot_management.wild_revert_on_mob_explosion.entities",
+        "key": "TNTPrimed",
+        "value": "PRIMED_TNT",
+        "worldAction": "UPDATE_WORLD_EXPLOSION_REVERT_ENTITIES"
+      },{
+        "type": "REPLACE",
+        "path": "new_world_settings.plot_management.wild_revert_on_mob_explosion.entities",
+        "key": "ExplosiveMinecartl",
+        "value": "MINECART_TNT",
+        "worldAction": "UPDATE_WORLD_EXPLOSION_REVERT_ENTITIES"
+      },
+      {
+        "type": "REPLACE",
+        "path": "new_world_settings.plot_management.wild_revert_on_mob_explosion.entities",
+        "key": "Wither",
+        "value": "WITHER",
+        "worldAction": "UPDATE_WORLD_EXPLOSION_REVERT_ENTITIES"
+      },
+      {
+        "type": "REPLACE",
+        "path": "new_world_settings.plot_management.wild_revert_on_mob_explosion.entities",
+        "key": "WitherSkull",
+        "value": "WITHER_SKULL",
+        "worldAction": "UPDATE_WORLD_EXPLOSION_REVERT_ENTITIES"
+      },
       {
         "type": "TOWNYPERMS_ADD",
         "path": "towns.ranks.sheriff",
         "value": "towny.command.town.jail"
-      }
-    ]
-  },
-  {
-    "version": "0.98.0.3",
-    "changes": [
+      },
       {
         "type": "TOWNYPERMS_ADD",
         "path": "towns.ranks.sheriff",
         "value": "towny.command.town.unjail"
-      }
-    ]
-  },
-  {
-    "version": "0.98.0.3",
-    "changes": [
+      },
       {
         "type": "TOWNYPERMS_ADD",
         "path": "towns.ranks.sheriff",
@@ -447,7 +487,12 @@
         "path": "new_world_settings.plot_management.revert_on_unclaim.block_ignore",
         "value": ",MOVING_PISTON",
         "worldAction": "UPDATE_WORLD_BLOCK_IGNORE"
-      },
+      }
+    ]
+  },
+  {
+    "version": "0.99.0.12",
+    "changes": [
       {
         "type": "REPLACE",
         "path": "new_world_settings.plot_management.wild_revert_on_mob_explosion.entities",
@@ -468,6 +513,20 @@
         "key": "MINECART_TNT",
         "value": "TNT_MINECART",
         "worldAction": "UPDATE_WORLD_EXPLOSION_REVERT_ENTITIES"
+      },
+      {
+        "type": "REPLACE",
+        "path": "new_world_settings.plot_management.wild_revert_on_mob_explosion.entities",
+        "key": "ENDER_CRYSTAL",
+        "value": "END_CRYSTAL",
+        "worldAction": "UPDATE_WORLD_EXPLOSION_REVERT_ENTITIES"
+      },
+      {
+        "type": "REPLACE",
+        "path": "new_world_settings.plot_management.entity_delete.unclaim_delete",
+        "key": "ENDER_CRYSTAL",
+        "value": "end_crystal",
+        "worldAction": "UPDATE_WORLD_UNCLAIM_REVERT_ENTITIES"
       }
     ]
   }


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This PR makes some changes required for the upcoming removal of various Bukkit enums, most notably material & entitytype.

Since some methods were returning EnumSets, we do have some breaking changes unfortunately. Mainly in TownyWorld and TownySettings, I've changed some return types and parameter types to Collection to avoid breakage if we ever change the impl again.

Also fixes an issue with large fireballs left over from when we were doing entity types with class names.
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
