### PR TITLE
Use material key for cache debug message

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/PlayerCacheUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/PlayerCacheUtil.java
@@ -77,7 +77,7 @@ public class PlayerCacheUtil {
 			cache.updateCoord(worldCoord);
 
 			boolean result = cache.getCachePermission(material, action); // Throws NullPointerException if the cache is empty
-			TownyMessaging.sendDebugMsg("Cache permissions for " + player.getName() + " using " + material + ":" + action + " = " + result);
+			TownyMessaging.sendDebugMsg("Cache permissions for " + player.getName() + " using " + material.getKey() + ":" + action + " = " + result);
 			return result;
 
 		} catch (NullPointerException e) {


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
The new cache created message already uses the material key instead of it's name, but the existing cache message didn't.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
