### PR TITLE
Remove reflection for isWaxed method

### DIFF
--- a/Towny/pom.xml
+++ b/Towny/pom.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.20-R0.1-SNAPSHOT</version>
+            <version>1.20.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -112,20 +112,10 @@ public class TownyPlayerListener implements Listener {
 	private CommandList blockedWarCommands;
 	private CommandList ownPlotLimitedCommands;
 	
-	private static final MethodHandle IS_WAXED;
 	private static final MethodHandle GET_RESPAWN_FLAGS;
 	
 	static {
 		MethodHandle temp = null;
-		try {
-			// https://jd.papermc.io/paper/1.20/org/bukkit/block/Sign.html#isWaxed()
-			//noinspection JavaReflectionMemberAccess
-			temp = MethodHandles.publicLookup().unreflect(Sign.class.getMethod("isWaxed"));
-		} catch (Throwable ignored) {}
-		
-		IS_WAXED = temp;
-		
-		temp = null;
 		try {
 			// https://jd.papermc.io/paper/1.20/org/bukkit/event/player/PlayerRespawnEvent.html#getRespawnFlags()
 			//noinspection JavaReflectionMemberAccess
@@ -1413,13 +1403,13 @@ public class TownyPlayerListener implements Listener {
 	}
 	
 	private boolean isSignWaxed(Block block) {
-		if (IS_WAXED == null || MinecraftVersion.CURRENT_VERSION.isOlderThan(MinecraftVersion.MINECRAFT_1_20) || !(PaperLib.getBlockState(block, false).getState() instanceof Sign sign))
+		if (MinecraftVersion.CURRENT_VERSION.isOlderThan(MinecraftVersion.MINECRAFT_1_20) || !(PaperLib.getBlockState(block, false).getState() instanceof Sign sign))
 			return false;
 		
 		try {
-			return (boolean) IS_WAXED.invoke(sign);
-		} catch (Throwable throwable) {
-			// Shouldn't be happening but treat as not waxed just in case
+			return sign.isWaxed();
+		} catch (NoSuchMethodError e) {
+			// Method does not exist in this version
 			return false;
 		}
 	}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
The latest spigot builds now have an isWaxed method, so reflection is no longer needed for it.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
