### PR TITLE
Fix Towny uncancelling PlayerInteractEvents.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -62,6 +62,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
+import org.bukkit.event.Event.Result;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -357,8 +358,8 @@ public class TownyPlayerListener implements Listener {
 			/*
 			 * Test item_use. 
 			 */
-			if (TownySettings.isItemUseMaterial(item, loc))
-				event.setCancelled(!TownyActionEventExecutor.canItemuse(player, loc, item));
+			if (TownySettings.isItemUseMaterial(item, loc) && !TownyActionEventExecutor.canItemuse(player, loc, item))
+				event.setUseItemInHand(Result.DENY);
 
 			/*
 			 * Test other Items using non-ItemUse test.
@@ -388,58 +389,67 @@ public class TownyPlayerListener implements Listener {
 					(item == Material.FLINT_AND_STEEL && clickedMat == Material.TNT) ||
 					((item == Material.GLASS_BOTTLE || item == Material.SHEARS) && (clickedMat == Material.BEE_NEST || clickedMat == Material.BEEHIVE || clickedMat == Material.PUMPKIN))) { 
 
-					event.setCancelled(!TownyActionEventExecutor.canDestroy(player, loc, clickedMat));
+					if (!TownyActionEventExecutor.canDestroy(player, loc, clickedMat))
+						event.setUseItemInHand(Result.DENY);
 				}
 
 				/*
 				 * Test bonemeal usage. Treat interaction as a Build test.
 				 */
-				if (item == Material.BONE_MEAL) 
-					event.setCancelled(!TownyActionEventExecutor.canBuild(player, loc, item));
+				if (item == Material.BONE_MEAL && !TownyActionEventExecutor.canBuild(player, loc, item))
+					event.setUseItemInHand(Result.DENY);
 				
 				/*
 				 * Test putting candles on cakes. Treat interaction as a Build test.
 				 */
-				if (ItemLists.CANDLES.contains(item) && clickedMat == Material.CAKE) 
-					event.setCancelled(!TownyActionEventExecutor.canBuild(player, loc, item));
+				if (ItemLists.CANDLES.contains(item) && clickedMat == Material.CAKE &&
+						!TownyActionEventExecutor.canBuild(player, loc, item))
+					event.setUseItemInHand(Result.DENY);
 				
 				/*
 				 * Test wax usage. Treat interaction as a Build test.
 				 */
-				if (item == Material.HONEYCOMB && ItemLists.WEATHERABLE_BLOCKS.contains(clickedMat))
-					event.setCancelled(!TownyActionEventExecutor.canBuild(player, loc, item));
+				if (item == Material.HONEYCOMB && ItemLists.WEATHERABLE_BLOCKS.contains(clickedMat) &&
+						!TownyActionEventExecutor.canBuild(player, loc, item))
+					event.setUseItemInHand(Result.DENY);
 
 				/*
 				 * Test if we're about to spawn either entity. Uses build test.
 				 */
-				if (item == Material.ARMOR_STAND || item == Material.END_CRYSTAL) 
-					event.setCancelled(!TownyActionEventExecutor.canBuild(player, clickedBlock.getRelative(event.getBlockFace()).getLocation(), item));
+				if (item == Material.ARMOR_STAND || item == Material.END_CRYSTAL &&
+						!TownyActionEventExecutor.canBuild(player, clickedBlock.getRelative(event.getBlockFace()).getLocation(), item))
+					event.setUseItemInHand(Result.DENY);
 
 				/*
 				 * Test if we're putting a book into a BookContainer.
 				 */
-				if (ItemLists.PLACEABLE_BOOKS.contains(item) && ItemLists.BOOK_CONTAINERS.contains(clickedMat))
-					event.setCancelled(!TownyActionEventExecutor.canBuild(player, loc, item));
+				if (ItemLists.PLACEABLE_BOOKS.contains(item) && ItemLists.BOOK_CONTAINERS.contains(clickedMat) &&
+						!TownyActionEventExecutor.canBuild(player, loc, item))
+					event.setUseItemInHand(Result.DENY);
 
 				/*
 				 * Catches hoes taking dirt from Rooted Dirt blocks.
 				 */
-				if (clickedMat.getKey().equals(NamespacedKey.minecraft("rooted_dirt")) && ItemLists.HOES.contains(item))
-					event.setCancelled(!TownyActionEventExecutor.canDestroy(player, clickedBlock));
+				if (clickedMat.getKey().equals(NamespacedKey.minecraft("rooted_dirt")) && ItemLists.HOES.contains(item) &&
+						!TownyActionEventExecutor.canDestroy(player, loc, clickedMat))
+					event.setUseItemInHand(Result.DENY);
+
 
 				/*
 				 * Prevents players using wax on signs
 				 */
-				if (item == Material.HONEYCOMB && ItemLists.SIGNS.contains(clickedMat) && !isSignWaxed(clickedBlock) && !TownyActionEventExecutor.canItemuse(player, clickedBlock.getLocation(), clickedMat)) {
-					event.setCancelled(true);
+				if (item == Material.HONEYCOMB && ItemLists.SIGNS.contains(clickedMat) && !isSignWaxed(clickedBlock) &&
+						!TownyActionEventExecutor.canItemuse(player, clickedBlock.getLocation(), clickedMat)) {
+					event.setUseItemInHand(Result.DENY);
 					return;
 				}
 				
 				/*
 				 * Prevents players from using brushes on brush-able blocks (suspicious sand, suspicious gravel)
 				 */
-				if (ItemLists.BRUSHABLE_BLOCKS.contains(clickedMat) && item == Material.BRUSH && !TownyActionEventExecutor.canDestroy(player, clickedBlock))
-					event.setCancelled(true);
+				if (ItemLists.BRUSHABLE_BLOCKS.contains(clickedMat) && item == Material.BRUSH &&
+						!TownyActionEventExecutor.canDestroy(player, clickedBlock))
+					event.setUseItemInHand(Result.DENY);
 			}
 		}
 		
