### PR TITLE
Cache a townblock's worldcoord/pos

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/WorldCoord.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/WorldCoord.java
@@ -94,7 +94,11 @@ public class WorldCoord extends Coord {
 	}
 	
 	public static WorldCoord parseWorldCoord(Location loc) {
-		return new WorldCoord(loc.getWorld(), toCell(loc.getBlockX()), toCell(loc.getBlockZ()));
+		final World world = loc.getWorld();
+		if (world == null)
+			throw new IllegalArgumentException("Provided location does not have an associated world");
+		
+		return new WorldCoord(world, toCell(loc.getBlockX()), toCell(loc.getBlockZ()));
 	}
 
 	public static WorldCoord parseWorldCoord(Block block) {
@@ -147,6 +151,9 @@ public class WorldCoord extends Coord {
 		if (world == null) {
 			world = Bukkit.getServer().getWorld(this.worldName);
 			worldRef = new WeakReference<>(world);
+			
+			if (this.worldUUID == null && world != null)
+				this.worldUUID = world.getUID();
 		}
 		
 		return world;
@@ -197,7 +204,7 @@ public class WorldCoord extends Coord {
 	}
 	
 	public boolean hasTown(Town town) {
-		return hasTownBlock() && getTownOrNull().equals(town);
+		return town != null && town.equals(getTownOrNull());
 	}
 
 	/**
@@ -271,8 +278,7 @@ public class WorldCoord extends Coord {
 
 	// Used to get a location at the corner of a WorldCoord.
 	private Location getCorner() {
-		Location loc = new Location(getBukkitWorld(), getX() * getCellSize(), 0, getZ() * getCellSize());
-		return loc;
+		return new Location(getBukkitWorld(), getX() * getCellSize(), 0, getZ() * getCellSize());
 	}
 	
 	// Used to get a location representing sub coordinates of a WorldCoord, to ease the lookup of a corresponding Chunk. 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Instead of creating a new WorldCoord object for every getWorldCoord call, we can just cache it in a field. Also does some small cleanup and deprecates setZ/X since worldcoords are immutable.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
