### PR TITLE
Fix personal permission line loading in TownBlocks.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -1685,10 +1685,6 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 						} catch (Exception ignored) {
 						}
 					
-					line = keys.get("type");
-					if (line != null)
-						townBlock.setType(TownBlockTypeHandler.getTypeInternal(line));
-					
 					line = keys.get("resident");
 					if (line != null && !line.isEmpty()) {
 						Resident res = universe.getResident(line.trim());
@@ -1699,6 +1695,10 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 							TownyMessaging.sendErrorMsg(Translation.of("flatfile_err_invalid_townblock_resident", townBlock.toString()));
 						}
 					}
+					
+					line = keys.get("type");
+					if (line != null)
+						townBlock.setType(TownBlockTypeHandler.getTypeInternal(line));
 					
 					line = keys.get("price");
 					if (line != null)

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -1835,10 +1835,6 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 					}
 				}
 
-				line = rs.getString("type");
-				if (line != null)
-					townBlock.setType(TownBlockTypeHandler.getTypeInternal(line));
-
 				line = rs.getString("resident");
 				if (line != null && !line.isEmpty()) {
 					Resident res = universe.getResident(line.trim());
@@ -1851,6 +1847,10 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 						));
 					}
 				}
+
+				line = rs.getString("type");
+				if (line != null)
+					townBlock.setType(TownBlockTypeHandler.getTypeInternal(line));
 
 				line = rs.getString("price");
 				if (line != null)


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Because we're setting a townblock's type before the resident, while loading most of the plot types are choosing the permission line of the town, when the changed flag is also false.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #6856 
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
