### PR TITLE
Remove unneeded filtering from matchRegistry

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/util/BukkitTools.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/BukkitTools.java
@@ -369,7 +369,7 @@ public class BukkitTools {
 	 */
 	@Nullable
 	public static <T extends Keyed> T matchRegistry(@NotNull Registry<T> registry, @NotNull String input) {
-		final String filtered = input.toLowerCase(Locale.ROOT).replaceAll("\\s+", "_").replaceAll("[^a-zA-Z0-9_:]", "");
+		final String filtered = input.toLowerCase(Locale.ROOT).replaceAll("\\s+", "_");
 		if (filtered.isEmpty())
 			return null;
 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
The actual matchRegistry doesn't have this second replace, no idea where I got it from. This prevents us from removing valid namespace/key characters like - and /. If the input contains invalid characters then the fromString method will just silently fail by returning null.
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
