### PR TITLE
Add reload listeners to some timer tasks

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -3433,12 +3433,21 @@ public class TownySettings {
 		return getString(ConfigNodes.ASCII_MAP_SYMBOLS_WILDERNESS);
 	}
 
-	public static void addReloadListener(NamespacedKey key, Consumer<CommentedConfiguration> consumer) {
-		if (!CONFIG_RELOAD_LISTENERS.containsKey(key))
-			CONFIG_RELOAD_LISTENERS.put(key, consumer);
+	public static void addReloadListener(NamespacedKey key, @NotNull Consumer<CommentedConfiguration> consumer) {
+		if (key == null)
+			throw new IllegalArgumentException("Key cannot be null");
+		
+		CONFIG_RELOAD_LISTENERS.putIfAbsent(key, consumer);
 	}
 	
-	public static void removeReloadListener(NamespacedKey key) {
+	public static void addReloadListener(NamespacedKey key, @NotNull Runnable runnable) {
+		if (key == null)
+			throw new IllegalArgumentException("Key cannot be null");
+
+		CONFIG_RELOAD_LISTENERS.putIfAbsent(key, config -> runnable.run());
+	}
+	
+	public static void removeReloadListener(@NotNull NamespacedKey key) {
 		CONFIG_RELOAD_LISTENERS.remove(key);
 	}
 	

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/DrawSpawnPointsTask.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/DrawSpawnPointsTask.java
@@ -1,10 +1,17 @@
 package com.palmergames.bukkit.towny.tasks;
 
 import com.palmergames.bukkit.towny.Towny;
+import com.palmergames.bukkit.towny.TownySettings;
+import com.palmergames.bukkit.towny.TownyTimerHandler;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.object.SpawnPoint;
+import org.bukkit.NamespacedKey;
 
 public class DrawSpawnPointsTask extends TownyTimerTask {
+	static {
+		TownySettings.addReloadListener(NamespacedKey.fromString("towny:spawnpoint-task"), () -> TownyTimerHandler.toggleDrawSpointsTask(TownySettings.getVisualizedSpawnPointsEnabled()));
+	}
+	
 	public DrawSpawnPointsTask(Towny plugin) {
 		super(plugin);
 	}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/HealthRegenTimerTask.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/HealthRegenTimerTask.java
@@ -1,6 +1,9 @@
 package com.palmergames.bukkit.towny.tasks;
 
+import com.palmergames.bukkit.towny.TownySettings;
+import com.palmergames.bukkit.towny.TownyTimerHandler;
 import com.palmergames.bukkit.towny.object.Town;
+import org.bukkit.NamespacedKey;
 import org.bukkit.Server;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.Player;
@@ -15,6 +18,9 @@ import com.palmergames.bukkit.towny.utils.CombatUtil;
 import com.palmergames.bukkit.util.BukkitTools;
 
 public class HealthRegenTimerTask extends TownyTimerTask {
+	static {
+		TownySettings.addReloadListener(NamespacedKey.fromString("towny:health-regen-task"), () -> TownyTimerHandler.toggleHealthRegen(TownySettings.hasHealthRegen()));
+	}
 
 	private final Server server;
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/TeleportWarmupTimerTask.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/TeleportWarmupTimerTask.java
@@ -4,6 +4,7 @@ import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.TownyEconomyHandler;
 import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.TownySettings;
+import com.palmergames.bukkit.towny.TownyTimerHandler;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.TeleportRequest;
 import com.palmergames.bukkit.towny.object.Translatable;
@@ -12,6 +13,7 @@ import com.palmergames.bukkit.towny.object.economy.Account;
 import io.papermc.lib.PaperLib;
 
 import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.jetbrains.annotations.NotNull;
@@ -27,6 +29,10 @@ import java.util.concurrent.ConcurrentHashMap;
 public class TeleportWarmupTimerTask extends TownyTimerTask {
 
 	private static final Map<Resident, TeleportRequest> TELEPORT_QUEUE = new ConcurrentHashMap<>();
+	
+	static {
+		TownySettings.addReloadListener(NamespacedKey.fromString("towny:warmup-task"), () -> TownyTimerHandler.toggleTeleportWarmup(TownySettings.getTeleportWarmupTime() > 0));
+	}
 
 	public TeleportWarmupTimerTask(Towny plugin) {
 		super(plugin);


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Starts/stops the timers when the config option changes after a config reload, so that the value of the option always matches the state of the task.
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
