### PR TITLE
Add option to allow enemies to spawn to neutral/peaceful towns.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -802,6 +802,12 @@ public enum ConfigNodes {
 			"",
 			"# Prevent players from using /town spawn while within unclaimed areas and/or enemy/neutral towns.",
 			"# Allowed options: unclaimed,enemy,neutral,outlaw"),
+	GTOWN_SETTINGS_ENEMIES_ALLOWED_TO_SPAWN_TO_PEACEFUL_TOWNS(
+			"global_town_settings.allow_enemies_spawn_to_peaceful_towns",
+			"false",
+			"",
+			"# When true, players will be allowed to spawn to peaceful/neutral towns in which they are considered enemies.",
+			"# Setting this to true will make town spawn points unsafe for private towns which are part of nations with enemies."),
 	GTOWN_RESPAWN_ANCHOR_HIGHER_PRECEDENCE(
 			"global_town_settings.respawn_anchor_higher_precendence",
 			"true",

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -1731,7 +1731,11 @@ public class TownySettings {
 	public static List<String> getDisallowedTownSpawnZones() {
 		return getStrArr(ConfigNodes.GTOWN_SETTINGS_PREVENT_TOWN_SPAWN_IN);
 	}
-	
+
+	public static boolean areEnemiesAllowedToSpawnToPeacefulTowns() {
+		return getBoolean(ConfigNodes.GTOWN_SETTINGS_ENEMIES_ALLOWED_TO_SPAWN_TO_PEACEFUL_TOWNS);
+	}
+
 	public static boolean isSpawnWarnConfirmationUsed() {
 		return getBoolean(ConfigNodes.GTOWN_SETTINGS_SPAWN_WARNINGS);
 	}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/SpawnUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/SpawnUtil.java
@@ -291,8 +291,12 @@ public class SpawnUtil {
 					else
 						townSpawnLevel = TownSpawnLevel.PART_OF_NATION;
 				} else if (targetNation.hasEnemy(playerNation)) {
-					// Prevent enemies from using spawn travel.
-					throw new TownyException(Translatable.of("msg_err_public_spawn_enemy"));
+					if (town.isNeutral() && TownySettings.areEnemiesAllowedToSpawnToPeacefulTowns())
+						// Let enemies spawn to peaceful towns.
+						townSpawnLevel = TownSpawnLevel.TOWN_RESIDENT;
+					else 
+						// Prevent enemies from using spawn travel.
+						throw new TownyException(Translatable.of("msg_err_public_spawn_enemy"));
 				} else if (targetNation.hasAlly(playerNation)) {
 					if (!town.isPublic() && 
 						(TownySettings.isAllySpawningRequiringPublicStatus() && !resident.hasPermissionNode(PermissionNodes.TOWNY_SPAWN_ALLY_BYPASS_PUBLIC.getNode())))


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
```
  - New Config Option: global_town_settings.allow_enemies_spawn_to_peaceful_towns
    - Default: false
    - When true, players will be allowed to spawn to peaceful/neutral towns in which they are considered enemies.
    - Setting this to true will make town spawn points unsafe for private towns which are part of nations with enemies.
```


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

Closes #6401.

____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
