### PR TITLE
Fix world settings being wiped on load.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyUniverse.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyUniverse.java
@@ -749,26 +749,15 @@ public class TownyUniverse {
 	// =========== World Methods ===========
 
 	/**
-	 * Called during loading of the database only, to prevent saving over existing world data.
-	 * @param world World being loaded as a TownyWorld.
+	 * Causes a new TownyWorld object to be made in the Universe, from a Bukkit World.
 	 */
 	public void newWorld(@NotNull World world) {
-		newWorld(world, false);
-	}
-
-	/**
-	 * Causes a new TownyWorld object to be made in the Universe, from a Bukkit World.
-	 * 
-	 * @param newlyDetected Used to cause Towny to save the TownyWorld to the database.
-	 */
-	public void newWorld(@NotNull World world, boolean newlyDetected) {
 		Preconditions.checkNotNull(world, "World cannot be null!");
 		if (getWorldIDMap().containsKey(world.getUID()))
 			return;
 		TownyWorld townyWorld = new TownyWorld(world.getName(), world.getUID());
 		registerTownyWorld(townyWorld);
-		if (newlyDetected)
-			townyWorld.save();
+		townyWorld.save();
 	}
 
 	public void registerTownyWorld(@NotNull TownyWorld world) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyUniverse.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyUniverse.java
@@ -748,13 +748,27 @@ public class TownyUniverse {
 	
 	// =========== World Methods ===========
 
+	/**
+	 * Called during loading of the database only, to prevent saving over existing world data.
+	 * @param world World being loaded as a TownyWorld.
+	 */
 	public void newWorld(@NotNull World world) {
+		newWorld(world, false);
+	}
+
+	/**
+	 * Causes a new TownyWorld object to be made in the Universe, from a Bukkit World.
+	 * 
+	 * @param newlyDetected Used to cause Towny to save the TownyWorld to the database.
+	 */
+	public void newWorld(@NotNull World world, boolean newlyDetected) {
 		Preconditions.checkNotNull(world, "World cannot be null!");
 		if (getWorldIDMap().containsKey(world.getUID()))
 			return;
 		TownyWorld townyWorld = new TownyWorld(world.getName(), world.getUID());
 		registerTownyWorld(townyWorld);
-		townyWorld.save();
+		if (newlyDetected)
+			townyWorld.save();
 	}
 
 	public void registerTownyWorld(@NotNull TownyWorld world) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -343,7 +343,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 		
 		TownyMessaging.sendDebugMsg(Translation.of("flatfile_dbg_loading_server_world_list"));
 		for (World world : Bukkit.getServer().getWorlds())
-			universe.newWorld(world);
+			universe.registerTownyWorld(new TownyWorld(world.getName(), world.getUID()));
 
 		TownyMessaging.sendDebugMsg(Translation.of("flatfile_dbg_loading_world_list"));
 		

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -649,7 +649,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 
 		// Check for any new worlds registered with bukkit.
 		for (World world : Bukkit.getServer().getWorlds())
-			universe.newWorld(world);
+			universe.registerTownyWorld(new TownyWorld(world.getName(), world.getUID()));
 
 		if (!getContext())
 			return false;

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyWorldListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyWorldListener.java
@@ -68,7 +68,7 @@ public class TownyWorldListener implements Listener {
 		}
 
 		// This is a world we've never seen before, make a new TownyWorld.
-		TownyUniverse.getInstance().newWorld(world, true);
+		TownyUniverse.getInstance().newWorld(world);
 		TownyWorld townyWorld = TownyAPI.getInstance().getTownyWorld(world.getUID());
 		
 		if (townyWorld == null) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyWorldListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyWorldListener.java
@@ -68,7 +68,7 @@ public class TownyWorldListener implements Listener {
 		}
 
 		// This is a world we've never seen before, make a new TownyWorld.
-		TownyUniverse.getInstance().newWorld(world);
+		TownyUniverse.getInstance().newWorld(world, true);
 		TownyWorld townyWorld = TownyAPI.getInstance().getTownyWorld(world.getUID());
 		
 		if (townyWorld == null) {


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

An issue exists, where some MySQL servers are having their worlds take on default settings during the loading process, I believe this PR solves that problem, introduced in 0.98.6.4 with https://github.com/TownyAdvanced/Towny/pull/6377/

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
