### PR TITLE
Fix hex gradients with minimessage not working

### DIFF
--- a/Towny/pom.xml
+++ b/Towny/pom.xml
@@ -218,6 +218,18 @@
             <artifactId>towny-base-providers</artifactId>
             <version>1.0.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <pluginRepositories>
         <pluginRepository>
@@ -418,6 +430,11 @@
                             </goals>
                         </execution>
                     </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.22.2</version>
                 </plugin>
             </plugins>
         <resources>

--- a/Towny/src/main/java/com/palmergames/util/StringMgmt.java
+++ b/Towny/src/main/java/com/palmergames/util/StringMgmt.java
@@ -28,7 +28,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class StringMgmt {
 
-	public static final Pattern hexPattern = Pattern.compile("((&|\\{|<|)(#|§x))([a-fA-F0-9]|§[a-fA-F0-9]){6}(}|>|)");
+	public static final Pattern hexPattern = Pattern.compile("(&#|\\{|§x|<#)([a-fA-F0-9]|§[a-fA-F0-9]){6}(}|>|)");
 	public static final Pattern hexReplacePattern = Pattern.compile("(§x|[&{}<>§#])");
 	public static final @Deprecated Pattern ampersandPattern = Pattern.compile("(?<!\\\\)(&#[a-fA-F0-9]{6})"); // Deprecated sometime during 0.98.*.*
 	public static final @Deprecated Pattern bracketPattern = Pattern.compile("(?<!\\\\)\\{(#[a-fA-F0-9]{6})}"); // Deprecated sometime during 0.98.*.*

--- a/Towny/src/test/java/com/palmergames/bukkit/towny/test/text/HexConversionTests.java
+++ b/Towny/src/test/java/com/palmergames/bukkit/towny/test/text/HexConversionTests.java
@@ -1,0 +1,49 @@
+package com.palmergames.bukkit.towny.test.text;
+
+import com.palmergames.bukkit.util.Colors;
+import com.palmergames.util.StringMgmt;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class HexConversionTests {
+	
+	// https://github.com/TownyAdvanced/Towny/issues/6291
+	// MiniMessage gradient tags should be untouched
+	@Test
+	void testNoHexGradientConversion() {
+		final String gradient = "<gradient:#AA076B:#61045F>";
+		assertEquals(gradient, Colors.translateLegacyHex(gradient));
+	}
+	
+	// MiniMessage hex tags should also not be touched
+	@Test
+	void testNoMiniMessageConversion() {
+		final String hex = "<#aaaaaa>";
+		assertEquals(hex, Colors.translateLegacyHex(hex));
+	}
+	
+	@Test
+	void testUnusualRepeatingPattern() {
+		final String hexFormat = "§x§a§a§a§a§a§a";
+		assertEquals("<#aaaaaa>", Colors.translateLegacyHex(hexFormat));
+	}
+	
+	@Test
+	void testAmpersandPoundFormat() {
+		String hexFormat = "&#aaaaaa";
+		assertEquals("<#aaaaaa>", Colors.translateLegacyHex(hexFormat));
+	}
+	
+	@Test
+	void testBracketFormat() {
+		String hexFormat = "{aaaaaa}";
+		assertEquals("<#aaaaaa>", Colors.translateLegacyHex(hexFormat));
+	}
+	
+	@Test
+	void testMiniMessageToLegacy() {
+		String hex = "<#aaaaaa>";
+		assertEquals("§x§a§a§a§a§a§a", StringMgmt.translateHexColors(hex));
+	}
+}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Fixes minimessage gradient tags with hex colors being mistakenly converted from \<gradient:#hex1:#hex2> to <gradient:<#hex1>:<#hex2>> by tweaking our hex regex pattern to not consider #aaaaaa valid for converting.
____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #6291

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
