### PR TITLE
Use paper's isWaxed API for signs

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -1447,11 +1447,8 @@ public class TownyPlayerListener implements Listener {
 	}
 	
 	private boolean isSignWaxed(Block block) {
-		if (MinecraftVersion.CURRENT_VERSION.isOlderThan(MinecraftVersion.MINECRAFT_1_20) || !(PaperLib.getBlockState(block, false).getState() instanceof Sign sign))
+		if (IS_WAXED == null || MinecraftVersion.CURRENT_VERSION.isOlderThan(MinecraftVersion.MINECRAFT_1_20) || !(PaperLib.getBlockState(block, false).getState() instanceof Sign sign))
 			return false;
-		
-		if (IS_WAXED == null)
-			return false; // Always treat as not waxed on spigot
 		
 		try {
 			return (boolean) IS_WAXED.invoke(sign);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -435,7 +435,7 @@ public class TownyPlayerListener implements Listener {
 				/*
 				 * Prevents players using wax on signs
 				 */
-				if (item == Material.HONEYCOMB && Tag.SIGNS.isTagged(clickedMat) && MinecraftVersion.CURRENT_VERSION.isNewerThanOrEquals(MinecraftVersion.MINECRAFT_1_20) && PaperLib.getBlockState(clickedBlock, false).getState() instanceof Sign sign && !isSignWaxed(sign) && !TownyActionEventExecutor.canItemuse(player, clickedBlock.getLocation(), clickedMat)) {
+				if (item == Material.HONEYCOMB && Tag.SIGNS.isTagged(clickedMat) && !isSignWaxed(clickedBlock) && !TownyActionEventExecutor.canItemuse(player, clickedBlock.getLocation(), clickedMat)) {
 					event.setCancelled(true);
 					return;
 				}
@@ -486,7 +486,7 @@ public class TownyPlayerListener implements Listener {
 			/*
 			 * Prevents players from editing signs where they shouldn't.
 			 */
-			if (Tag.SIGNS.isTagged(clickedMat) && MinecraftVersion.CURRENT_VERSION.isNewerThanOrEquals(MinecraftVersion.MINECRAFT_1_20) && PaperLib.getBlockState(clickedBlock, false).getState() instanceof Sign sign && !isSignWaxed(sign))
+			if (Tag.SIGNS.isTagged(clickedMat) && !isSignWaxed(clickedBlock))
 				event.setCancelled(!TownyActionEventExecutor.canDestroy(player, clickedBlock.getLocation(), clickedMat));
 		}
 	}
@@ -1446,7 +1446,10 @@ public class TownyPlayerListener implements Listener {
 		this.ownPlotLimitedCommands = new CommandList(TownySettings.getPlayerOwnedPlotLimitedCommands());
 	}
 	
-	private boolean isSignWaxed(Sign sign) {
+	private boolean isSignWaxed(Block block) {
+		if (MinecraftVersion.CURRENT_VERSION.isOlderThan(MinecraftVersion.MINECRAFT_1_20) || !(PaperLib.getBlockState(block, false).getState() instanceof Sign sign))
+			return false;
+		
 		if (IS_WAXED == null)
 			return false; // Always treat as not waxed on spigot
 		

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -44,6 +44,7 @@ import com.palmergames.bukkit.util.ChatTools;
 import com.palmergames.bukkit.util.ItemLists;
 import com.palmergames.util.StringMgmt;
 
+import io.papermc.lib.PaperLib;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -51,10 +52,11 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.Tag;
 import org.bukkit.World.Environment;
 import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.Sign;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.Rotatable;
 import org.bukkit.block.data.type.RespawnAnchor;
-import org.bukkit.block.data.type.Sign;
-import org.bukkit.block.data.type.WallSign;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
@@ -84,6 +86,8 @@ import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.metadata.MetadataValue;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collection;
@@ -107,6 +111,19 @@ public class TownyPlayerListener implements Listener {
 	private CommandList blockedOutlawCommands;
 	private CommandList blockedWarCommands;
 	private CommandList ownPlotLimitedCommands;
+	
+	private static final MethodHandle IS_WAXED;
+	
+	static {
+		MethodHandle temp = null;
+		try {
+			// https://jd.papermc.io/paper/1.20/org/bukkit/block/Sign.html#isWaxed()
+			//noinspection JavaReflectionMemberAccess
+			temp = MethodHandles.publicLookup().unreflect(Sign.class.getMethod("isWaxed"));
+		} catch (Throwable ignored) {}
+		
+		IS_WAXED = temp;
+	}
 
 	public TownyPlayerListener(Towny plugin) {
 		this.plugin = plugin;
@@ -417,10 +434,11 @@ public class TownyPlayerListener implements Listener {
 
 				/*
 				 * Prevents players using wax on signs
-				 * TODO: Add a check for whether the sign is waxed once that API is available.
 				 */
-				if (Tag.SIGNS.isTagged(clickedMat) && item == Material.HONEYCOMB && MinecraftVersion.CURRENT_VERSION.isNewerThanOrEquals(MinecraftVersion.MINECRAFT_1_20))
-					event.setCancelled(!TownyActionEventExecutor.canItemuse(player, clickedBlock.getLocation(), clickedMat));
+				if (item == Material.HONEYCOMB && Tag.SIGNS.isTagged(clickedMat) && MinecraftVersion.CURRENT_VERSION.isNewerThanOrEquals(MinecraftVersion.MINECRAFT_1_20) && PaperLib.getBlockState(clickedBlock, false).getState() instanceof Sign sign && !isSignWaxed(sign) && !TownyActionEventExecutor.canItemuse(player, clickedBlock.getLocation(), clickedMat)) {
+					event.setCancelled(true);
+					return;
+				}
 				
 				/*
 				 * Prevents players from using brushes on brush-able blocks (suspicious sand, suspicious gravel)
@@ -468,7 +486,7 @@ public class TownyPlayerListener implements Listener {
 			/*
 			 * Prevents players from editing signs where they shouldn't.
 			 */
-			if (Tag.SIGNS.isTagged(clickedMat) && MinecraftVersion.CURRENT_VERSION.isNewerThanOrEquals(MinecraftVersion.MINECRAFT_1_20))
+			if (Tag.SIGNS.isTagged(clickedMat) && MinecraftVersion.CURRENT_VERSION.isNewerThanOrEquals(MinecraftVersion.MINECRAFT_1_20) && PaperLib.getBlockState(clickedBlock, false).getState() instanceof Sign sign && !isSignWaxed(sign))
 				event.setCancelled(!TownyActionEventExecutor.canDestroy(player, clickedBlock.getLocation(), clickedMat));
 		}
 	}
@@ -1334,21 +1352,14 @@ public class TownyPlayerListener implements Listener {
 				&& event.getClickedBlock() != null) {
 					Player player = event.getPlayer();
 					Block block = event.getClickedBlock();
+					final BlockState state = PaperLib.getBlockState(block, false).getState();
+					final BlockData data = state.getBlockData();
 					
-					if (Tag.SIGNS.isTagged(block.getType())) {
-						BlockFace facing = null;
-						if (block.getBlockData() instanceof Sign) {
-							org.bukkit.block.data.type.Sign sign = (org.bukkit.block.data.type.Sign) block.getBlockData();
-							facing = sign.getRotation();
-						}
-						if (block.getBlockData() instanceof WallSign)  { 
-							org.bukkit.block.data.type.WallSign sign = (org.bukkit.block.data.type.WallSign) block.getBlockData();
-							facing = sign.getFacing();	
-						}
+					if (Tag.SIGNS.isTagged(block.getType()) && data instanceof Rotatable rotatable) {
 						TownyMessaging.sendMessage(player, Arrays.asList(
 								ChatTools.formatTitle("Sign Info"),
 								ChatTools.formatCommand("", "Sign Type", "", block.getType().name()),
-								ChatTools.formatCommand("", "Facing", "", facing.toString())
+								ChatTools.formatCommand("", "Facing", "", rotatable.getRotation().toString())
 								));
 					} else if (Tag.DOORS.isTagged(block.getType())) {
 						org.bukkit.block.data.type.Door door = (org.bukkit.block.data.type.Door) block.getBlockData();
@@ -1433,5 +1444,17 @@ public class TownyPlayerListener implements Listener {
 		this.blockedOutlawCommands = new CommandList(TownySettings.getOutlawBlacklistedCommands());
 		this.blockedWarCommands = new CommandList(TownySettings.getWarBlacklistedCommands());
 		this.ownPlotLimitedCommands = new CommandList(TownySettings.getPlayerOwnedPlotLimitedCommands());
+	}
+	
+	private boolean isSignWaxed(Sign sign) {
+		if (IS_WAXED == null)
+			return false; // Always treat as not waxed on spigot
+		
+		try {
+			return (boolean) IS_WAXED.invoke(sign);
+		} catch (Throwable throwable) {
+			// Shouldn't be happening but treat as not waxed just in case
+			return false;
+		}
 	}
 }


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Adds a check to our editing/waxing protection for signs to prevent the event from being cancelled if the sign is already waxed. The reason we're not just using spigot's isEditable method is because it only returns true if the sign is not waxed and there is a player actively editing the sign.
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
