### PR TITLE
Remove teleport related fields from Resident

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyEntityMonitorListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyEntityMonitorListener.java
@@ -26,7 +26,6 @@ import com.palmergames.bukkit.towny.utils.JailUtil;
 import com.palmergames.bukkit.util.BukkitTools;
 
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.event.EventHandler;
@@ -55,24 +54,19 @@ public class TownyEntityMonitorListener implements Listener {
 
 	/**
 	 * Handles players who have taken damage having their spawn cancelled.
-	 * 
-	 * @param event EntityDamageEvent.
 	 */
 	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
 	public void onPlayerTakesDamage(EntityDamageEvent event) {
-		if (!TownySettings.isDamageCancellingSpawnWarmup() 
-				|| !event.getEntityType().equals(EntityType.PLAYER) 
+		if (!(event.getEntity() instanceof Player player)
+				|| !TownySettings.isDamageCancellingSpawnWarmup() 
 				|| !TownyTimerHandler.isTeleportWarmupRunning() 
-				|| PluginIntegrations.getInstance().checkCitizens(event.getEntity()))
+				|| PluginIntegrations.getInstance().checkCitizens(player))
 			return;
 
-		Resident resident = TownyUniverse.getInstance().getResident(event.getEntity().getUniqueId());
+		Resident resident = TownyAPI.getInstance().getResident(player);
 
-		if (resident != null && resident.getTeleportRequestTime() > 0) {
-			TeleportWarmupTimerTask.abortTeleportRequest(resident);
-			TownyMessaging.sendErrorMsg(event.getEntity(), Translatable.of("msg_err_teleport_cancelled_damage"));
-		}
-	}
+		if (TeleportWarmupTimerTask.abortTeleportRequest(resident))
+			TownyMessaging.sendErrorMsg(player, Translatable.of("msg_err_teleport_cancelled_damage"));}
 	
 	/**
 	 * This handles PlayerDeathEvents on MONITOR in order to handle Towny features such as:

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -754,7 +754,7 @@ public class TownyPlayerListener implements Listener {
 				&& TownyTimerHandler.isTeleportWarmupRunning()	 
 				&& TownySettings.getTeleportWarmupTime() > 0
 				&& TownySettings.isMovementCancellingSpawnWarmup()
-				&& resident.getTeleportRequestTime() > 0
+				&& resident.hasRequestedTeleport()
 				&& !townyUniverse.getPermissionSource().isTownyAdmin(player)) {
 			TeleportWarmupTimerTask.abortTeleportRequest(resident);
 			TownyMessaging.sendErrorMsg(player, Translatable.of("msg_err_teleport_cancelled"));

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Resident.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Resident.java
@@ -26,6 +26,7 @@ import com.palmergames.bukkit.towny.object.metadata.CustomDataField;
 import com.palmergames.bukkit.towny.permissions.TownyPerms;
 import com.palmergames.bukkit.towny.scheduling.ScheduledTask;
 import com.palmergames.bukkit.towny.tasks.SetDefaultModes;
+import com.palmergames.bukkit.towny.tasks.TeleportWarmupTimerTask;
 import com.palmergames.bukkit.towny.utils.CombatUtil;
 import com.palmergames.bukkit.towny.utils.MetaDataUtil;
 import com.palmergames.bukkit.util.BukkitTools;
@@ -62,11 +63,6 @@ public class Resident extends TownyObject implements InviteReceiver, EconomyHand
 	private boolean isNPC = false;
 	private String title = "";
 	private String surname = "";
-	private long teleportRequestTime = -1;
-	private Location teleportDestination;
-	private int teleportCooldown;
-	private double teleportCost = 0.0;
-	private Account teleportAccount;
 	private final List<String> modes = new ArrayList<>();
 	private transient Confirmation confirmation;
 	private final transient List<Invite> receivedInvites = new ArrayList<>();
@@ -399,64 +395,95 @@ public class Resident extends TownyObject implements InviteReceiver, EconomyHand
 		return out;
 	}
 
+	/**
+	 * @deprecated Deprecated as of 0.99.0.10, clearing teleport requests is no longer needed.
+	 * Use {@link com.palmergames.bukkit.towny.TownyAPI#abortTeleportRequest(Resident)} to abort an active teleport request.
+	 */
+	@Deprecated
 	public void clearTeleportRequest() {
-		teleportCost = 0;
-		teleportRequestTime = -1;
-		teleportAccount = null;
-		teleportCooldown = 0;
+
 	}
 
+	/**
+	 * @deprecated Deprecated as of 0.99.0.10, teleport request related values are no longer modifiable once the teleport has been requested.
+	 */
+	@Deprecated
 	public void setTeleportRequestTime() {
 
-		teleportRequestTime = System.currentTimeMillis();
 	}
 
+	@ApiStatus.Obsolete
 	public long getTeleportRequestTime() {
-
-		return teleportRequestTime;
+		TeleportRequest request = TeleportWarmupTimerTask.getTeleportRequest(this);
+		
+		return request == null ? -1 : request.requestTime();
 	}
 
