### PR TITLE
Replace all printStackTraces with the logger

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/InviteCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/InviteCommand.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 public class InviteCommand extends BaseCommand implements CommandExecutor {
@@ -201,7 +202,7 @@ public class InviteCommand extends BaseCommand implements CommandExecutor {
 			try {
 				InviteHandler.declineInvite(toDecline, false);
 			} catch (InvalidObjectException e) {
-				e.printStackTrace();
+				plugin.getLogger().log(Level.WARNING, "unknown exception occurred while denying invite", e);
 			}
 		} else
 			TownyMessaging.sendErrorMsg(player, Translatable.of("msg_specify_name"));			
@@ -265,14 +266,12 @@ public class InviteCommand extends BaseCommand implements CommandExecutor {
 			try {
 				if (TownySettings.getMaxResidentsPerTown() > 0 && town.getResidents().size() >= TownySettings.getMaxResidentsForTown(town)) {
 					TownyMessaging.sendMsg(player, Translatable.of("msg_err_max_residents_per_town_reached", TownySettings.getMaxResidentsForTown(town)));
-					return;
 				} else if (town.hasNation() && TownySettings.getMaxResidentsPerNation() > 0 && town.getNationOrNull().getResidents().size() >= TownySettings.getMaxResidentsPerNation()) {
 					TownyMessaging.sendMsg(player, Translatable.of("msg_err_cannot_join_nation_over_resident_limit", TownySettings.getMaxResidentsPerNation()));
-					return;
 				} else
 					InviteHandler.acceptInvite(toAccept);
 			} catch (TownyException | InvalidObjectException e) {
-				e.printStackTrace();
+				plugin.getLogger().log(Level.WARNING, "unknown exception occurred while accepting invite", e);
 			}
 		} else
 			TownyMessaging.sendErrorMsg(player, Translatable.of("msg_specify_name"));

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -94,6 +94,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 
@@ -1341,7 +1342,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 							TownyMessaging.sendMsg(sender, Translatable.of("nation_revoke_invite_successful"));
 							break;
 						} catch (InvalidObjectException e) {
-							e.printStackTrace();
+							plugin.getLogger().log(Level.WARNING, "unknown exception occurred while revoking invite", e);
 						}
 					}
 				}
@@ -1586,9 +1587,8 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 					return;
 				}
 				InviteHandler.acceptInvite(toAccept);
-				return;
 			} catch (InvalidObjectException e) {
-				e.printStackTrace(); // Shouldn't happen, however like i said a fallback
+				plugin.getLogger().log(Level.WARNING, "unknown exception occurred while accepting invite", e); // Shouldn't happen, however like i said a fallback
 			}
 		}
 
@@ -1635,7 +1635,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 				InviteHandler.declineInvite(toDecline, false);
 				TownyMessaging.sendMsg(player, Translatable.of("successful_deny_request"));
 			} catch (InvalidObjectException e) {
-				e.printStackTrace(); // Shouldn't happen, however like i said a fallback
+				plugin.getLogger().log(Level.WARNING, "unknown exception occurred while declining invite", e); // Shouldn't happen, however like i said a fallback
 			}
 		}
 	}
