### PR TITLE
Make explicitly false nodes bypass towny admin check

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyMessaging.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyMessaging.java
@@ -931,7 +931,7 @@ public class TownyMessaging {
 	public static void sendMsgToOnlineAdmins(Translatable message) {
 		sendMsg(message);
 		for (Player player : Bukkit.getOnlinePlayers())
-			if (player.isOp() || player.hasPermission("towny.admin"))
+			if (TownyUniverse.getInstance().getPermissionSource().isTownyAdmin(player))
 				sendMsg(player, message);
 	}
 	

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -937,7 +937,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			throw new TownyException("Player couldn't be found");
 		}
 		String node = split[1];
-		if (player.hasPermission(node))
+		if (TownyUniverse.getInstance().getPermissionSource().testPermission(player, node))
 			TownyMessaging.sendMsg(sender, Translatable.of("msg_perm_true"));
 		else
 			TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_perm_false"));


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Allows admins to have both towny.admin permissions while still negating some specific permissions.
Also removes a weird '-'-prefixed permission check being done, was likely just an artifact of the past.
____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #6543 (no longer needed)

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
