### PR TITLE
Fix previously async timers tasks being sync

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyTimerHandler.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyTimerHandler.java
@@ -97,7 +97,7 @@ public class TownyTimerHandler{
 	public static void toggleHealthRegen(boolean on) {
 
 		if (on && !isHealthRegenRunning()) {
-			healthRegenTask = plugin.getScheduler().runAsyncRepeating(new HealthRegenTimerTask(plugin, BukkitTools.getServer()), 1, TimeTools.convertToTicks(TownySettings.getHealthRegenSpeed()));
+			healthRegenTask = plugin.getScheduler().runRepeating(new HealthRegenTimerTask(plugin, BukkitTools.getServer()), 1, TimeTools.convertToTicks(TownySettings.getHealthRegenSpeed()));
 		} else if (!on && isHealthRegenRunning()) {
 			healthRegenTask.cancel();
 			healthRegenTask = null;

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyTimerHandler.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyTimerHandler.java
@@ -76,7 +76,7 @@ public class TownyTimerHandler{
 
 	public static void toggleHourlyTimer(boolean on) {
 		if (on && !isHourlyTimerRunning()) {
-			hourlyTask = plugin.getScheduler().runRepeating(new HourlyTimerTask(plugin), getTimeUntilNextHourInSeconds(), TimeTools.convertToTicks(TownySettings.getHourInterval()));
+			hourlyTask = plugin.getScheduler().runAsyncRepeating(new HourlyTimerTask(plugin), getTimeUntilNextHourInSeconds(), TimeTools.convertToTicks(TownySettings.getHourInterval()));
 		} else if (!on && isHourlyTimerRunning()) {
 			hourlyTask.cancel();
 			hourlyTask = null;
@@ -87,7 +87,7 @@ public class TownyTimerHandler{
 		if (on && !isShortTimerRunning()) {
 			//This small delay is a safeguard against race conditions
 			long delayTicks = TimeTools.convertToTicks(60);
-			shortTask = plugin.getScheduler().runRepeating(new ShortTimerTask(plugin), delayTicks, TimeTools.convertToTicks(TownySettings.getShortInterval()));
+			shortTask = plugin.getScheduler().runAsyncRepeating(new ShortTimerTask(plugin), delayTicks, TimeTools.convertToTicks(TownySettings.getShortInterval()));
 		} else if (!on && isShortTimerRunning()) {
 			shortTask.cancel();
 			shortTask = null;
@@ -97,7 +97,7 @@ public class TownyTimerHandler{
 	public static void toggleHealthRegen(boolean on) {
 
 		if (on && !isHealthRegenRunning()) {
-			healthRegenTask = plugin.getScheduler().runRepeating(new HealthRegenTimerTask(plugin, BukkitTools.getServer()), 1, TimeTools.convertToTicks(TownySettings.getHealthRegenSpeed()));
+			healthRegenTask = plugin.getScheduler().runAsyncRepeating(new HealthRegenTimerTask(plugin, BukkitTools.getServer()), 1, TimeTools.convertToTicks(TownySettings.getHealthRegenSpeed()));
 		} else if (!on && isHealthRegenRunning()) {
 			healthRegenTask.cancel();
 			healthRegenTask = null;
@@ -117,7 +117,7 @@ public class TownyTimerHandler{
 	public static void toggleCooldownTimer(boolean on) {
 		
 		if (on && !isCooldownTimerRunning()) {
-			cooldownTimerTask = plugin.getScheduler().runRepeating(new CooldownTimerTask(plugin), 1, 20);
+			cooldownTimerTask = plugin.getScheduler().runAsyncRepeating(new CooldownTimerTask(plugin), 1, 20);
 		} else if (!on && isCooldownTimerRunning()) {
 			cooldownTimerTask.cancel();
 			cooldownTimerTask = null;
@@ -126,7 +126,7 @@ public class TownyTimerHandler{
 	
 	public static void toggleDrawSmokeTask(boolean on) {
 		if (on && !isDrawSmokeTaskRunning()) {
-			drawSmokeTask = plugin.getScheduler().runRepeating(new DrawSmokeTask(plugin), 1, 40);
+			drawSmokeTask = plugin.getScheduler().runAsyncRepeating(new DrawSmokeTask(plugin), 1, 40);
 		} else if (!on && isDrawSmokeTaskRunning()) {
 			drawSmokeTask.cancel();
 			drawSmokeTask = null;
@@ -136,7 +136,7 @@ public class TownyTimerHandler{
 	public static void toggleDrawSpointsTask(boolean on) {
 		if (on && !isDrawSpawnPointsTaskRunning()) {
 			// This is given a delay because it was causing ConcurrentModificationExceptions on startup on one server.
-			drawSpawnPointsTask = plugin.getScheduler().runRepeating(new DrawSpawnPointsTask(plugin), 40, 52);
+			drawSpawnPointsTask = plugin.getScheduler().runAsyncRepeating(new DrawSpawnPointsTask(plugin), 40, 52);
 		} else if (!on && isDrawSpawnPointsTaskRunning()) {
 			drawSpawnPointsTask.cancel();
 			drawSpawnPointsTask = null;

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/HealthRegenTimerTask.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/HealthRegenTimerTask.java
@@ -31,10 +31,8 @@ public class HealthRegenTimerTask extends TownyTimerTask {
 			for (Player player : server.getOnlinePlayers())
 				plugin.getScheduler().run(player, () -> checkPlayer(player));
 		} else {
-			plugin.getScheduler().run(() -> {
-				for (Player player : server.getOnlinePlayers())
-					checkPlayer(player);
-			});
+			for (Player player : server.getOnlinePlayers())
+				checkPlayer(player);
 		}
 	}
 	


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Fixes some tasks that used to be async pre-folia now being sync, also makes the health regen task more safe on folia by running it on the player's region thread.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
