### PR TITLE
Remove useless volatile keyword in OnPlayerLogin

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/OnPlayerLogin.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/OnPlayerLogin.java
@@ -35,9 +35,9 @@ import java.util.logging.Level;
  */
 public class OnPlayerLogin implements Runnable {
 	
-	Towny plugin;
-	com.palmergames.bukkit.towny.TownyUniverse universe;
-	volatile Player player;
+	private final Towny plugin;
+	private final TownyUniverse universe = TownyUniverse.getInstance();
+	private final Player player;
 	
 	/**
 	 * Constructor
@@ -48,7 +48,6 @@ public class OnPlayerLogin implements Runnable {
 	public OnPlayerLogin(Towny plugin, Player player) {
 		
 		this.plugin = plugin;
-		this.universe = com.palmergames.bukkit.towny.TownyUniverse.getInstance();
 		this.player = player;
 	}
 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
The player field is never reassigned so having it as volatile seems a bit useless, at least from my understanding of it
____
- [N/A] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
