### PR TITLE
Fix legacy debt converter not respecting isEconomyAsync

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/MoneyUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/MoneyUtil.java
@@ -217,7 +217,7 @@ public class MoneyUtil {
 	public static void checkLegacyDebtAccounts() {
 		File f = new File(TownyUniverse.getInstance().getRootFolder(), "debtAccountsConverted.txt");
 		if (!f.exists())
-			Towny.getPlugin().getScheduler().runAsyncLater(MoneyUtil::convertLegacyDebtAccounts, 600L);
+			Towny.getPlugin().getScheduler().runAsyncLater(() -> TownyEconomyHandler.economyExecutor().execute(MoneyUtil::convertLegacyDebtAccounts), 600L);
 	}
 	
 	/**
@@ -227,10 +227,9 @@ public class MoneyUtil {
 		for (Town town : TownyUniverse.getInstance().getTowns()) {
 			final String name = "[DEBT]-" + town.getName();
 			if (TownyEconomyHandler.hasAccount(name)) {
-				TownyEconomyHandler.economyExecutor().execute(() -> {
-					town.setDebtBalance(TownyEconomyHandler.getBalance(name, town.getAccount().getBukkitWorld()));
-					TownyEconomyHandler.setBalance(name, 0.0, town.getAccount().getBukkitWorld());
-				});
+				town.setDebtBalance(TownyEconomyHandler.getBalance(name, town.getAccount().getBukkitWorld()));
+				town.save();
+				TownyEconomyHandler.setBalance(name, 0.0, town.getAccount().getBukkitWorld());
 			}
 		}
 		Towny.getPlugin().saveResource("debtAccountsConverted.txt", false);


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
The hasAccount call wasn't being done on the right thread if the async_economy option was set to false, this PR just changes it to run the entire task on the economy executor and additionally saves the town after a conversion.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