+	/**
+	 * @deprecated Deprecated as of 0.99.0.10, teleport request related values are no longer modifiable once the teleport has been requested.
+	 */
+	@Deprecated
 	public void setTeleportDestination(Location spawnLoc) {
 
-		teleportDestination = spawnLoc;
 	}
 
+	@ApiStatus.Obsolete
 	public Location getTeleportDestination() {
+		TeleportRequest request = TeleportWarmupTimerTask.getTeleportRequest(this);
 
-		return teleportDestination;
+		return request == null ? null : request.destinationLocation();
 	}
 
+	/**
+	 * @deprecated Deprecated as of 0.99.0.10, teleport request related values are no longer modifiable once the teleport has been requested.
+	 */
+	@Deprecated
 	public void setTeleportCooldown(int cooldown) {
 
-		teleportCooldown = cooldown;
 	}
 
+	@ApiStatus.Obsolete
 	public int getTeleportCooldown() {
+		TeleportRequest request = TeleportWarmupTimerTask.getTeleportRequest(this);
 
-		return teleportCooldown;
+		return request == null ? -1 : request.cooldown();
 	}
 
+	/**
+	 * @return Whether this resident has an active teleport warmup that they're waiting for.
+	 */
 	public boolean hasRequestedTeleport() {
-
-		return teleportRequestTime != -1;
+		return TeleportWarmupTimerTask.hasTeleportRequest(this);
 	}
 
+	/**
+	 * @deprecated Deprecated as of 0.99.0.10, teleport request related values are no longer modifiable once the teleport has been requested.
+	 */
+	@Deprecated
 	public void setTeleportCost(double cost) {
 
-		teleportCost = cost;
 	}
 
+	@ApiStatus.Obsolete
 	public double getTeleportCost() {
+		TeleportRequest request = TeleportWarmupTimerTask.getTeleportRequest(this);
 
-		return teleportCost;
+		return request == null ? 0 : request.teleportCost();
 	}
 	
+	/**
+	 * @deprecated Deprecated as of 0.99.0.10, teleport request related values are no longer modifiable once the teleport has been requested.
+	 */
+	@Deprecated
 	public void setTeleportAccount(Account payee) {
-		teleportAccount = payee;
+
 	}
 	
+	@ApiStatus.Obsolete
 	public Account getTeleportAccount() {
-		return teleportAccount;
+		TeleportRequest request = TeleportWarmupTimerTask.getTeleportRequest(this);
+
+		return request == null ? null : request.teleportAccount();
 	}
 
 	//TODO: Restore /tw regen and /tw regen undo functionality.

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/TeleportRequest.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/TeleportRequest.java
@@ -1,0 +1,55 @@
+package com.palmergames.bukkit.towny.object;
+
+import com.palmergames.bukkit.towny.object.economy.Account;
+import org.bukkit.Location;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * @since 0.99.0.10
+ */
+public class TeleportRequest {
+	private final long requestTime;
+	private final Location destination;
+	private final int cooldown;
+	private final double teleportCost;
+	private final Account account;
+	
+	private TeleportRequest(long requestTime, @NotNull Location destination, int cooldown, double teleportCost, @Nullable Account account) {
+		this.requestTime = requestTime;
+		this.destination = destination;
+		this.cooldown = cooldown;
+		this.teleportCost = teleportCost;
+		this.account = account;
+	}
+	
+	public static TeleportRequest teleportRequest(long requestTime, @NotNull Location destination, int cooldown) {
+		return teleportRequest(requestTime, destination, cooldown, 0, null);
+	}
+	
+	public static TeleportRequest teleportRequest(long requestTime, @NotNull Location destination, int cooldown, double teleportCost, @Nullable Account account) {
+		return new TeleportRequest(requestTime, destination, cooldown, teleportCost, account);
+	}
+	
+	public long requestTime() {
+		return this.requestTime;
+	}
+	
+	@NotNull
+	public Location destinationLocation() {
+		return this.destination;
+	}
+	
+	public int cooldown() {
+		return this.cooldown;
+	}
+	
+	public double teleportCost() {
+		return this.teleportCost;
+	}
+	
+	@Nullable
+	public final Account teleportAccount() {
+		return this.account;
+	}
+}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/TeleportWarmupTimerTask.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/TeleportWarmupTimerTask.java
@@ -1,59 +1,60 @@
 package com.palmergames.bukkit.towny.tasks;
 
 import com.palmergames.bukkit.towny.Towny;
-import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownyEconomyHandler;
 import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.object.Resident;
+import com.palmergames.bukkit.towny.object.TeleportRequest;
 import com.palmergames.bukkit.towny.object.Translatable;
 import com.palmergames.bukkit.towny.object.Translation;