@@ -451,9 +461,9 @@ public class TownyPlayerListener implements Listener {
 			/*
 			 * Test switch use.
 			 */
-			if (TownySettings.isSwitchMaterial(clickedMat, clickedBlock.getLocation())) {
+			if (TownySettings.isSwitchMaterial(clickedMat, clickedBlock.getLocation()) && !TownyActionEventExecutor.canSwitch(player, clickedBlock.getLocation(), clickedMat)) {
 				//Make decision on whether this is allowed using the PlayerCache and then a cancellable event.
-				event.setCancelled(!TownyActionEventExecutor.canSwitch(player, clickedBlock.getLocation(), clickedMat));
+				event.setUseInteractedBlock(Result.DENY);
 				return;
 			}
 			/*
@@ -474,7 +484,8 @@ public class TownyPlayerListener implements Listener {
 				clickedMat == Material.COMMAND_BLOCK){
 				
 				//Make decision on whether this is allowed using the PlayerCache and then a cancellable event.
-				event.setCancelled(!TownyActionEventExecutor.canDestroy(player, clickedBlock.getLocation(), clickedMat));
+				if (!TownyActionEventExecutor.canDestroy(player, clickedBlock.getLocation(), clickedMat))
+					event.setUseInteractedBlock(Result.DENY);
 				return;
 			}
 			
@@ -482,8 +493,9 @@ public class TownyPlayerListener implements Listener {
 			 * Prevents players from editing signs where they shouldn't.
 			 * This check is only used when our listener for paper's sign open event is not in use, since that event fires when the sign is actually opened instead of interact.
 			 */
-			if (TownyPaperEvents.SIGN_OPEN_GET_CAUSE == null && ItemLists.SIGNS.contains(clickedMat) && !isSignWaxed(clickedBlock))
-				event.setCancelled(!TownyActionEventExecutor.canDestroy(player, clickedBlock.getLocation(), clickedMat));
+			if (TownyPaperEvents.SIGN_OPEN_GET_CAUSE == null && ItemLists.SIGNS.contains(clickedMat) && !isSignWaxed(clickedBlock) &&
+					!TownyActionEventExecutor.canDestroy(player, clickedBlock.getLocation(), clickedMat))
+				event.setUseInteractedBlock(Result.DENY);
 		}
 	}
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -379,14 +379,18 @@ public class TownyPlayerListener implements Listener {
 
 				/*
 				 * Test stripping logs, scraping copper blocks, dye-able signs,
-				 * glass bottles, flint&steel on TNT and shears on beehomes
+				 * glass bottles, flint&steel on TNT and shears on beehomes,
+				 * catches hoes taking dirt from Rooted Dirt blocks,
+				 * prevents players from using brushes on brush-able blocks (suspicious sand, suspicious gravel)
 				 * 
 				 * Treat interaction as a Destroy test.
 				 */
 				if ((ItemLists.AXES.contains(item) && (ItemLists.UNSTRIPPED_WOOD.contains(clickedMat) || ItemLists.WAXED_BLOCKS.contains(clickedMat) || ItemLists.WEATHERABLE_BLOCKS.contains(clickedMat))) ||
 					(ItemLists.DYES.contains(item) && ItemLists.SIGNS.contains(clickedMat)) ||
 					(item == Material.FLINT_AND_STEEL && clickedMat == Material.TNT) ||
-					((item == Material.GLASS_BOTTLE || item == Material.SHEARS) && (clickedMat == Material.BEE_NEST || clickedMat == Material.BEEHIVE || clickedMat == Material.PUMPKIN))) { 
+					((item == Material.GLASS_BOTTLE || item == Material.SHEARS) && (clickedMat == Material.BEE_NEST || clickedMat == Material.BEEHIVE || clickedMat == Material.PUMPKIN)) ||
+					clickedMat.getKey().equals(NamespacedKey.minecraft("rooted_dirt")) && ItemLists.HOES.contains(item) ||
+					ItemLists.BRUSHABLE_BLOCKS.contains(clickedMat) && item == Material.BRUSH) { 
 
 					if (!TownyActionEventExecutor.canDestroy(player, loc, clickedMat))
 						event.setCancelled(true);
@@ -399,18 +403,20 @@ public class TownyPlayerListener implements Listener {
 					event.setCancelled(true);
 				
 				/*
-				 * Test putting candles on cakes. Treat interaction as a Build test.
+				 * Test putting candles on cakes.
+				 * Test wax usage.
+				 * Test putting plants in pots.
+				 * Test if we're putting a book into a BookContainer.
+				 * Treat interaction as a Build test.
 				 */
-				if (ItemLists.CANDLES.contains(item) && clickedMat == Material.CAKE &&
-						!TownyActionEventExecutor.canBuild(player, loc, item))
-					event.setCancelled(true);
-				
-				/*
-				 * Test wax usage. Treat interaction as a Build test.
-				 */
-				if (item == Material.HONEYCOMB && ItemLists.WEATHERABLE_BLOCKS.contains(clickedMat) &&
-						!TownyActionEventExecutor.canBuild(player, loc, item))
-					event.setCancelled(true);
+				if ((ItemLists.CANDLES.contains(item) && clickedMat == Material.CAKE) ||  
+					ItemLists.PLANTS.contains(item) && clickedMat == Material.FLOWER_POT ||
+					item == Material.HONEYCOMB && ItemLists.WEATHERABLE_BLOCKS.contains(clickedMat) ||
+					ItemLists.PLACEABLE_BOOKS.contains(item) && ItemLists.BOOK_CONTAINERS.contains(clickedMat)) {
+
+					if (!TownyActionEventExecutor.canBuild(player, loc, item))
+						event.setCancelled(true);
+				}
 
 				/*
 				 * Test if we're about to spawn either entity. Uses build test.
@@ -420,21 +426,6 @@ public class TownyPlayerListener implements Listener {
 					event.setCancelled(true);
 
 				/*
-				 * Test if we're putting a book into a BookContainer.
-				 */
-				if (ItemLists.PLACEABLE_BOOKS.contains(item) && ItemLists.BOOK_CONTAINERS.contains(clickedMat) &&
-						!TownyActionEventExecutor.canBuild(player, loc, item))
-					event.setCancelled(true);
-
-				/*
-				 * Catches hoes taking dirt from Rooted Dirt blocks.
-				 */
-				if (clickedMat.getKey().equals(NamespacedKey.minecraft("rooted_dirt")) && ItemLists.HOES.contains(item) &&
-						!TownyActionEventExecutor.canDestroy(player, loc, clickedMat))
-					event.setCancelled(true);
-
-
-				/*
 				 * Prevents players using wax on signs
 				 */
 				if (item == Material.HONEYCOMB && ItemLists.SIGNS.contains(clickedMat) && !isSignWaxed(clickedBlock) &&
@@ -442,13 +433,6 @@ public class TownyPlayerListener implements Listener {
 					event.setCancelled(true);
 					return;
 				}
-				
-				/*
-				 * Prevents players from using brushes on brush-able blocks (suspicious sand, suspicious gravel)
-				 */
-				if (ItemLists.BRUSHABLE_BLOCKS.contains(clickedMat) && item == Material.BRUSH &&
-						!TownyActionEventExecutor.canDestroy(player, clickedBlock))
-					event.setCancelled(true);
 			}
 		}
 		

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -357,8 +357,10 @@ public class TownyPlayerListener implements Listener {
 			/*
 			 * Test item_use. 
 			 */
-			if (TownySettings.isItemUseMaterial(item, loc) && !TownyActionEventExecutor.canItemuse(player, loc, item))
+			if (TownySettings.isItemUseMaterial(item, loc) && !TownyActionEventExecutor.canItemuse(player, loc, item)) {
 				event.setCancelled(true);
+				return;
+			}
 
 			/*
 			 * Test other Items using non-ItemUse test.
@@ -394,43 +396,44 @@ public class TownyPlayerListener implements Listener {
 
 					if (!TownyActionEventExecutor.canDestroy(player, loc, clickedMat))
 						event.setCancelled(true);
+					return;
 				}
 
-				/*
-				 * Test bonemeal usage. Treat interaction as a Build test.
-				 */
-				if (item == Material.BONE_MEAL && !TownyActionEventExecutor.canBuild(player, loc, item))
-					event.setCancelled(true);
-				
 				/*
 				 * Test putting candles on cakes.
 				 * Test wax usage.
 				 * Test putting plants in pots.
 				 * Test if we're putting a book into a BookContainer.
+				 * Test bonemeal usage.
+				 * 
 				 * Treat interaction as a Build test.
 				 */
 				if ((ItemLists.CANDLES.contains(item) && clickedMat == Material.CAKE) ||  
 					ItemLists.PLANTS.contains(item) && clickedMat == Material.FLOWER_POT ||
 					item == Material.HONEYCOMB && ItemLists.WEATHERABLE_BLOCKS.contains(clickedMat) ||
-					ItemLists.PLACEABLE_BOOKS.contains(item) && ItemLists.BOOK_CONTAINERS.contains(clickedMat)) {
+					ItemLists.PLACEABLE_BOOKS.contains(item) && ItemLists.BOOK_CONTAINERS.contains(clickedMat) ||
+					item == Material.BONE_MEAL && !TownyActionEventExecutor.canBuild(player, loc, item)) {
 
 					if (!TownyActionEventExecutor.canBuild(player, loc, item))
 						event.setCancelled(true);
+					return;
 				}
 
 				/*
 				 * Test if we're about to spawn either entity. Uses build test.
 				 */
-				if (item == Material.ARMOR_STAND || item == Material.END_CRYSTAL &&
-						!TownyActionEventExecutor.canBuild(player, clickedBlock.getRelative(event.getBlockFace()).getLocation(), item))
-					event.setCancelled(true);
+				if (item == Material.ARMOR_STAND || item == Material.END_CRYSTAL) {
+					if (!TownyActionEventExecutor.canBuild(player, clickedBlock.getRelative(event.getBlockFace()).getLocation(), item))
+						event.setCancelled(true);
+					return;
+				}
 
 				/*
 				 * Prevents players using wax on signs
 				 */
-				if (item == Material.HONEYCOMB && ItemLists.SIGNS.contains(clickedMat) && !isSignWaxed(clickedBlock) &&
-						!TownyActionEventExecutor.canItemuse(player, clickedBlock.getLocation(), clickedMat)) {
-					event.setCancelled(true);
+				if (item == Material.HONEYCOMB && ItemLists.SIGNS.contains(clickedMat) && !isSignWaxed(clickedBlock)) {
+					if (!TownyActionEventExecutor.canItemuse(player, clickedBlock.getLocation(), clickedMat))
+						event.setCancelled(true);
 					return;
 				}
 			}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -62,7 +62,6 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
-import org.bukkit.event.Event.Result;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -359,7 +358,7 @@ public class TownyPlayerListener implements Listener {
 			 * Test item_use. 
 			 */
 			if (TownySettings.isItemUseMaterial(item, loc) && !TownyActionEventExecutor.canItemuse(player, loc, item))
-				event.setUseItemInHand(Result.DENY);
+				event.setCancelled(true);
 
 			/*
 			 * Test other Items using non-ItemUse test.
@@ -390,49 +389,49 @@ public class TownyPlayerListener implements Listener {
 					((item == Material.GLASS_BOTTLE || item == Material.SHEARS) && (clickedMat == Material.BEE_NEST || clickedMat == Material.BEEHIVE || clickedMat == Material.PUMPKIN))) { 
 
 					if (!TownyActionEventExecutor.canDestroy(player, loc, clickedMat))
-						event.setUseItemInHand(Result.DENY);
+						event.setCancelled(true);
 				}
 
 				/*
 				 * Test bonemeal usage. Treat interaction as a Build test.
 				 */
 				if (item == Material.BONE_MEAL && !TownyActionEventExecutor.canBuild(player, loc, item))
-					event.setUseItemInHand(Result.DENY);
+					event.setCancelled(true);
 				
 				/*
 				 * Test putting candles on cakes. Treat interaction as a Build test.
 				 */
 				if (ItemLists.CANDLES.contains(item) && clickedMat == Material.CAKE &&
 						!TownyActionEventExecutor.canBuild(player, loc, item))
-					event.setUseItemInHand(Result.DENY);
+					event.setCancelled(true);
 				
 				/*
 				 * Test wax usage. Treat interaction as a Build test.
 				 */
 				if (item == Material.HONEYCOMB && ItemLists.WEATHERABLE_BLOCKS.contains(clickedMat) &&
 						!TownyActionEventExecutor.canBuild(player, loc, item))
-					event.setUseItemInHand(Result.DENY);
+					event.setCancelled(true);
 
 				/*
 				 * Test if we're about to spawn either entity. Uses build test.
 				 */
 				if (item == Material.ARMOR_STAND || item == Material.END_CRYSTAL &&
 						!TownyActionEventExecutor.canBuild(player, clickedBlock.getRelative(event.getBlockFace()).getLocation(), item))
-					event.setUseItemInHand(Result.DENY);
+					event.setCancelled(true);
 
 				/*
 				 * Test if we're putting a book into a BookContainer.
 				 */
 				if (ItemLists.PLACEABLE_BOOKS.contains(item) && ItemLists.BOOK_CONTAINERS.contains(clickedMat) &&
 						!TownyActionEventExecutor.canBuild(player, loc, item))
-					event.setUseItemInHand(Result.DENY);
+					event.setCancelled(true);
 
 				/*
 				 * Catches hoes taking dirt from Rooted Dirt blocks.
 				 */
 				if (clickedMat.getKey().equals(NamespacedKey.minecraft("rooted_dirt")) && ItemLists.HOES.contains(item) &&
 						!TownyActionEventExecutor.canDestroy(player, loc, clickedMat))
-					event.setUseItemInHand(Result.DENY);
+					event.setCancelled(true);
 
 
 				/*
@@ -440,7 +439,7 @@ public class TownyPlayerListener implements Listener {
 				 */
 				if (item == Material.HONEYCOMB && ItemLists.SIGNS.contains(clickedMat) && !isSignWaxed(clickedBlock) &&
 						!TownyActionEventExecutor.canItemuse(player, clickedBlock.getLocation(), clickedMat)) {
-					event.setUseItemInHand(Result.DENY);
+					event.setCancelled(true);
 					return;
 				}
 				
@@ -449,7 +448,7 @@ public class TownyPlayerListener implements Listener {
 				 */
 				if (ItemLists.BRUSHABLE_BLOCKS.contains(clickedMat) && item == Material.BRUSH &&
 						!TownyActionEventExecutor.canDestroy(player, clickedBlock))
-					event.setUseItemInHand(Result.DENY);
+					event.setCancelled(true);
 			}
 		}
 		
@@ -463,7 +462,7 @@ public class TownyPlayerListener implements Listener {
 			 */
 			if (TownySettings.isSwitchMaterial(clickedMat, clickedBlock.getLocation()) && !TownyActionEventExecutor.canSwitch(player, clickedBlock.getLocation(), clickedMat)) {
 				//Make decision on whether this is allowed using the PlayerCache and then a cancellable event.
-				event.setUseInteractedBlock(Result.DENY);
+				event.setCancelled(true);
 				return;
 			}
 			/*
@@ -485,7 +484,7 @@ public class TownyPlayerListener implements Listener {
 				
 				//Make decision on whether this is allowed using the PlayerCache and then a cancellable event.
 				if (!TownyActionEventExecutor.canDestroy(player, clickedBlock.getLocation(), clickedMat))
-					event.setUseInteractedBlock(Result.DENY);
+					event.setCancelled(true);
 				return;
 			}
 			
@@ -495,7 +494,7 @@ public class TownyPlayerListener implements Listener {
 			 */
 			if (TownyPaperEvents.SIGN_OPEN_GET_CAUSE == null && ItemLists.SIGNS.contains(clickedMat) && !isSignWaxed(clickedBlock) &&
 					!TownyActionEventExecutor.canDestroy(player, clickedBlock.getLocation(), clickedMat))
-				event.setUseInteractedBlock(Result.DENY);
+				event.setCancelled(true);
 		}
 	}
 


### PR DESCRIPTION

<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
There are occasions where plugins will cancel one of the above aspects of the PlayerInteractEvent without cancelling the event as a whole.

Because we were specifically calling for the event to be uncancelled we were overriding previously set use-item and interact-with-block decisions made by other plugins.

This PR has Towny ~~making setUseItemInHand and setUseInteractedBlock decisions rather than fully uncancelling/cancelling events.~~ only cancelling events when we're actually denying it. We will no long setCancelled(false) when players are allowed to do their actions.
.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


Closes #6861
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
