### PR TITLE
Fix isUpperCased failing on underscores

### DIFF
--- a/Towny/pom.xml
+++ b/Towny/pom.xml
@@ -13,7 +13,7 @@
 
     <artifactId>towny</artifactId>
     <packaging>jar</packaging>
-    <version>0.99.3.0</version>
+    <version>0.99.3.1</version>
 
     <licenses>
         <license>

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -236,6 +236,11 @@ public class TownyPlayerListener implements Listener {
 		
 		event.setRespawnLocation(respawn);
 		
+		System.out.println("Towny has set a respawn location: " + respawn.toString());
+		Town town = TownyAPI.getInstance().getTown(respawn);
+		if (town != null)
+			System.out.println("Town at that location: " + town.getName());
+
 		// Handle Spawn protection
 		long protectionTime = TownySettings.getSpawnProtectionDuration();
 		if (protectionTime > 0L) {

--- a/Towny/src/main/java/com/palmergames/util/StringMgmt.java
+++ b/Towny/src/main/java/com/palmergames/util/StringMgmt.java
@@ -218,8 +218,12 @@ public class StringMgmt {
 		if (string.isEmpty())
 			return false;
 
+		char underscore = '_';
 		for (int i = 0; i < string.length(); i++) {
-			if (!Character.isUpperCase(string.charAt(i)))
+			char character = string.charAt(i);
+			if (character == underscore)
+				continue;
+			if (!Character.isUpperCase(character))
 				return false;
 		}
 		return true;

--- a/Towny/src/main/resources/config-migration.json
+++ b/Towny/src/main/resources/config-migration.json
@@ -530,5 +530,16 @@
         "worldAction": "UPDATE_WORLD_UNCLAIM_REVERT_ENTITIES"
       }
     ]
+  },
+  {
+    "version": "0.99.3.1",
+    "changes": [
+      {
+        "type": "APPEND",
+        "path": "new_world_settings.plot_management.wild_revert_on_mob_explosion.entities",
+        "value": ",CREEPER",
+        "worldAction": "UPDATE_WORLD_EXPLOSION_REVERT_ENTITIES"
+      }
+    ]
   }
 ]


### PR DESCRIPTION

<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
The isUpperCased test meant that we were constantly re-converting the entity-expl-revert list (and maybe more).

This resulted in the CREEPER being changed into minecraft:creeper, which is not a valid option in our Entity registry. This resulted in the CREEPER being removed from the list of entities whose explosions we would revert.

What is still not working, and I have not had enough time to diagnose:

The config migration results I added has resulted in the world's PlotManagementWildRegenEntities being wiped, and I can see no evidence of the worldAction being done at all.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
