### PR TITLE
Add ignored entity spawn reason option

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1662,6 +1662,13 @@ public enum ConfigNodes {
 			"false",
 			"",
 			"# Prevent the spawning of villager babies in towns."),
+	PROT_MOB_REMOVE_IGNORED_SPAWN_CAUSES(
+			"protection.town_mob_removal_ignored_spawn_causes",
+			"",
+			"",
+			"# A comma seperated list of spawn causes, if an entity has a spawn cause that is in this list they will not be removed by town mob removal.",
+			"# For the list of valid spawn causes, see https://jd.papermc.io/paper/1.20/org/bukkit/event/entity/CreatureSpawnEvent.SpawnReason.html",
+			"# Due to technical reasons, this setting only works on Paper servers."),
 
 	PROT_MOB_DISABLE_TRIGGER_PRESSURE_PLATE_STONE(
 			"protection.disable_creature_pressureplate_stone",

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
@@ -366,7 +366,7 @@ public class TownyEntityListener implements Listener {
 
 		// ignore Citizens NPCs and named-mobs (if configured.) 
 		LivingEntity livingEntity = event.getEntity();
-		if (entityIsExempt(livingEntity))
+		if (entityIsExempt(livingEntity, event.getSpawnReason()))
 			return;
 
 		final TownyWorld townyWorld = TownyAPI.getInstance().getTownyWorld(event.getEntity().getWorld());
@@ -385,9 +385,10 @@ public class TownyEntityListener implements Listener {
 		}
 	}
 
-	private boolean entityIsExempt(LivingEntity livingEntity) {
+	private boolean entityIsExempt(LivingEntity livingEntity, CreatureSpawnEvent.SpawnReason spawnReason) {
 		return PluginIntegrations.getInstance().checkCitizens(livingEntity)
-			|| entityIsExemptByName(livingEntity);
+			|| entityIsExemptByName(livingEntity)
+			|| MobRemovalTimerTask.isSpawnReasonIgnored(livingEntity, spawnReason);
 	}
 
 	private boolean entityIsExemptByName(LivingEntity livingEntity) {


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Uses a paper specific method to allow us to check an entity's spawn reason outside the actual creature spawn event, there's currently a bug in Paper where summoned entities have a spawn reason of DEFAULT but that will be fixed soon.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
New config option: protection.town_mob_removal_ignored_spawn_causes
Default: "" (none)
A comma seperated list of spawn causes, if an entity has a spawn cause that is in this list they will not be removed by town mob removal.
For the list of valid spawn causes, see https://jd.papermc.io/paper/1.20/org/bukkit/event/entity/CreatureSpawnEvent.SpawnReason.html
Due to technical reasons, this setting only works on Paper servers.
____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #6832

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