+import com.palmergames.bukkit.towny.object.economy.Account;
 import io.papermc.lib.PaperLib;
 
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayDeque;
-import java.util.Queue;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author dumptruckman
  */
 public class TeleportWarmupTimerTask extends TownyTimerTask {
 
-	private static Queue<Resident> teleportQueue;
+	private static final Map<Resident, TeleportRequest> TELEPORT_QUEUE = new ConcurrentHashMap<>();
 
 	public TeleportWarmupTimerTask(Towny plugin) {
-
 		super(plugin);
-		teleportQueue = new ArrayDeque<>();
 	}
 
 	@Override
 	public void run() {
 
 		long currentTime = System.currentTimeMillis();
+		Iterator<Map.Entry<Resident, TeleportRequest>> iterator = TELEPORT_QUEUE.entrySet().iterator();
 
-		while (true) {
-			Resident resident = teleportQueue.peek();
-			if (resident == null)
-				break;
-			if (currentTime > resident.getTeleportRequestTime() + (TownySettings.getTeleportWarmupTime() * 1000)) {
-				int cooldown = resident.getTeleportCooldown();
-				resident.clearTeleportRequest();
+		while (iterator.hasNext()) {
+			Map.Entry<Resident, TeleportRequest> next = iterator.next();
+			final Resident resident = next.getKey();
+			final TeleportRequest request = next.getValue();
+
+			if (currentTime > request.requestTime() + (TownySettings.getTeleportWarmupTime() * 1000L)) {
+				iterator.remove();
 				
-				Player p = TownyAPI.getInstance().getPlayer(resident);
+				Player player = resident.getPlayer();
 				// Only teleport & add cooldown if player is valid
-				if (p != null) {
-					PaperLib.teleportAsync(p, resident.getTeleportDestination(), TeleportCause.COMMAND);
-					if (cooldown > 0)
-						CooldownTimerTask.addCooldownTimer(resident.getName(), "teleport", cooldown);
-				}
+				if (player == null)
+					continue;
 				
-				teleportQueue.poll();
-			} else {
-				break;
+				PaperLib.teleportAsync(player, request.destinationLocation(), TeleportCause.COMMAND);
+				
+				if (request.cooldown() > 0)
+					CooldownTimerTask.addCooldownTimer(resident.getName(), "teleport", request.cooldown());
 			}
 		}
 	}
@@ -63,28 +64,44 @@ public class TeleportWarmupTimerTask extends TownyTimerTask {
 	}
 
 	public static void requestTeleport(Resident resident, Location spawnLoc, int cooldown) {
-		resident.setTeleportRequestTime();
-		resident.setTeleportDestination(spawnLoc);
-		resident.setTeleportCooldown(cooldown);
-		try {
-			if (teleportQueue.contains(resident))
-				teleportQueue.remove(resident);
-			teleportQueue.add(resident);
-		} catch (NullPointerException e) {
-			Towny.getPlugin().getLogger().severe("Error: Null returned from teleport queue.");
-			e.printStackTrace();
-		}
+		requestTeleport(resident, spawnLoc, cooldown, null, 0);
 	}
 
-	public static void abortTeleportRequest(Resident resident) {
+	/**
+	 * @apiNote This does not refund any other teleport requests that might be active for the resident, use
+	 * {@link #abortTeleportRequest(Resident)} first if you want them to be refunded.
+	 */
+	public static void requestTeleport(@NotNull Resident resident, @NotNull Location destination, int cooldown, @Nullable Account teleportAccount, double teleportCost) {
+		TeleportRequest request = TeleportRequest.teleportRequest(System.currentTimeMillis(), destination, cooldown, teleportCost, teleportAccount);
+		TELEPORT_QUEUE.put(resident, request);
+	}
+	
+	/**
+	 * Aborts the current active teleport request for the given resident.
+	 * @param resident The resident to abort the request for.
+	 * @return Whether the resident had an active teleport request.
+	 */
+	public static boolean abortTeleportRequest(Resident resident) {
+		if (resident == null)
+			return false;
 
-		if (resident != null && teleportQueue.contains(resident)) {
-			if (resident.getTeleportCost() != 0 && TownyEconomyHandler.isActive() && resident.getTeleportAccount() != null) {
-				resident.getTeleportAccount().payTo(resident.getTeleportCost(), resident.getAccount(), Translation.of("msg_cost_spawn_refund"));
-				TownyMessaging.sendMsg(resident, Translatable.of("msg_cost_spawn_refund"));
-			}
-			resident.clearTeleportRequest();
-			teleportQueue.remove(resident);
+		TeleportRequest request = TELEPORT_QUEUE.remove(resident);
+		if (request == null)
+			return false;
+
+		if (request.teleportCost() != 0 && TownyEconomyHandler.isActive() && request.teleportAccount() != null) {
+			request.teleportAccount().payTo(request.teleportCost(), resident.getAccount(), Translation.of("msg_cost_spawn_refund"));
+			TownyMessaging.sendMsg(resident, Translatable.of("msg_cost_spawn_refund"));
 		}
+
+		return true;
+	}
+	
+	public static boolean hasTeleportRequest(@NotNull Resident resident) {
+		return TELEPORT_QUEUE.containsKey(resident);
+	}
+	
+	public static TeleportRequest getTeleportRequest(@NotNull Resident resident) {
+		return TELEPORT_QUEUE.get(resident);
 	}
 }


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
These fields are only ever used for online residents who want to teleport, so moving them away will probably reduce the used memory at least a bit. All the different variables used for a teleport are now stored together so that there's also a smaller likelyhood of it entering an invalid state.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
