### PR TITLE
Fix hanging signs not being edit protected

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -389,7 +389,7 @@ public class TownyPlayerListener implements Listener {
 				 * Treat interaction as a Destroy test.
 				 */
 				if ((ItemLists.AXES.contains(item) && (ItemLists.UNSTRIPPED_WOOD.contains(clickedMat) || ItemLists.WAXED_BLOCKS.contains(clickedMat) || ItemLists.WEATHERABLE_BLOCKS.contains(clickedMat))) ||
-					(ItemLists.DYES.contains(item) && Tag.SIGNS.isTagged(clickedMat)) ||
+					(ItemLists.DYES.contains(item) && ItemLists.SIGNS.contains(clickedMat)) ||
 					(item == Material.FLINT_AND_STEEL && clickedMat == Material.TNT) ||
 					((item == Material.GLASS_BOTTLE || item == Material.SHEARS) && (clickedMat == Material.BEE_NEST || clickedMat == Material.BEEHIVE || clickedMat == Material.PUMPKIN))) { 
 
@@ -435,7 +435,7 @@ public class TownyPlayerListener implements Listener {
 				/*
 				 * Prevents players using wax on signs
 				 */
-				if (item == Material.HONEYCOMB && Tag.SIGNS.isTagged(clickedMat) && !isSignWaxed(clickedBlock) && !TownyActionEventExecutor.canItemuse(player, clickedBlock.getLocation(), clickedMat)) {
+				if (item == Material.HONEYCOMB && ItemLists.SIGNS.contains(clickedMat) && !isSignWaxed(clickedBlock) && !TownyActionEventExecutor.canItemuse(player, clickedBlock.getLocation(), clickedMat)) {
 					event.setCancelled(true);
 					return;
 				}
@@ -486,7 +486,7 @@ public class TownyPlayerListener implements Listener {
 			/*
 			 * Prevents players from editing signs where they shouldn't.
 			 */
-			if (Tag.SIGNS.isTagged(clickedMat) && !isSignWaxed(clickedBlock))
+			if (ItemLists.SIGNS.contains(clickedMat) && !isSignWaxed(clickedBlock))
 				event.setCancelled(!TownyActionEventExecutor.canDestroy(player, clickedBlock.getLocation(), clickedMat));
 		}
 	}
@@ -1355,7 +1355,7 @@ public class TownyPlayerListener implements Listener {
 					final BlockState state = PaperLib.getBlockState(block, false).getState();
 					final BlockData data = state.getBlockData();
 					
-					if (Tag.SIGNS.isTagged(block.getType()) && data instanceof Rotatable rotatable) {
+					if (ItemLists.SIGNS.contains(block.getType()) && data instanceof Rotatable rotatable) {
 						TownyMessaging.sendMessage(player, Arrays.asList(
 								ChatTools.formatTitle("Sign Info"),
 								ChatTools.formatCommand("", "Sign Type", "", block.getType().name()),

--- a/Towny/src/main/java/com/palmergames/bukkit/util/ItemLists.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/ItemLists.java
@@ -83,7 +83,7 @@ public class ItemLists extends AbstractRegistryList<Material> {
 	/**
 	 * List of Signs.
 	 */
-	public static final ItemLists SIGNS = newBuilder().withTag(Tag.REGISTRY_BLOCKS, minecraft("signs")).endsWith("_SIGN").build();
+	public static final ItemLists SIGNS = newBuilder().withTag(Tag.REGISTRY_BLOCKS, minecraft("all_signs")).endsWith("_SIGN").build();
 
 	/**
 	 * List of Torches

--- a/Towny/src/main/java/com/palmergames/bukkit/util/ItemLists.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/ItemLists.java
@@ -83,7 +83,7 @@ public class ItemLists extends AbstractRegistryList<Material> {
 	/**
 	 * List of Signs.
 	 */
-	public static final ItemLists SIGNS = newBuilder().withTag(Tag.REGISTRY_BLOCKS, minecraft("all_signs")).endsWith("_SIGN").build();
+	public static final ItemLists SIGNS = newBuilder().withTag(Tag.REGISTRY_BLOCKS, minecraft("signs")).withTag(Tag.REGISTRY_BLOCKS, minecraft("all_signs")).endsWith("_SIGN").build();
 
 	/**
 	 * List of Torches


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Instead of modifying the existing sign tag, vanilla instead added a new all_signs tag which made our tests not catch hanging signs. The signs itemlist already contained hanging signs via the endsWith but also has the all_signs tag now just in case.
____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #6780

____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
