### PR TITLE
New overclaiming restrictions/features.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -203,6 +203,18 @@ public enum ConfigNodes {
 			"",
 			"# While true, overclaiming is stopped by the min_distance_from_town_homeblock setting below.",
 			"# This prevents a town from having townblocks stolen surrounding their homeblocks."),
+	TOWN_OVERCLAIMING_TOWN_AGE_REQUIREMENT(
+			"town.overclaiming.town_age_requirement",
+			"7d",
+			"",
+			"# When in use, requires that a town be of a minimum age in order to overclaim another town. This prevents new towns being made just to overclaim someone.",
+			"# Default is for 7 days."),
+	TOWN_OVERCLAIMING_COMMAND_COOLDOWN(
+			"town.overclaiming.command_cooldown",
+			"0m",
+			"",
+			"# When in use, requires an amount of time to pass before the /t takeoverclaim command can be used again."),
+
 	TOWN_LIMIT(
 			"town.town_limit",
 			"3000",

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/Towny.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/Towny.java
@@ -1,4 +1,4 @@
- package com.palmergames.bukkit.towny;
+package com.palmergames.bukkit.towny;
 
 import com.earth2me.essentials.Essentials;
 import com.palmergames.bukkit.config.CommentedConfiguration;

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/Towny.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/Towny.java
@@ -1,4 +1,4 @@
-package com.palmergames.bukkit.towny;
+ package com.palmergames.bukkit.towny;
 
 import com.earth2me.essentials.Essentials;
 import com.palmergames.bukkit.config.CommentedConfiguration;

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -529,6 +529,16 @@ public class TownySettings {
 		}
 	}
 
+	public static long getMillis(ConfigNodes node) {
+
+		try {
+			return TimeTools.getMillis(getString(node));
+		} catch (NumberFormatException e) {
+			sendError(node.getRoot().toLowerCase(Locale.ROOT) + " from config.yml");
+			return 1;
+		}
+	}
+
 	public static void addComment(String root, String... comments) {
 
 		newConfig.addComment(root.toLowerCase(Locale.ROOT), comments);
@@ -1493,6 +1503,14 @@ public class TownySettings {
 
 	public static boolean isOverClaimingPreventedByHomeBlockRadius() {
 		return getBoolean(ConfigNodes.TOWN_OVERCLAIMING_PREVENTED_BY_HOMEBLOCK_RADIUS);
+	}
+
+	public static long getOverclaimingTownAgeRequirement() {
+		return getMillis(ConfigNodes.TOWN_OVERCLAIMING_TOWN_AGE_REQUIREMENT);
+	}
+
+	public static int getOverclaimingCommandCooldownInSeconds() {
+		return (int) getSeconds(ConfigNodes.TOWN_OVERCLAIMING_COMMAND_COOLDOWN);
 	}
 
 	public static boolean isSellingBonusBlocks(Town town) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -3923,6 +3923,13 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 
 		Town town = getTownFromPlayerOrThrow(player);
 
+		long ageRequirement = TownySettings.getOverclaimingTownAgeRequirement();
+		if (ageRequirement > 0l) {
+			long ageNeeded = System.currentTimeMillis() - ageRequirement;
+			if (ageNeeded < town.getRegistered())
+				throw new TownyException(Translatable.of("msg_err_your_town_is_not_old_enough_to_overclaim", TimeMgmt.getFormattedTimeValue(town.getRegistered() - ageNeeded)));
+		}
+
 		// Make sure this wouldn't end up becoming a homeblock.
 		if (town.getTownBlocks().size() == 0)
 			throw new TownyException(Translatable.of("msg_err_you_cannot_make_this_your_homeblock"));

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/TownClaim.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/TownClaim.java
@@ -17,6 +17,8 @@ import com.palmergames.bukkit.towny.object.WorldCoord;
 import com.palmergames.bukkit.towny.regen.PlotBlockData;
 import com.palmergames.bukkit.towny.regen.TownyRegenAPI;
 import com.palmergames.bukkit.util.BukkitTools;
+import com.palmergames.util.TimeMgmt;
+
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
@@ -182,6 +184,12 @@ public class TownClaim implements Runnable {
 		// If this is an occaision where a town is stealing this land, do the
 		// prep to clean the old town from the townblock.
 		if (alreadyClaimed) {
+			if (TownySettings.getOverclaimingCommandCooldownInSeconds() > 0 &&
+				CooldownTimerTask.hasCooldown(town.getUUID().toString(), "overclaimingcooldown")) {
+				long req = CooldownTimerTask.getCooldownRemaining(town.getUUID().toString(), "overclaimingcooldown") * 1000;
+				throw new TownyException(Translatable.of("msg_err_your_cannot_overclaim_for_another", TimeMgmt.getFormattedTimeValue(req)));
+			}
+
 			Town oldTown = worldCoord.getTownOrNull();
 
 			//  Fire an event for other plugins.
@@ -197,6 +205,9 @@ public class TownClaim implements Runnable {
 			// - Removing the town's jail if it is.
 			// - Removing the oldTown's nation spawn point.
 			// - Updating the oldTown's TownBlockTypeCache.
+			
+			if (TownySettings.getOverclaimingCommandCooldownInSeconds() > 0)
+				CooldownTimerTask.addCooldownTimer(town.getUUID().toString(), "overclaimingcooldown", TownySettings.getOverclaimingCommandCooldownInSeconds());
 		}
 
 		townBlock.setTown(town);

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -1965,3 +1965,7 @@ msg_your_town_was_exempt_from_the_nation_conquered_tax: "<aqua>Your town was exe
 msg_nation_set_conquered_tax__amount_set: "%s has set the conquered tax amount to %s."
 
 msg_err_cannot_set_nation_conquere_tax_amount_higher_than: "You cannot set the conquered tax above %s."
+
+msg_err_your_town_is_not_old_enough_to_overclaim: "Your town is not old enough to overclaim, you must wait another %s."
+
+msg_err_your_cannot_overclaim_for_another: "You cannot overclaim again for another %s."


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
````
  - Add new options to the overclaiming feature:
    - A configurable cooldown between using /t takeoverclaim.
    - A configurable age requirement to prevent new towns using /t takeoverclaim.
    - Closes #6734.
  - New Config Option: town.overclaiming.town_age_requirement
    - Default: 7d - When in use, requires that a town be of a minimum age in order to overclaim another town. This prevents new towns being made just to overclaim someone.
    - Default is for 7 days.
  - New Config Option: town.overclaiming.command_cooldown 
    - Default: 0m 
    - When in use, requires an amount of time to pass before the /t takeoverclaim command can be used again.
````
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #6734.

____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
