### PR TITLE
Fix exception being thrown for empty key

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -409,6 +409,9 @@ public class TownySettings {
 		Set<EntityType> entities = new HashSet<>();
 		
 		for (String entityName : entityList) {
+			if (entityName.isEmpty())
+				continue;
+			
 			EntityType type = BukkitTools.matchRegistry(Registry.ENTITY_TYPE, entityName);
 			if (type != null)
 				entities.add(type);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -409,9 +409,6 @@ public class TownySettings {
 		Set<EntityType> entities = new HashSet<>();
 		
 		for (String entityName : entityList) {
-			if (entityName.isEmpty())
-				continue;
-			
 			EntityType type = BukkitTools.matchRegistry(Registry.ENTITY_TYPE, entityName);
 			if (type != null)
 				entities.add(type);

--- a/Towny/src/main/java/com/palmergames/bukkit/util/BukkitTools.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/BukkitTools.java
@@ -358,8 +358,10 @@ public class BukkitTools {
 	 * Our own copy of {@link Registry#match(String)}, since this method did not exist on the currently lowest supported version, 1.16.
 	 */
 	@Nullable
-	public static <T extends Keyed> T matchRegistry(Registry<T> registry, String input) {
+	public static <T extends Keyed> T matchRegistry(@NotNull Registry<T> registry, @NotNull String input) {
 		final String filtered = input.toLowerCase(Locale.ROOT).replaceAll("\\s+", "_").replaceAll("[^a-zA-Z0-9_:]", "");
+		if (filtered.isEmpty())
+			return null;
 
 		final NamespacedKey key = NamespacedKey.fromString(filtered);
 		return key != null ? registry.get(key) : null;


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Return null early if the filtered key is empty, not sure if the wild regen entities being empty is due to a different issue but this fixes part of it at least.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
