### PR TITLE
Add new perm node for inviting multiple residents

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -3432,6 +3432,10 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 					removeInvites.add(resName);
 			}
 		}
+		
+		if (newResList.size() + removeInvites.size() > 1)
+			checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWN_INVITE_ADD_MULTIPLE.getNode());
+		
 		names = newResList.toArray(new String[0]);
 		String[] namesToRemove = removeInvites.toArray(new String[0]);
 		if (namesToRemove.length != 0) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
@@ -461,6 +461,7 @@ public enum PermissionNodes {
 	// Towns invite residents.
 	TOWNY_COMMAND_TOWN_INVITE_SEE_HOME("towny.command.town.invite"),
 	TOWNY_COMMAND_TOWN_INVITE_ADD("towny.command.town.invite.add"),
+	TOWNY_COMMAND_TOWN_INVITE_ADD_MULTIPLE("towny.command.town.invite.add.multiple"),
 	TOWNY_COMMAND_TOWN_INVITE_LIST_SENT("towny.command.town.invite.sent"),
 	TOWNY_COMMAND_TOWN_INVITE_LIST_RECEIVED("towny.command.town.invite.received"),
 	TOWNY_COMMAND_TOWN_INVITE_ACCEPT("towny.command.town.invite.accept"),

--- a/Towny/src/main/resources/plugin.yml
+++ b/Towny/src/main/resources/plugin.yml
@@ -436,6 +436,11 @@ permissions:
         children:
             towny.command.town.invite.add: true
 
+    towny.command.town.invite.add:
+        default: false
+        children:
+            towny.command.invite.add.multiple: true
+
     towny.command.town.invite.sent:
         description: User can see sent invites from their town.
         default: true


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Adds a new permission node that server admins can use to prevent players from inviting/uninviting multiple players at once.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
