### PR TITLE
Fix matchRegistry filtering out ':'

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/util/BukkitTools.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/BukkitTools.java
@@ -359,7 +359,7 @@ public class BukkitTools {
 	 */
 	@Nullable
 	public static <T extends Keyed> T matchRegistry(Registry<T> registry, String input) {
-		final String filtered = input.toLowerCase(Locale.ROOT).replaceAll("\\s+", "_").replaceAll("\\W", "");
+		final String filtered = input.toLowerCase(Locale.ROOT).replaceAll("\\s+", "_").replaceAll("[^a-zA-Z0-9_:]", "");
 
 		final NamespacedKey key = NamespacedKey.fromString(filtered);
 		return key != null ? registry.get(key) : null;


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
\W is equivalent to [^a-zA-Z0-9_] which doesn't include the : character, so if we passed minecraft:creeper to it it'd change that to minecraftcreeper which is obviously not a valid name.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