@@ -1650,7 +1650,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 							TownyMessaging.sendMsg(sender, Translatable.of("nation_revoke_ally_successful"));
 							break;
 						} catch (InvalidObjectException e) {
-							e.printStackTrace();
+							plugin.getLogger().log(Level.WARNING, "An exception occurred while revoking invites for nation " + invitedNation.getName(), e);
 						}
 					}
 				}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -141,6 +141,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 /**
@@ -1013,7 +1014,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 						InviteHandler.acceptInvite(toAccept);
 						return;
 					} catch (TownyException | InvalidObjectException e) {
-						e.printStackTrace();
+						plugin.getLogger().log(Level.WARNING, "unknown exception occurred while accepting invite", e);
 					}
 				}
 			}
@@ -1053,9 +1054,8 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 					try {
 						InviteHandler.declineInvite(toDecline, false);
 						TownyMessaging.sendMsg(player, Translatable.of("successful_deny"));
-						return;
 					} catch (InvalidObjectException e) {
-						e.printStackTrace(); // Shouldn't happen, however like i said a fallback
+						plugin.getLogger().log(Level.WARNING, "unknown exception occurred while declining invite", e); // Shouldn't happen, however like i said a fallback
 					}
 				}
 			} else {
@@ -1794,8 +1794,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 			}
 
 		} catch (NullPointerException e) {
-			e.printStackTrace();
-			return;
+			plugin.getLogger().log(Level.WARNING, "while parsing jail command", e);
 		}
 	}
 
@@ -2780,7 +2779,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 				TownyMessaging.sendGlobalMessage(Translatable.of("msg_new_town", player.getName(), StringMgmt.remUnderscore(finalName)));
 			} catch (TownyException e) {
 				TownyMessaging.sendErrorMsg(player, e.getMessage(player));
-				e.printStackTrace();
+				plugin.getLogger().log(Level.WARNING, "An exception occurred while creating a new town", e);
 			}
 		})
 		.setCancellableEvent(new PreNewTownEvent(player, name, spawnLocation))
@@ -3179,7 +3178,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 							TownyMessaging.sendMsg(sender, Translatable.of("town_revoke_invite_successful"));
 							break;
 						} catch (InvalidObjectException e) {
-							e.printStackTrace();
+							plugin.getLogger().log(Level.WARNING, "An exception occurred while revoking invites for town " + town.getName(), e);
 						}
 					}
 				}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -87,6 +87,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -2094,7 +2095,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			TownBlockTypeHandler.initialize();
 		} catch (TownyException e) {
 			TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_reload_error"));
-			e.printStackTrace();
+			plugin.getLogger().log(Level.WARNING, "An exception occurred while reloading the config", e);
 			return;
 		}
 		

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
@@ -76,6 +76,7 @@ import java.util.Queue;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 import java.util.zip.ZipFile;
 
@@ -330,7 +331,7 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 		try {
 			universe.unregisterResident(resident);
 		} catch (NotRegisteredException e) {
-			e.printStackTrace();
+			plugin.getLogger().log(Level.WARNING, "An exception occurred while unregistering resident " + resident.getName(), e);
 		}
 
 		// Clear accounts
@@ -527,9 +528,8 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 
 		try {
 			universe.unregisterNation(nation);
-		} catch (NotRegisteredException e) {
-			// Just print out the exception. Very unlikely to happen.
-			e.printStackTrace();
+		} catch (NotRegisteredException ignored) {
+			// Just ignore the exception. Very unlikely to happen.
 		}
 
 		for (Town town : toSave) {
@@ -945,7 +945,7 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 				InputStream stream = zipFile.getInputStream(zipFile.entries().nextElement());
 				return loadDataStream(plotBlockData, stream);
 			} catch (IOException e) {
-				e.printStackTrace();
+				plugin.getLogger().log(Level.WARNING, "An exception occurred while loading plot block data from file " + fileName, e);
 				return null;
 			}
 			
@@ -957,7 +957,7 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
         	try {
     			return loadDataStream(plotBlockData, new FileInputStream(getLegacyPlotFilename(townBlock)));
     		} catch (FileNotFoundException e) {
-    			e.printStackTrace();
+				plugin.getLogger().log(Level.WARNING, "Could not find file for legacy plot block data file for townblock " + townBlock, e);
     			return null;
     		}
         }
@@ -1017,7 +1017,7 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 
         } catch (EOFException ignored) {
         } catch (IOException e) {
-            e.printStackTrace();
+            plugin.getLogger().log(Level.WARNING, "An exception occurred while loading plot block data stream", e);
         }
         
         plotBlockData.setBlockList(blockArr);
@@ -1080,8 +1080,7 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 			return true;
 			
 		} catch (Exception e) {
-			TownyMessaging.sendErrorMsg("Error Loading Regen List at " + line + ", in towny\\data\\regen.txt");
-			e.printStackTrace();
+			plugin.getLogger().log(Level.WARNING, "Error Loading Regen List at " + line + ", in towny\\data\\regen.txt", e);
 			return false;
 			
 		}
@@ -1242,8 +1241,8 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 		String replacementName = "replacementname" + r.nextInt(99) + 1;
 		try {
 			replacementName = getNextName(town);
-		} catch (TownyException e) {
-			e.printStackTrace();
+		} catch (TownyException ignored) {
+			// fallback to replacement name
 		}
 		return replacementName;
 	}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 public final class TownyFlatFileSource extends TownyDatabaseHandler {
@@ -181,7 +182,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 
 			return true;
 		} catch (Exception e1) {
-			e1.printStackTrace();
+			plugin.getLogger().log(Level.WARNING, "An exception occurred while loading the flatfile townblock list", e1);
 			return false;
 		}
 	}
@@ -221,7 +222,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 				newResident(name);
 			} catch (NotRegisteredException e) {
 				// Thrown if the resident name does not pass the filters.
-				e.printStackTrace();
+				plugin.getLogger().log(Level.WARNING, "Resident " + name + " has an invalid name", e);
 				return false;
 			} catch (AlreadyRegisteredException ignored) {
 				// Should not be possible in flatfile.
@@ -276,7 +277,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 				universe.newTownInternal(newName);
 			} catch (AlreadyRegisteredException | InvalidNameException e1) {
 				// We really hope this doesn't fail again.
-				e1.printStackTrace();
+				plugin.getLogger().log(Level.WARNING, "exception occurred while registering town '" + newName + "' internally", e1);
 				return false;
 			}
 			File newFile = new File(town.getParent(), newName + ".txt");
@@ -328,7 +329,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 				newNation(newName);
 			} catch (AlreadyRegisteredException | NotRegisteredException e1) {
 				// we really hope this doesn't fail a second time.
-				e1.printStackTrace();
+				plugin.getLogger().log(Level.WARNING, "exception occurred while registering nation '" + newName + "' internally", e1);
 				return false;
 			}
 			File newFile = new File(nation.getParent(), newName + ".txt");
@@ -556,8 +557,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 					}
 				}
 			} catch (Exception e) {
-				TownyMessaging.sendErrorMsg(Translation.of("flatfile_err_reading_resident_at_line", resident.getName(), line, resident.getName()));
-				e.printStackTrace();
+				plugin.getLogger().log(Level.WARNING, Translation.of("flatfile_err_reading_resident_at_line", resident.getName(), line, resident.getName()), e);
 				return false;
 			} finally {
 				if (save) saveResident(resident);
@@ -1033,8 +1033,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 				}
 				
 			} catch (Exception e) {
-				TownyMessaging.sendErrorMsg(Translation.of("flatfile_err_reading_town_file_at_line", town.getName(), line, town.getName()));
-				e.printStackTrace();
+				plugin.getLogger().log(Level.WARNING, Translation.of("flatfile_err_reading_town_file_at_line", town.getName(), line, town.getName()), e);
 				return false;
 			} finally {
 				saveTown(town);
@@ -1215,8 +1214,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 					MetadataLoader.getInstance().deserializeMetadata(nation, line.trim());
 
 			} catch (Exception e) {
-				TownyMessaging.sendErrorMsg(Translation.of("flatfile_err_reading_nation_file_at_line", nation.getName(), line, nation.getName()));
-				e.printStackTrace();
+				plugin.getLogger().log(Level.WARNING, Translation.of("flatfile_err_reading_nation_file_at_line", nation.getName(), line, nation.getName()), e);
 				return false;
 			} finally {
 				saveNation(nation);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -59,6 +59,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 public final class TownySQLSource extends TownyDatabaseHandler {
@@ -557,9 +558,9 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			
 			return true;
 		} catch (SQLException s) {
-			s.printStackTrace();
+			plugin.getLogger().warning("SQL: town block list error: " + s.getMessage());
 		} catch (Exception e) {
-			TownyMessaging.sendErrorMsg(e.getMessage());
+			plugin.getLogger().log(Level.WARNING, "SQL: townblock list unknown error", e);
 		}
 		return false;
 
@@ -584,7 +585,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			}
 			return true;
 		} catch (Exception e) {
-			e.printStackTrace();
+			plugin.getLogger().log(Level.WARNING, "SQL: resident list unknown error", e);
 		}
 		return false;
 	}
@@ -610,8 +611,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 		} catch (SQLException e) {
 			TownyMessaging.sendErrorMsg("SQL: town list sql error : " + e.getMessage());
 		} catch (Exception e) {
-			TownyMessaging.sendErrorMsg("SQL: town list unknown error: ");
-			e.printStackTrace();
+			plugin.getLogger().log(Level.WARNING, "SQL: town list unknown error", e);
 		}
 		return false;
 	}
@@ -636,8 +636,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 		} catch (SQLException e) {
 			TownyMessaging.sendErrorMsg("SQL: nation list sql error : " + e.getMessage());
 		} catch (Exception e) {
-			TownyMessaging.sendErrorMsg("SQL: nation list unknown error : ");
-			e.printStackTrace();
+			plugin.getLogger().log(Level.WARNING, "SQL: nation list unknown error", e);
 		}
 		return false;
 	}
@@ -680,8 +679,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 		} catch (SQLException e) {
 			TownyMessaging.sendErrorMsg("SQL: world list sql error : " + e.getMessage());
 		} catch (Exception e) {
-			TownyMessaging.sendErrorMsg("SQL: world list unknown error : ");
-			e.printStackTrace();
+			plugin.getLogger().log(Level.WARNING, "SQL: world list unknown error", e);
 		}
 
 		return true;
@@ -703,7 +701,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			return true;
 
 		} catch (Exception e) {
-			e.printStackTrace();
+			plugin.getLogger().log(Level.WARNING, "SQL: group list unknown error", e);
 		}
 		return false;
 	}
@@ -723,8 +721,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 		} catch (SQLException e) {
 			TownyMessaging.sendErrorMsg("SQL: jail list sql error : " + e.getMessage());
 		} catch (Exception e) {
-			TownyMessaging.sendErrorMsg("SQL: jail list unknown error : ");
-			e.printStackTrace();
+			plugin.getLogger().log(Level.WARNING, "SQL: jail list unknown error", e);
 		}
 		return false;
 	}
@@ -750,8 +747,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 				try {
 					residentName = rs.getString("name");
 				} catch (SQLException ex) {
-					plugin.getLogger().severe("Loading Error: Error fetching a resident name from SQL Database. Skipping loading resident..");
-					ex.printStackTrace();
+					plugin.getLogger().log(Level.SEVERE, "Loading Error: Error fetching a resident name from SQL Database. Skipping loading resident..", ex);
 					continue;
 				}
 				
@@ -823,29 +819,32 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 					resident.setUUID(uuid);
 					universe.registerResidentUUID(resident);
 				}
-			} catch (Exception e) {
-				e.printStackTrace();
+			} catch (SQLException e) {
+				plugin.getLogger().log(Level.WARNING, "Could not get uuid column on the residents table", e);
 			}
 
 			try {
 				resident.setLastOnline(rs.getLong("lastOnline"));
-			} catch (Exception e) {
-				e.printStackTrace();
+			} catch (SQLException e) {
+				plugin.getLogger().log(Level.WARNING, "Could not get lastOnline column on the residents table", e);
 			}
+			
 			try {
 				resident.setRegistered(rs.getLong("registered"));
-			} catch (Exception e) {
-				e.printStackTrace();
+			} catch (SQLException e) {
+				plugin.getLogger().log(Level.WARNING, "Could not get registered column on the residents table", e);
 			}
+			
 			try {
 				resident.setJoinedTownAt(rs.getLong("joinedTownAt"));
-			} catch (Exception e) {
-				e.printStackTrace();
+			} catch (SQLException e) {
+				plugin.getLogger().log(Level.WARNING, "Could not get joinedTownAt column on the residents table", e);
 			}
+			
 			try {
 				resident.setNPC(rs.getBoolean("isNPC"));
-			} catch (Exception e) {
-				e.printStackTrace();
+			} catch (SQLException e) {
+				plugin.getLogger().log(Level.WARNING, "Could not get isNPC column on the residents table", e);
 			}
 			
 			if (rs.getString("jailUUID") != null && !rs.getString("jailUUID").isEmpty()) {
@@ -854,24 +853,27 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 					resident.setJail(universe.getJail(uuid));
 				}
 			}
+			
 			if (resident.isJailed()) {
 				try {
 					if (rs.getString("jailCell") != null && !rs.getString("jailCell").isEmpty())
 						resident.setJailCell(rs.getInt("jailCell"));
-				} catch (Exception e) {
-					e.printStackTrace();
+				} catch (SQLException e) {
+					plugin.getLogger().log(Level.WARNING, "Could not get jailCell column on the residents table", e);
 				}
+				
 				try {
 					if (rs.getString("jailHours") != null && !rs.getString("jailHours").isEmpty())
 						resident.setJailHours(rs.getInt("jailHours"));
-				} catch (Exception e) {
-					e.printStackTrace();
+				} catch (SQLException e) {
+					plugin.getLogger().log(Level.WARNING, "Could not get jailHours column on the residents table", e);
 				}
+				
 				try {
 					if (rs.getString("jailBail") != null && !rs.getString("jailBail").isEmpty())
 						resident.setJailBailCost(rs.getDouble("jailBail"));
-				} catch (Exception e) {
-					e.printStackTrace();
+				} catch (SQLException e) {
+					plugin.getLogger().log(Level.WARNING, "Could not get jailBail column on the residents table", e);
 				}
 			}
 
@@ -887,13 +889,14 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 						} catch (AlreadyRegisteredException ignored) {}
 					}
 				}
-			} catch (Exception e) {
-				e.printStackTrace();
+			} catch (SQLException e) {
+				plugin.getLogger().log(Level.WARNING, "Could not get friends column on the residents table", e);
 			}
+			
 			try {
 				resident.setPermissions(rs.getString("protectionStatus").replaceAll("#", ","));
-			} catch (Exception e) {
-				e.printStackTrace();
+			} catch (SQLException e) {
+				plugin.getLogger().log(Level.WARNING, "Could not get protectionStatus column on the residents table", e);
 			}
 
 			try {
@@ -916,13 +919,13 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 
 					try {
 						resident.setTitle(rs.getString("title"));
-					} catch (Exception e) {
-						e.printStackTrace();
+					} catch (SQLException e) {
+						plugin.getLogger().log(Level.WARNING, "Could not get title column on the residents table", e);
 					}
 					try {
 						resident.setSurname(rs.getString("surname"));
-					} catch (Exception e) {
-						e.printStackTrace();
+					} catch (SQLException e) {
+						plugin.getLogger().log(Level.WARNING, "Could not get surname column on the residents table", e);
 					}
 
 					try {
@@ -931,8 +934,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 							search = (line.contains("#")) ? "#" : ",";
 							resident.setTownRanks(Arrays.asList((line.split(search))));
 						}
-					} catch (Exception e) {
-					}
+					} catch (Exception ignored) {}
 
 					try {
 						line = rs.getString("nation-ranks");
@@ -940,16 +942,14 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 							search = (line.contains("#")) ? "#" : ",";
 							resident.setNationRanks(Arrays.asList((line.split(search))));
 						}
-					} catch (Exception e) {
-					}
+					} catch (Exception ignored) {}
 				}
 			}
 			return true;
 		} catch (SQLException e) {
 			TownyMessaging.sendErrorMsg("SQL: Load resident sql error : " + e.getMessage());
 		} catch (Exception e) {
-			TownyMessaging.sendErrorMsg("SQL: Load resident unknown error");
-			e.printStackTrace();
+			plugin.getLogger().log(Level.WARNING, "SQL: Load resident unknown error", e);
 		}
 		return false;
 	}
@@ -1275,8 +1275,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 		} catch (SQLException e) {
 			TownyMessaging.sendErrorMsg("SQL: Load Town " + name + " sql Error - " + e.getMessage());
 		} catch (Exception e) {
-			TownyMessaging.sendErrorMsg("SQL: Load Town " + name + " unknown Error - ");
-			e.printStackTrace();
+			plugin.getLogger().log(Level.WARNING, "SQL: Load Town " + name + " unknown Error - ", e);
 		}
 
 		return false;
@@ -1446,8 +1445,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 		} catch (SQLException e) {
 			TownyMessaging.sendErrorMsg("SQL: Load Nation " + name + " SQL Error - " + e.getMessage());
 		} catch (TownyException ex) {
-			TownyMessaging.sendErrorMsg("SQL: Load Nation " + name + " unknown Error - ");
-			ex.printStackTrace();
+			plugin.getLogger().log(Level.WARNING, "SQL: Load Nation " + name + " unknown Error - ", ex);
 		}
 
 		return false;
@@ -1983,9 +1981,8 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			}
 
 		} catch (SQLException ex) {
-			TownyMessaging.sendErrorMsg("Loading Error: Exception while reading TownBlock: "
-					+ (townBlock != null ? townBlock : "NULL") + " at line: " + line + " in the sql database");
-			ex.printStackTrace();
+			plugin.getLogger().log(Level.WARNING, "Loading Error: Exception while reading TownBlock: "
+					+ (townBlock != null ? townBlock : "NULL") + " at line: " + line + " in the sql database", ex);
 			return false;
 		}
 
@@ -2050,9 +2047,8 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 				} catch (Exception ignored) {}
 			}
 		} catch (SQLException e) {
-			TownyMessaging.sendErrorMsg("Loading Error: Exception while reading plot group: " + uuid
-			+ " at line: " + line + " in the sql database");
-			e.printStackTrace();
+			plugin.getLogger().log(Level.WARNING, "Loading Error: Exception while reading plot group: " + uuid
+			+ " at line: " + line + " in the sql database", e);
 			return false;
 		}
 		return true;
@@ -2158,8 +2154,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 		} catch (SQLException e) {
 			TownyMessaging.sendErrorMsg("SQL: Load Jail " + uuid + " sql Error - " + e.getMessage());
 		} catch (Exception e) {
-			TownyMessaging.sendErrorMsg("SQL: Load Jail " + uuid + " unknown Error - ");
-			e.printStackTrace();
+			plugin.getLogger().log(Level.WARNING, "SQL: Load Jail " + uuid + " unknown Error - ", e);
 		}
 
 		return false;
@@ -2318,8 +2313,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			return true;
 
 		} catch (Exception e) {
-			TownyMessaging.sendErrorMsg("SQL: Save Town unknown error");
-			e.printStackTrace();
+			plugin.getLogger().log(Level.WARNING, "SQL: Save Town unknown error", e);
 		}
 		return false;
 	}
@@ -2337,8 +2331,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			UpdateDB("PLOTGROUPS", pltgrp_hm, Collections.singletonList("groupID"));
 
 		} catch (Exception e) {
-			TownyMessaging.sendErrorMsg("SQL: Save Plot groups unknown error");
-			e.printStackTrace();
+			plugin.getLogger().log(Level.WARNING, "SQL: Save Plot groups unknown error", e);
 		}
 		return false;
 	}
@@ -2384,8 +2377,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			UpdateDB("NATIONS", nat_hm, Collections.singletonList("name"));
 
 		} catch (Exception e) {
-			TownyMessaging.sendErrorMsg("SQL: Save Nation unknown error");
-			e.printStackTrace();
+			plugin.getLogger().log(Level.WARNING, "SQL: Save Nation unknown error", e);
 		}
 		return false;
 	}
@@ -2504,8 +2496,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			UpdateDB("WORLDS", nat_hm, Collections.singletonList("name"));
 
 		} catch (Exception e) {
-			TownyMessaging.sendErrorMsg("SQL: Save world unknown error (" + world.getName() + ")");
-			e.printStackTrace();
+			plugin.getLogger().log(Level.WARNING, "SQL: Save world unknown error (" + world.getName() + ")", e);
 			return false;
 		}
 		return true;
@@ -2552,8 +2543,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			UpdateDB("TOWNBLOCKS", tb_hm, Arrays.asList("world", "x", "z"));
 
 		} catch (Exception e) {
-			TownyMessaging.sendErrorMsg("SQL: Save TownBlock unknown error");
-			e.printStackTrace();
+			plugin.getLogger().log(Level.WARNING, "SQL: Save TownBlock unknown error", e);
 		}
 		return true;
 	}
@@ -2581,8 +2571,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			UpdateDB("JAILS", jail_hm, Collections.singletonList("uuid"));
 			return true;
 		} catch (Exception e) {
-			TownyMessaging.sendErrorMsg("SQL: Save jail unknown error");
-			e.printStackTrace();
+			plugin.getLogger().log(Level.WARNING, "SQL: Save jail unknown error", e);
 		}
 		return true;
 		

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
@@ -52,6 +52,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
 
 /**
  * Author: Chris H (Zren / Shade)
@@ -100,9 +101,8 @@ public class TownyCustomListener implements Listener {
 				ChunkNotification chunkNotifier = new ChunkNotification(from, to);
 				msg = chunkNotifier.getNotificationString(resident);
 			} catch (NullPointerException e) {
-				plugin.getLogger().info("ChunkNotifier generated an NPE, this is harmless but if you'd like to report it the following information will be useful:");
-				plugin.getLogger().info("  Player: " + player.getName() + "  To: " + to.getWorldName() + "," + to.getX() + "," + to.getZ() + "  From: " + from.getWorldName() + "," + from.getX() + "," + from.getZ());
-				e.printStackTrace();
+				plugin.getLogger().log(Level.WARNING, "ChunkNotifier generated an NPE, this is harmless but if you'd like to report it the following information will be useful: " + System.lineSeparator() +
+					"  Player: " + player.getName() + "  To: " + to.getWorldName() + "," + to.getX() + "," + to.getZ() + "  From: " + from.getWorldName() + "," + from.getX() + "," + from.getZ(), e);
 			}
 			if (msg == null)
 				return;

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPaperEvents.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPaperEvents.java
@@ -27,6 +27,7 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.logging.Level;
 
 @ApiStatus.Internal
 public class TownyPaperEvents implements Listener {
@@ -126,7 +127,7 @@ public class TownyPaperEvents implements Listener {
 			try {
 				origin = (Location) GET_ORIGIN.invoke(event.getEntity());
 			} catch (final Throwable e) {
-				e.printStackTrace();
+				plugin.getLogger().log(Level.WARNING, "An exception occurred while invoking Entity#getOrigin reflectively", e);
 				return;
 			}
 			

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Resident.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Resident.java
@@ -291,13 +291,8 @@ public class Resident extends TownyObject implements InviteReceiver, EconomyHand
 		BukkitTools.fireEvent(new TownPreRemoveResidentEvent(this, town));
 		
 		try {
-			
 			town.removeResident(this);
-			
-		} catch (NotRegisteredException e1) {
-			e1.printStackTrace();
-		} catch (EmptyTownException ignore) {
-		}
+		} catch (NotRegisteredException | EmptyTownException ignored) {}
 
 		BukkitTools.fireEvent(new TownRemoveResidentEvent(this, town));
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Town.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Town.java
@@ -369,13 +369,10 @@ public class Town extends Government implements TownBlockOwner {
 
 		if (hasResident(resident))
 			throw new AlreadyRegisteredException(Translation.of("msg_err_already_in_town", resident.getName(), getFormattedName()));
-		else if (resident.hasTown())
-			try {
-				if (!resident.getTown().equals(this))
-					throw new AlreadyRegisteredException(Translation.of("msg_err_already_in_town", resident.getName(), resident.getTown().getFormattedName()));
-			} catch (NotRegisteredException e) {
-				e.printStackTrace();
-			}
+		
+		final Town residentTown = resident.getTownOrNull();
+		if (residentTown != null && !this.equals(residentTown)) {
+			throw new AlreadyRegisteredException(Translation.of("msg_err_already_in_town", resident.getName(), residentTown.getFormattedName()));			}
 	}
 
 	public boolean isMayor(Resident resident) {
@@ -1151,13 +1148,10 @@ public class Town extends Government implements TownBlockOwner {
 
 		if (hasOutlaw(resident))
 			throw new AlreadyRegisteredException(Translation.of("msg_err_resident_already_an_outlaw"));
-		else if (resident.hasTown())
-			try {
-				if (resident.getTown().equals(this))
-					throw new AlreadyRegisteredException(Translation.of("msg_err_not_outlaw_in_your_town"));
-			} catch (NotRegisteredException e) {
-				e.printStackTrace();
-			}
+		
+		final Town residentTown = resident.getTownOrNull();
+		if (this.equals(residentTown))
+			throw new AlreadyRegisteredException(Translation.of("msg_err_not_outlaw_in_your_town"));
 	}
 	
 	public void removeOutlaw(Resident resident) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownBlockTypeHandler.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownBlockTypeHandler.java
@@ -142,7 +142,7 @@ public final class TownBlockTypeHandler {
 				newData.put(name.toLowerCase(Locale.ROOT), townBlockType);
 				
 			} catch (Exception e) {
-				Towny.getPlugin().getLogger().log(Level.WARNING, "Config: Error while loading townblock type '%s', skipping...".formatted(name), e);
+				Towny.getPlugin().getLogger().log(Level.WARNING, String.format("Config: Error while loading townblock type '%s', skipping...", name), e);
 			}
 		}
 	}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownBlockTypeHandler.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownBlockTypeHandler.java
@@ -26,6 +26,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
 
 public final class TownBlockTypeHandler {
 	private final static Map<String, TownBlockType> townBlockTypeMap = new ConcurrentHashMap<>();
@@ -141,8 +142,7 @@ public final class TownBlockTypeHandler {
 				newData.put(name.toLowerCase(Locale.ROOT), townBlockType);
 				
 			} catch (Exception e) {
-				Towny.getPlugin().getLogger().warning(String.format("Config: Error while loading townblock type '%s', skipping...", name));
-				e.printStackTrace();
+				Towny.getPlugin().getLogger().log(Level.WARNING, "Config: Error while loading townblock type '%s', skipping...".formatted(name), e);
 			}
 		}
 	}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Translation.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Translation.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.IllegalFormatException;
 import java.util.Locale;
 import java.util.Map;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 /**
@@ -116,8 +117,7 @@ public final class Translation {
 		try {
 			return String.format(translated, args);
 		} catch (IllegalFormatException e) {
-			Towny.getPlugin().getLogger().warning("An exception occurred when formatting translation '" + translated + "' for {key=" + key + ",args=" + Arrays.toString(args) + "}, see the below error for more details");
-			e.printStackTrace();
+			Towny.getPlugin().getLogger().log(Level.WARNING, "An exception occurred when formatting translation '" + translated + "' for {key=" + key + ",args=" + Arrays.toString(args) + "}, see the below error for more details", e);
 			return translated;
 		}
 	}
@@ -154,8 +154,7 @@ public final class Translation {
 		try {
 			return String.format(of(key, locale), args);
 		} catch (IllegalFormatException e) {
-			Towny.getPlugin().getLogger().warning("An exception occurred when formatting translation '" + translated + "' for {key=" + key + ",locale=" + locale.toString() + ",args=" + Arrays.toString(args) + "}, see the below error for more details");
-			e.printStackTrace();
+			Towny.getPlugin().getLogger().log(Level.WARNING, "An exception occurred when formatting translation '" + translated + "' for {key=" + key + ",locale=" + locale + ",args=" + Arrays.toString(args) + "}, see the below error for more details", e);
 			return translated;
 		}
 	}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/TranslationLoader.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/TranslationLoader.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -177,8 +178,7 @@ public class TranslationLoader {
 					newTranslations.get(lang).put(entry.getKey().toLowerCase(Locale.ROOT), String.valueOf(entry.getValue()));
 			} catch (Exception e) {
 				// An IO exception occured, or the file had invalid yaml
-				plugin.getLogger().warning("Unabled to read yaml file: '" + lang + ".yml' from within the " + plugin.getName() + ".jar.");
-				e.printStackTrace();
+				plugin.getLogger().log(Level.WARNING, "Unabled to read yaml file: '" + lang + ".yml' from within the " + plugin.getName() + ".jar.", e);
 			}
 		}
 	}
@@ -197,7 +197,7 @@ public class TranslationLoader {
 					.forEach(p -> lang.add(FileNameUtils.getBaseName(p.toString())));
 			}
 		} catch (URISyntaxException | IOException e) {
-			e.printStackTrace();
+			plugin.getLogger().log(Level.WARNING, "An exception occurred while getting language file names from the plugin jar", e);
 		}
 		return lang;
 	}
@@ -229,8 +229,7 @@ public class TranslationLoader {
 					FileMgmt.writeString(langPath, string);
 			}
 		} catch (IOException e) {
-			plugin.getLogger().warning("Failed to copy " + "'/lang/" + lang + ".yml'" + " from the JAR to '" + langPath.toAbsolutePath() + "' during a reference language file update.");
-			e.printStackTrace();
+			plugin.getLogger().log(Level.WARNING, "Failed to copy " + "'/lang/" + lang + ".yml'" + " from the JAR to '" + langPath.toAbsolutePath() + "' during a reference language file update.", e);
 		}
 	}
 
@@ -260,8 +259,7 @@ public class TranslationLoader {
 								newTranslations.get(lang).put(entry.getKey().toLowerCase(Locale.ROOT), getTranslationValue(entry));
 						}
 					} catch (Exception e) {
-						plugin.getLogger().warning("Unabled to read yaml file: '" + file.getName() + "' in the override folder.");
-						e.printStackTrace();
+						plugin.getLogger().log(Level.WARNING, "Unabled to read yaml file: '" + file.getName() + "' in the override folder.", e);
 					}
 				}
 			}
@@ -363,7 +361,7 @@ public class TranslationLoader {
 		try (InputStream is = Files.newInputStream(globalYMLPath)) {
 			globalOverrides = new Yaml(new SafeConstructor(new LoaderOptions())).load(is);
 		} catch (Exception e) {
-			e.printStackTrace();
+			plugin.getLogger().log(Level.WARNING, "An exception occurred while reading the global.yml file", e);
 		}
 		return globalOverrides;
 	}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/comparators/ComparatorCaches.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/comparators/ComparatorCaches.java
@@ -5,7 +5,9 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 
+import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.object.Translatable;
 import com.google.common.cache.CacheBuilder;
@@ -31,21 +33,22 @@ import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
+import org.jetbrains.annotations.NotNull;
 
 public class ComparatorCaches {
 	
-	private static LoadingCache<ComparatorType, List<TextComponent>> townCompCache = CacheBuilder.newBuilder()
+	private static final LoadingCache<ComparatorType, List<TextComponent>> townCompCache = CacheBuilder.newBuilder()
 			.expireAfterWrite(10, TimeUnit.MINUTES)
-			.build(new CacheLoader<ComparatorType, List<TextComponent>>() {
-				public List<TextComponent> load(ComparatorType compType) throws Exception {
+			.build(new CacheLoader<>() {
+				public @NotNull List<TextComponent> load(@NotNull ComparatorType compType) {
 					return gatherTownLines(compType);
 				}
 			});
 	
-	private static LoadingCache<ComparatorType, List<TextComponent>> nationCompCache = CacheBuilder.newBuilder()
+	private static final LoadingCache<ComparatorType, List<TextComponent>> nationCompCache = CacheBuilder.newBuilder()
 			.expireAfterWrite(10, TimeUnit.MINUTES)
-			.build(new CacheLoader<ComparatorType, List<TextComponent>>() {
-				public List<TextComponent> load(ComparatorType compType) throws Exception {
+			.build(new CacheLoader<>() {
+				public @NotNull List<TextComponent> load(@NotNull ComparatorType compType) {
 					return gatherNationLines(compType);
 				}
 			}); 
@@ -54,7 +57,7 @@ public class ComparatorCaches {
 		try {
 			return townCompCache.get(compType);
 		} catch (ExecutionException e) {
-			e.printStackTrace();
+			Towny.getPlugin().getLogger().log(Level.WARNING, "exception occurred while updating town comparator cache", e);
 			return new ArrayList<>();
 		}
 	}
@@ -63,7 +66,7 @@ public class ComparatorCaches {
 		try {
 			return nationCompCache.get(compType);
 		} catch (ExecutionException e) {
-			e.printStackTrace();
+			Towny.getPlugin().getLogger().log(Level.WARNING, "exception occurred while updating nation comparator cache", e);
 			return new ArrayList<>();
 		}
 	}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/economy/Account.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/economy/Account.java
@@ -43,7 +43,7 @@ public abstract class Account implements Nameable {
 		try {
 			this.cachedBalance = new CachedBalance(getHoldingBalance(false));
 		} catch (Exception e) {
-			Towny.getPlugin().getLogger().log(Level.WARNING, "An exception occurred when initializing cached balance for an account (name: %s), see the below error for more details.".formatted(name), e);
+			Towny.getPlugin().getLogger().log(Level.WARNING, String.format("An exception occurred when initializing cached balance for an account (name: %s), see the below error for more details.", name), e);
 			
 			this.cachedBalance = new CachedBalance(0);
 		}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/economy/Account.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/economy/Account.java
@@ -13,6 +13,7 @@ import org.bukkit.World;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Level;
 
 /**
  * Used to facilitate transactions regarding money, 
@@ -42,8 +43,7 @@ public abstract class Account implements Nameable {
 		try {
 			this.cachedBalance = new CachedBalance(getHoldingBalance(false));
 		} catch (Exception e) {
-			Towny.getPlugin().getLogger().warning(String.format("An exception occurred when initializing cached balance for an account (name: %s), see the below error for more details.", name));
-			e.printStackTrace();
+			Towny.getPlugin().getLogger().log(Level.WARNING, "An exception occurred when initializing cached balance for an account (name: %s), see the below error for more details.".formatted(name), e);
 			
 			this.cachedBalance = new CachedBalance(0);
 		}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/metadata/MetadataLoader.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/metadata/MetadataLoader.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
 
 public class MetadataLoader {
 	
@@ -69,8 +70,7 @@ public class MetadataLoader {
 			fields = DataFieldIO.deserializeMeta(serializedMetadata);
 		} catch (IOException e) {
 			// Unsure if logger is loaded at this point
-			Towny.getPlugin().getLogger().warning("Error loading metadata for towny object " + object.getClass().getName() + object.getName() + "!");
-			e.printStackTrace();
+			Towny.getPlugin().getLogger().log(Level.WARNING, "Error loading metadata for towny object " + object.getClass().getName() + object.getName() + "!", e);
 		}
 		
 		if (!fields.isEmpty()) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/TownyPerms.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/TownyPerms.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
+import java.util.logging.Level;
 
 /**
  * @author ElgarL
@@ -61,14 +62,14 @@ public class TownyPerms {
 		TownyPerms.plugin = plugin;
 	}
 	
-	private static final MethodHandle permissions;
+	private static final MethodHandle PERMISSIONS;
 
 	// Setup reflection (Thanks to Codename_B for the reflection source)
 	static {
 		try {
 			Field permissionsField = PermissionAttachment.class.getDeclaredField("permissions");
 			permissionsField.setAccessible(true);
-			permissions = MethodHandles.lookup().unreflectGetter(permissionsField);
+			PERMISSIONS = MethodHandles.lookup().unreflectGetter(permissionsField);
 		} catch (ReflectiveOperationException e) {
 			throw new RuntimeException(e);
 		}
@@ -137,6 +138,7 @@ public class TownyPerms {
 	 * @param resident - Resident to check if player is valid
 	 * @param player - Player to register permission
 	 */
