### PR TITLE
Fix edge case scenario where NPCs can be treated like Players in Combat. 

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/CombatUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/CombatUtil.java
@@ -123,14 +123,14 @@ public class CombatUtil {
 		TownBlock defenderTB = TownyAPI.getInstance().getTownBlock(defendingEntity.getLocation());
 		TownBlock attackerTB = TownyAPI.getInstance().getTownBlock(attackingEntity.getLocation());
 		/*
-		 * We have an attacking player, which is not an NPC..
+		 * We have an attacking player, which is not an NPC.
 		 */
 		if (attackingPlayer != null && isNotNPC(attackingPlayer)) {
 
 			boolean cancelled = false;
 			
 			/*
-			 * Defender is a player.
+			 * Defender is a player, which is not an NPC..
 			 */
 			if (defendingPlayer != null && isNotNPC(defendingPlayer)) {
 				

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/CombatUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/CombatUtil.java
@@ -10,6 +10,7 @@ import com.palmergames.bukkit.towny.event.damage.TownyFriendlyFireTestEvent;
 import com.palmergames.bukkit.towny.event.damage.TownyPlayerDamagePlayerEvent;
 import com.palmergames.bukkit.towny.event.damage.WildernessPVPTestEvent;
 import com.palmergames.bukkit.towny.event.executors.TownyActionEventExecutor;
+import com.palmergames.bukkit.towny.hooks.PluginIntegrations;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
@@ -122,16 +123,16 @@ public class CombatUtil {
 		TownBlock defenderTB = TownyAPI.getInstance().getTownBlock(defendingEntity.getLocation());
 		TownBlock attackerTB = TownyAPI.getInstance().getTownBlock(attackingEntity.getLocation());
 		/*
-		 * We have an attacking player
+		 * We have an attacking player, which is not an NPC..
 		 */
-		if (attackingPlayer != null) {
+		if (attackingPlayer != null && isNotNPC(attackingPlayer)) {
 
 			boolean cancelled = false;
 			
 			/*
 			 * Defender is a player.
 			 */
-			if (defendingPlayer != null) {
+			if (defendingPlayer != null && isNotNPC(defendingPlayer)) {
 				
 				/*
 				 * Both townblocks are not Arena plots.
@@ -662,5 +663,9 @@ public class CombatUtil {
 			preventDamage = preventPvP(world, dispenserTB) || preventPvP(world, defenderTB);
 
 		return BukkitTools.isEventCancelled(new TownyDispenserDamageEntityEvent(entity.getLocation(), entity, cause, defenderTB, preventDamage, dispenser));
+	}
+
+	private static boolean isNotNPC(Entity entity) {
+		return !PluginIntegrations.getInstance().checkCitizens(entity);
 	}
 }


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Sentinel could cause Towny to throw events that assume a player is involved, but the lack of a backing Resident can cause issues for plugins using our events.

This change should result in non-player-involved damage events being thrown instead.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

https://mclo.gs/brb2gHd

____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
