### PR TITLE
Fix all the weirdness around world entity key loading

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -417,11 +417,35 @@ public class TownySettings {
 		}
 	}
 
-	public static Set<EntityType> toEntityTypeSet(List<String> entityList) {
-		Set<EntityType> entities = new HashSet<>();
+	public static Set<EntityType> toEntityTypeSet(final List<String> entityList) {
+		final Set<EntityType> entities = new HashSet<>();
 		
-		for (String entityName : entityList) {
-			EntityType type = BukkitTools.matchRegistry(Registry.ENTITY_TYPE, entityName);
+		for (final String entityName : entityList) {
+			final EntityType type = BukkitTools.matchRegistry(Registry.ENTITY_TYPE, switch (entityName.toLowerCase(Locale.ROOT)) {
+				// This is needed because some of the entity type fields don't/didn't match the actual key.
+				//<editor-fold desc="Lots of switch cases">
+				case "primed_tnt" -> "tnt";
+				case "minecart_tnt" -> "tnt_minecart";
+				case "ender_crystal" -> "end_crystal";
+				case "fishing_hook" -> "fishing_bobber";
+				case "minecart_chest" -> "chest_minecart";
+				case "minecart_hopper" -> "hopper_minecart";
+				case "minecart_furnace" -> "furnace_minecart";
+				case "minecart_command" -> "command_block_minecart";
+				case "thrown_exp_bottle" -> "experience_bottle";
+				case "ender_signal" -> "eye_of_ender";
+				case "mushroom_cow" -> "mooshroom";
+				case "splash_potion" -> "potion";
+				case "leash_hitch" -> "leash_knot";
+				case "lightning" -> "lightning_bolt";
+				case "dropped_item" -> "item";
+				case "minecart_mob_spawner" -> "spawner_minecart";
+				case "snowman" -> "snow_golem";
+				case "firework" -> "firework_rocket";
+				//</editor-fold>
+				default -> entityName;
+			});
+			
 			if (type != null)
 				entities.add(type);
 		}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -2267,8 +2267,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 		list.add("# The list of entities whose explosions would be reverted.");
 		// Wilderness Explosion Protection entities
 		if (world.getPlotManagementWildRevertEntities() != null)
-			// getKey().getKey() strips out any minecraft: from minecraft:creeper.
-			list.add("PlotManagementWildRegenEntities=" + StringMgmt.join(world.getPlotManagementWildRevertEntities().stream().map(type -> type.getKey().getKey()).collect(Collectors.toList()), ","));
+			list.add("PlotManagementWildRegenEntities=" + StringMgmt.join(world.getPlotManagementWildRevertEntities().stream().map(type -> BukkitTools.keyAsString(type.getKey())).collect(Collectors.toList()), ","));
 
 		list.add("# If enabled any damage caused by block explosions will repair itself.");
 		// Using PlotManagement Wild Block Regen

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -2231,7 +2231,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 		list.add("# Valid EntityTypes are listed here: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/EntityType.html");
 		list.add("isDeletingEntitiesOnUnclaim=" + world.isDeletingEntitiesOnUnclaim());
 		if (world.getUnclaimDeleteEntityTypes() != null)
-			list.add("unclaimDeleteEntityTypes=" + StringMgmt.join(world.getUnclaimDeleteEntityTypes().stream().map(type -> BukkitTools.keyAsString(type.getKey())).collect(Collectors.toList()), ","));
+			list.add("unclaimDeleteEntityTypes=" + StringMgmt.join(BukkitTools.convertKeyedToString(world.getUnclaimDeleteEntityTypes()), ","));
 
 		// PlotManagement
 		list.add("");
@@ -2267,7 +2267,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 		list.add("# The list of entities whose explosions would be reverted.");
 		// Wilderness Explosion Protection entities
 		if (world.getPlotManagementWildRevertEntities() != null)
-			list.add("PlotManagementWildRegenEntities=" + StringMgmt.join(world.getPlotManagementWildRevertEntities().stream().map(type -> BukkitTools.keyAsString(type.getKey())).collect(Collectors.toList()), ","));
+			list.add("PlotManagementWildRegenEntities=" + StringMgmt.join(BukkitTools.convertKeyedToString(world.getPlotManagementWildRevertEntities()), ","));
 
 		list.add("# If enabled any damage caused by block explosions will repair itself.");
 		// Using PlotManagement Wild Block Regen

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -2231,7 +2231,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 		list.add("# Valid EntityTypes are listed here: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/EntityType.html");
 		list.add("isDeletingEntitiesOnUnclaim=" + world.isDeletingEntitiesOnUnclaim());
 		if (world.getUnclaimDeleteEntityTypes() != null)
-			list.add("unclaimDeleteEntityTypes=" + StringMgmt.join(world.getUnclaimDeleteEntityTypes(), ","));
+			list.add("unclaimDeleteEntityTypes=" + StringMgmt.join(world.getUnclaimDeleteEntityTypes().stream().map(type -> BukkitTools.keyAsString(type.getKey())).collect(Collectors.toList()), ","));
 
 		// PlotManagement
 		list.add("");

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -2463,8 +2463,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 
 			// Wilderness Explosion Protection entities
 			if (world.getPlotManagementWildRevertEntities() != null)
-				// getKey().getKey() strips out any minecraft: from minecraft:creeper.
-				nat_hm.put("PlotManagementWildRegenEntities", StringMgmt.join(world.getPlotManagementWildRevertEntities().stream().map(type -> type.getKey().getKey()).collect(Collectors.toList()), "#"));
+				nat_hm.put("PlotManagementWildRegenEntities", StringMgmt.join(world.getPlotManagementWildRevertEntities().stream().map(type -> BukkitTools.keyAsString(type.getKey())).collect(Collectors.toList()), "#"));
 
 			// Wilderness Explosion Protection Block Whitelist
 			if (world.getPlotManagementWildRevertBlockWhitelist() != null)

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -2433,7 +2433,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			// Deleting EntityTypes from Townblocks on Unclaim.
 			nat_hm.put("isDeletingEntitiesOnUnclaim", world.isDeletingEntitiesOnUnclaim());
 			if (world.getUnclaimDeleteEntityTypes() != null)
-				nat_hm.put("unclaimDeleteEntityTypes", StringMgmt.join(world.getUnclaimDeleteEntityTypes().stream().map(type -> BukkitTools.keyAsString(type.getKey())).collect(Collectors.toList()), "#"));
+				nat_hm.put("unclaimDeleteEntityTypes", StringMgmt.join(BukkitTools.convertKeyedToString(world.getUnclaimDeleteEntityTypes()), "#"));
 
 			// Using PlotManagement Delete
 			nat_hm.put("usingPlotManagementDelete", world.isUsingPlotManagementDelete());
@@ -2463,7 +2463,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 
 			// Wilderness Explosion Protection entities
 			if (world.getPlotManagementWildRevertEntities() != null)
-				nat_hm.put("PlotManagementWildRegenEntities", StringMgmt.join(world.getPlotManagementWildRevertEntities().stream().map(type -> BukkitTools.keyAsString(type.getKey())).collect(Collectors.toList()), "#"));
+				nat_hm.put("PlotManagementWildRegenEntities", StringMgmt.join(BukkitTools.convertKeyedToString(world.getPlotManagementWildRevertEntities()), "#"));
 
 			// Wilderness Explosion Protection Block Whitelist
 			if (world.getPlotManagementWildRevertBlockWhitelist() != null)

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -2433,7 +2433,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			// Deleting EntityTypes from Townblocks on Unclaim.
 			nat_hm.put("isDeletingEntitiesOnUnclaim", world.isDeletingEntitiesOnUnclaim());
 			if (world.getUnclaimDeleteEntityTypes() != null)
-				nat_hm.put("unclaimDeleteEntityTypes", StringMgmt.join(world.getUnclaimDeleteEntityTypes(), "#"));
+				nat_hm.put("unclaimDeleteEntityTypes", StringMgmt.join(world.getUnclaimDeleteEntityTypes().stream().map(type -> BukkitTools.keyAsString(type.getKey())).collect(Collectors.toList()), "#"));
 
 			// Using PlotManagement Delete
 			nat_hm.put("usingPlotManagementDelete", world.isUsingPlotManagementDelete());

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownyWorld.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownyWorld.java
@@ -13,7 +13,6 @@ import com.palmergames.util.StringMgmt;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.Registry;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
@@ -557,24 +556,7 @@ public class TownyWorld extends TownyObject {
 
 	public void setPlotManagementWildRevertEntities(List<String> entities) {
 		entityExplosionProtection = new HashSet<>();
-		
-		// If entities isn't empty and the first string isn't entirely uppercase, convert the legacy names to the entity's key.
-		if (entities.size() > 0 && !StringMgmt.isAllUpperCase(entities))
-			convertLegacyEntityNames(entities);
-		
 		entityExplosionProtection.addAll(TownySettings.toEntityTypeSet(entities));
-	}
-	
-	private void convertLegacyEntityNames(List<String> entities) {
-		for (int i = 0; i < entities.size(); i++) {
-			String entity = entities.get(i);
-			for (EntityType type : Registry.ENTITY_TYPE) {
-				if (type.getEntityClass() != null && type.getEntityClass().getSimpleName().equalsIgnoreCase(entity)) {
-					entities.set(i, type.getKey().toString());
-					break;
-				}					
-			}
-		}
 	}
 
 	public Collection<EntityType> getPlotManagementWildRevertEntities() {

--- a/Towny/src/main/java/com/palmergames/bukkit/util/BukkitTools.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/BukkitTools.java
@@ -376,6 +376,14 @@ public class BukkitTools {
 		final NamespacedKey key = NamespacedKey.fromString(filtered);
 		return key != null ? registry.get(key) : null;
 	}
+
+	/**
+	 * Converts a namespaced key into a string. The namespace is included for non minecraft namespaced keys.
+	 * @return The string representation of the key.
+	 */
+	public static String keyAsString(@NotNull NamespacedKey key) {
+		return key.getNamespace().equals(NamespacedKey.MINECRAFT) ? key.getKey() : key.toString();
+	}
 	
 	static {
 		MethodHandle temp = null;

--- a/Towny/src/main/java/com/palmergames/bukkit/util/BukkitTools.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/BukkitTools.java
@@ -26,6 +26,7 @@ import org.bukkit.scheduler.BukkitScheduler;
 import org.bukkit.scoreboard.Criteria;
 import org.bukkit.scoreboard.Objective;
 import org.bukkit.scoreboard.Scoreboard;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -34,8 +35,10 @@ import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -383,6 +386,16 @@ public class BukkitTools {
 	 */
 	public static String keyAsString(@NotNull NamespacedKey key) {
 		return key.getNamespace().equals(NamespacedKey.MINECRAFT) ? key.getKey() : key.toString();
+	}
+	
+	@ApiStatus.Internal
+	public static Collection<String> convertKeyedToString(@NotNull Collection<? extends Keyed> keys) {
+		final Set<String> set = new HashSet<>();
+		
+		for (Keyed keyed : keys)
+			set.add(keyAsString(keyed.getKey()));
+		
+		return set;
 	}
 	
 	static {

--- a/Towny/src/main/java/com/palmergames/util/StringMgmt.java
+++ b/Towny/src/main/java/com/palmergames/util/StringMgmt.java
@@ -218,12 +218,9 @@ public class StringMgmt {
 		if (string.isEmpty())
 			return false;
 
-		char underscore = '_';
 		for (int i = 0; i < string.length(); i++) {
 			char character = string.charAt(i);
-			if (character == underscore)
-				continue;
-			if (!Character.isUpperCase(character))
+			if (Character.isLowerCase(character))
 				return false;
 		}
 		return true;

--- a/Towny/src/main/resources/config-migration.json
+++ b/Towny/src/main/resources/config-migration.json
@@ -232,71 +232,17 @@
     ]
   },
   {
-    "version": "0.98.0.3",
+    "version": "0.98.0.1",
     "changes": [
       {
-        "type": "REPLACE",
-        "path": "new_world_settings.plot_management.wild_revert_on_mob_explosion.entities",
-        "key": "Creeper",
-        "value": "CREEPER",
-        "worldAction": "UPDATE_WORLD_EXPLOSION_REVERT_ENTITIES"
-      },
-      {
-        "type": "REPLACE",
-        "path": "new_world_settings.plot_management.wild_revert_on_mob_explosion.entities",
-        "key": "EnderCrystal",
-        "value": "ENDER_CRYSTAL",
-        "worldAction": "UPDATE_WORLD_EXPLOSION_REVERT_ENTITIES"
-      },
-      {
-        "type": "REPLACE",
-        "path": "new_world_settings.plot_management.wild_revert_on_mob_explosion.entities",
-        "key": "EnderDragon",
-        "value": "ENDER_DRAGON",
-        "worldAction": "UPDATE_WORLD_EXPLOSION_REVERT_ENTITIES"
-      },
-      {
-        "type": "REPLACE",
-        "path": "new_world_settings.plot_management.wild_revert_on_mob_explosion.entities",
-        "key": "Fireball",
-        "value": "FIREBALL",
-        "worldAction": "UPDATE_WORLD_EXPLOSION_REVERT_ENTITIES"
-      },
-      {
-        "type": "REPLACE",
-        "path": "new_world_settings.plot_management.wild_revert_on_mob_explosion.entities",
-        "key": "SmallFireball",
-        "value": "SMALL_FIREBALL",
-        "worldAction": "UPDATE_WORLD_EXPLOSION_REVERT_ENTITIES"
-      },
-      {
-        "type": "REPLACE",
-        "path": "new_world_settings.plot_management.wild_revert_on_mob_explosion.entities",
-        "key": "TNTPrimed",
-        "value": "PRIMED_TNT",
-        "worldAction": "UPDATE_WORLD_EXPLOSION_REVERT_ENTITIES"
-      },
-      {
-        "type": "REPLACE",
-        "path": "new_world_settings.plot_management.wild_revert_on_mob_explosion.entities",
-        "key": "ExplosiveMinecart",
-        "value": "MINECART_TNT",
-        "worldAction": "UPDATE_WORLD_EXPLOSION_REVERT_ENTITIES"
-      },
-      {
-        "type": "REPLACE",
-        "path": "new_world_settings.plot_management.wild_revert_on_mob_explosion.entities",
-        "key": "Wither",
-        "value": "WITHER",
-        "worldAction": "UPDATE_WORLD_EXPLOSION_REVERT_ENTITIES"
-      },
-      {
-        "type": "REPLACE",
-        "path": "new_world_settings.plot_management.wild_revert_on_mob_explosion.entities",
-        "key": "WitherSkull",
-        "value": "WITHER_SKULL",
-        "worldAction": "UPDATE_WORLD_EXPLOSION_REVERT_ENTITIES"
-      },
+        "type": "RUNNABLE",
+        "key": "convert_entity_class_names"
+      }
+    ]
+  },
+  {
+    "version": "0.98.0.3",
+    "changes": [
       {
         "type": "TOWNYPERMS_ADD",
         "path": "towns.ranks.sheriff",

--- a/Towny/src/test/java/com/palmergames/bukkit/towny/test/ConfigMigrationTests.java
+++ b/Towny/src/test/java/com/palmergames/bukkit/towny/test/ConfigMigrationTests.java
@@ -1,0 +1,39 @@
+package com.palmergames.bukkit.towny.test;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import com.palmergames.bukkit.config.CommentedConfiguration;
+import com.palmergames.bukkit.config.ConfigNodes;
+import com.palmergames.bukkit.config.migration.RunnableMigrations;
+import com.palmergames.bukkit.towny.TownySettings;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ConfigMigrationTests {
+	
+	static RunnableMigrations runnableMigrations = new RunnableMigrations();
+	
+	@BeforeAll
+	static void init() {
+		MockBukkit.getOrCreateMock();
+		TownySettings.loadDefaultConfig();
+	}
+	
+	@Test
+	void testEntityClassMigration() {
+		TownySettings.getConfig().set(ConfigNodes.NWS_PLOT_MANAGEMENT_WILD_ENTITY_REVERT_LIST.getRoot(), "Creeper,EnderCrystal,EnderDragon,Fireball,SmallFireball,LargeFireball,TNTPrimed,ExplosiveMinecart,Wither,WitherSkull");
+		
+		Consumer<CommentedConfiguration> migration = runnableMigrations.getByName("convert_entity_class_names");
+		assertNotNull(migration);
+
+		migration.accept(TownySettings.getConfig());
+		
+		// The same as our current default but with SMALL_FIREBALL and FIREBALL switched around.
+		String expected = "CREEPER,END_CRYSTAL,ENDER_DRAGON,SMALL_FIREBALL,FIREBALL,TNT,TNT_MINECART,WITHER,WITHER_SKULL".toLowerCase(Locale.ROOT);
+		assertEquals(expected, TownySettings.getConfig().get(ConfigNodes.NWS_PLOT_MANAGEMENT_WILD_ENTITY_REVERT_LIST.getRoot()));
+	}
+}

--- a/Towny/src/test/java/com/palmergames/bukkit/towny/test/EntityTypeConversionTests.java
+++ b/Towny/src/test/java/com/palmergames/bukkit/towny/test/EntityTypeConversionTests.java
@@ -1,0 +1,39 @@
+package com.palmergames.bukkit.towny.test;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import com.palmergames.bukkit.towny.TownySettings;
+import com.palmergames.bukkit.towny.object.TownyWorld;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class EntityTypeConversionTests {
+	
+	@BeforeAll
+	static void init() {
+		MockBukkit.getOrCreateMock();
+		TownySettings.loadDefaultConfig();
+	}
+	
+	@Test
+	void testRenamedFieldsConversions() {
+		TownyWorld world = new TownyWorld("test", UUID.randomUUID());
+		List<String> renamed = Arrays.asList("FISHING_HOOK", "MINECART_CHEST", "ENDER_CRYSTAL", "MINECART_FURNACE", "MINECART_HOPPER", "MINECART_COMMAND", "THROWN_EXP_BOTTLE", "ENDER_SIGNAL", "MINECART_TNT", "MUSHROOM_COW", "SPLASH_POTION", "PRIMED_TNT", "LEASH_HITCH", "LIGHTNING", "DROPPED_ITEM", "MINECART_MOB_SPAWNER", "SNOWMAN", "FIREWORK");
+		world.setPlotManagementWildRevertEntities(renamed);
+		
+		assertEquals(renamed.size(), world.getPlotManagementWildRevertEntities().size());
+	}
+	
+	@Test
+	void testDefaultConfigAllNamesAreValid() {
+		TownyWorld world = new TownyWorld("test", UUID.randomUUID());
+		world.setPlotManagementWildRevertEntities(TownySettings.getWildExplosionProtectionEntities());
+		
+		assertEquals(world.getPlotManagementWildRevertEntities().size(), TownySettings.getWildExplosionProtectionEntities().size());
+	}
+}

--- a/Towny/src/test/java/com/palmergames/bukkit/towny/test/RegistryListTests.java
+++ b/Towny/src/test/java/com/palmergames/bukkit/towny/test/RegistryListTests.java
@@ -12,7 +12,7 @@ public class RegistryListTests {
 	
 	@BeforeAll
 	static void mock() {
-		MockBukkit.mock();
+		MockBukkit.getOrCreateMock();
 		TownySettings.loadDefaultConfig();
 	}
 	


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
* Moved the entity class name migration done inside setPlotManagementWildRevertEntities to a one time migration
* Added a switch case with all old entity names so that these can still be looked up correctly
* Fixes unclaimDeleteEntityTypes saving using EntityType enum names instead of keys 
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
