### PR TITLE
Fallback to Plot Group name when Plot has no name

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/hooks/TownyPlaceholderExpansion.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/hooks/TownyPlaceholderExpansion.java
@@ -650,7 +650,7 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 			case "player_location_formattedtown_or_wildname": // %townyadvanced_player_location_formattedtown_or_wildname%
 				return townblock != null ? townblock.getTownOrNull().getFormattedName() : TownyAPI.getInstance().getTownyWorld(player.getWorld()).getFormattedUnclaimedZoneName();
 			case "player_location_plot_name": // %townyadvanced_player_location_plot_name%
-				return townblock != null ? townblock.getName() : "";
+				return townblock != null ? (!townblock.getName().isEmpty() ? townblock.getName() : (townblock.hasPlotObjectGroup() ? townblock.getPlotObjectGroup().getName() : "")) : "";
 			case "player_location_plot_forsale": { // %townyadvanced_player_location_plot_forsale%
 				if (townblock == null) return "";
 				return townblock.isForSale() ? Translation.of("towny_map_forsale") : "";


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
* Fixes #6703:
  * Whenever the placeholder `player_location_plot_name` is used inside a Plot Group, and the individual plot has no name, it displays the Plot Group's name instead.

____
#### New Nodes/Commands/ConfigOptions: 
* None


____
#### Relevant Towny Issue ticket:
 * #6703 


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