+	@SuppressWarnings("unchecked")
 	public static void assignPermissions(Resident resident, Player player) {
 
 		if (resident == null) {
@@ -173,7 +175,7 @@ public class TownyPerms {
 		 */
 
 		try {
-			final Map<String, Boolean> orig = (Map<String, Boolean>) permissions.invoke(attachment);
+			final Map<String, Boolean> orig = (Map<String, Boolean>) PERMISSIONS.invoke(attachment);
 			/*
 			 * Clear the map (faster than removing the attachment and
 			 * recalculating)
@@ -192,7 +194,7 @@ public class TownyPerms {
 			*/
 			player.recalculatePermissions();
 		} catch (final Throwable e) {
-			e.printStackTrace();
+			plugin.getLogger().log(Level.WARNING, "exception occurred while assigning permissions to player " + player.getName(), e);
 		}
 		
 		/*

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/OnPlayerLogin.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/OnPlayerLogin.java
@@ -204,7 +204,7 @@ public class OnPlayerLogin implements Runnable {
 				try {
 					TownyUniverse.getInstance().registerResidentUUID(resident);
 				} catch (AlreadyRegisteredException e) {
-					e.printStackTrace();
+					plugin.getLogger().log(Level.WARNING, "uuid for resident " + resident.getName() + " was already registered! (" + player.getUniqueId() + ")", e);
 				}
 				TownySettings.incrementUUIDCount();
 			}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/ProtectionRegenTask.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/ProtectionRegenTask.java
@@ -68,13 +68,9 @@ public class ProtectionRegenTask extends TownyTimerTask {
 		Block block = state.getBlock();
 		
 		// Replace physical block.
-		try {
-			BlockData blockData = state.getBlockData().clone();			
-			block.setType(state.getType(), false);
-			block.setBlockData(blockData);
-		} catch (Exception ex) {
-			ex.printStackTrace();
-		}
+		BlockData blockData = state.getBlockData().clone();			
+		block.setType(state.getType(), false);
+		block.setBlockData(blockData);
 		
 		// If the state is a creature spawner, then replace properly.
 		if (state instanceof CreatureSpawner) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/ResidentUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/ResidentUtil.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 import com.palmergames.bukkit.towny.object.TownBlockType;
@@ -222,7 +223,7 @@ public class ResidentUtil {
 			npc.setNPC(true);
 			npc.save();
 		} catch (TownyException e) {
-			e.printStackTrace();
+			Towny.getPlugin().getLogger().log(Level.WARNING, "exception occurred while creating new npc resident", e);
 		}
 		
 		return npc;

--- a/Towny/src/main/java/com/palmergames/bukkit/util/NameValidation.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/NameValidation.java
@@ -1,5 +1,6 @@
 package com.palmergames.bukkit.util;
 
+import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.exceptions.InvalidNameException;
 
@@ -7,6 +8,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Locale;
+import java.util.logging.Level;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -153,7 +155,7 @@ public class NameValidation {
 				namePattern = Pattern.compile(TownySettings.getNameCheckRegex(), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
 			return namePattern.matcher(name).find();
 		} catch (PatternSyntaxException e) {
-			e.printStackTrace();
+			Towny.getPlugin().getLogger().log(Level.WARNING, "Failed to compile the name check regex pattern because it contains errors (" + TownySettings.getNameCheckRegex() + ")", e);
 			return false;
 		}
 		
@@ -176,7 +178,7 @@ public class NameValidation {
 				stringPattern = Pattern.compile(TownySettings.getStringCheckRegex(), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
 			return stringPattern.matcher(message).find();
 		} catch (PatternSyntaxException e) {
-			e.printStackTrace();
+			Towny.getPlugin().getLogger().log(Level.WARNING, "Failed to compile the string check regex pattern because it contains errors (" + TownySettings.getStringCheckRegex() + ")", e);
 			return false;
 		}
 	}

--- a/Towny/src/main/java/com/palmergames/util/FileMgmt.java
+++ b/Towny/src/main/java/com/palmergames/util/FileMgmt.java
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
@@ -181,7 +182,7 @@ public final class FileMgmt {
 
 				return true;
 			} catch (IOException e) {
-				e.printStackTrace();
+				Towny.getPlugin().getLogger().log(Level.WARNING, "An exception occurred while writing to " + targetLocation, e);
 				return false;
 			}
 		} finally {
@@ -280,10 +281,8 @@ public final class FileMgmt {
                     zos.write(buffer, 0, len);
                 }
             }			
-		} catch (FileNotFoundException e) {
-			e.printStackTrace();
 		} catch (IOException e) {
-			e.printStackTrace();
+			Towny.getPlugin().getLogger().log(Level.WARNING, "An exception occurred while zipping up file " + file.getName(), e);
 		} finally {
 			writeLock.unlock();
 		}
@@ -436,7 +435,7 @@ public final class FileMgmt {
 					keys.put(key, String.valueOf(value));
 				}
 			} catch (IOException e) {
-				e.printStackTrace();
+				Towny.getPlugin().getLogger().log(Level.WARNING, "An exception occurred while reading file " + file.getName(), e);
 			}
 			return keys;
 		} finally {
@@ -469,7 +468,7 @@ public final class FileMgmt {
 					fout.writeUTF(block);
 			}
 		} catch (IOException e1) {
-			e1.printStackTrace();
+			Towny.getPlugin().getLogger().log(Level.WARNING, "An exception occurred while saving plot data to " + file.getName(), e1);
 		} finally {
 			writeLock.unlock();
 		}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Changes all of our uses of printStackTraces to use our logger instead, and removes some redundant catches entirely. The benefit of this is so that stacktraces can easily be attributed back to us, which services like sentry use.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
