### PR TITLE
Add ability for mayors to exempt their townblocks from paying taxes.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -113,7 +113,9 @@ public class TownyFormatter {
 		
 		if (townBlock.getTrustedResidents().size() > 0)
 			screen.addComponentOf("trusted", getFormattedTownyObjects(translator.of("status_trustedlist"), new ArrayList<>(townBlock.getTrustedResidents())));
-		
+
+		screen.addComponentOf("plottax", colourKeyValue(translator.of("status_townblock_plottax"), townBlock.isTaxed() ? formatMoney(townBlock.getPlotTax()) : translator.of("status_townblock_untaxed")));
+
 		// Add any metadata which opt to be visible.
 		List<Component> fields = getExtraFields(townBlock);
 		if (!fields.isEmpty())

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/SQLSchema.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/SQLSchema.java
@@ -313,6 +313,7 @@ public class SQLSchema {
 		List<String> columns = new ArrayList<>();
 		columns.add("`name` mediumtext");
 		columns.add("`price` float DEFAULT '-1'");
+		columns.add("`taxed` bool NOT NULL DEFAULT '1'");
 		columns.add("`town` mediumtext");
 		columns.add("`resident` mediumtext");
 		columns.add("`type` TINYINT NOT  NULL DEFAULT '0'");

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -1671,6 +1671,13 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 							townBlock.setPlotPrice(Double.parseDouble(line.trim()));
 						} catch (Exception ignored) {
 						}
+
+					line = keys.get("taxed");
+					if (line != null)
+						try {
+							townBlock.setTaxed(Boolean.parseBoolean(line));
+						} catch (Exception ignored) {
+						}
 					
 					line = keys.get("outpost");
 					if (line != null)
@@ -2275,6 +2282,9 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 
 		// price
 		list.add("price=" + townBlock.getPlotPrice());
+
+		// taxed
+		list.add("taxed=" + townBlock.isTaxed());
 
 		// town
 		try {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -1826,6 +1826,12 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 						townBlock.setPlotPrice(Float.parseFloat(line.trim()));
 					} catch (Exception ignored) {
 					}
+
+				boolean taxed = rs.getBoolean("taxed");
+				try {
+					townBlock.setTaxed(taxed);
+				} catch (Exception ignored) {
+				}
 				
 				line = rs.getString("typeName");
 				if (line != null) 
@@ -2462,6 +2468,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			tb_hm.put("z", townBlock.getZ());
 			tb_hm.put("name", townBlock.getName());
 			tb_hm.put("price", townBlock.getPlotPrice());
+			tb_hm.put("taxed", townBlock.isTaxed());
 			tb_hm.put("town", townBlock.getTown().getName());
 			tb_hm.put("resident", (townBlock.hasResident()) ? townBlock.getResidentOrNull().getName() : "");
 			tb_hm.put("typeName", townBlock.getTypeName());

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/event/plot/toggle/PlotToggleTaxedEvent.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/event/plot/toggle/PlotToggleTaxedEvent.java
@@ -1,0 +1,12 @@
+package com.palmergames.bukkit.towny.event.plot.toggle;
+
+import org.bukkit.entity.Player;
+
+import com.palmergames.bukkit.towny.object.TownBlock;
+
+public class PlotToggleTaxedEvent extends PlotToggleEvent {
+
+	public PlotToggleTaxedEvent(TownBlock townBlock, Player player, boolean futureState) {
+		super(townBlock, player, futureState);
+	}
+}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownBlock.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownBlock.java
@@ -37,6 +37,7 @@ public class TownBlock extends TownyObject {
 	private TownBlockType type = TownBlockType.RESIDENTIAL;
 	private final WorldCoord worldCoord;
 	private double plotPrice = -1;
+	private boolean taxed = true;
 	private boolean outpost = false;
 	private PlotGroup plotGroup;
 	private long claimedAt;
@@ -64,8 +65,10 @@ public class TownBlock extends TownyObject {
 
 	public void setTown(Town town, boolean updateClaimedAt) {
 
-		if (hasTown())
+		if (hasTown()) {
 			this.town.removeTownBlock(this);
+			this.setTaxed(true);
+		}
 		this.town = town;
 		try {
 			TownyUniverse.getInstance().addTownBlock(this);
@@ -232,6 +235,18 @@ public class TownBlock extends TownyObject {
 	public boolean isForSale() {
 
 		return getPlotPrice() != -1.0;
+	}
+
+	public boolean isTaxed() {
+		return taxed;
+	}
+
+	public void setTaxed(boolean value) {
+		this.taxed = value;
+	}
+
+	public double getPlotTax() {
+		return getType().getTax(town);
 	}
 
 	public void setPermissions(String line) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
@@ -483,7 +483,7 @@ public class DailyTimerTask extends TownyTimerTask {
 			townBlock = townBlockItr.next();
 			double tax = townBlock.getType().getTax(town);
 
-			if (!townBlock.hasResident() || tax == 0 ||
+			if (!townBlock.isTaxed() || !townBlock.hasResident() || tax == 0 ||
 				!TownySettings.isNegativePlotTaxAllowed() && tax < 1)
 				continue;
 

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -702,6 +702,8 @@ status_res_taxexempt: 'Staff are exempt from paying town taxes.'
 status_res_tax: 'Town Tax:'
 status_res_plottax: 'Total Plot Taxes:'
 status_res_totaltax: 'Total Tax to pay:'
+status_townblock_plottax: 'Plot Tax:'
+status_townblock_untaxed: 'Untaxed'
 
 # Added in 0.45
 msg_err_unable_to_use_bank_outside_nation_capital: 'You cannot make use of your nation bank outside of the nation capital.'
@@ -1973,3 +1975,6 @@ msg_err_your_cannot_overclaim_for_another: "You cannot overclaim again for anoth
 
 # Generic error message for when a world isn't loaded
 msg_err_world_not_loaded: "<red>World is not loaded."
+
+# Message shown when a mayor toggles a plots taxed status.
+msg_changed_plot_taxed: '&cThis plot has had its taxed status set to %s.'

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -702,7 +702,7 @@ status_res_taxexempt: 'Staff are exempt from paying town taxes.'
 status_res_tax: 'Town Tax:'
 status_res_plottax: 'Total Plot Taxes:'
 status_res_totaltax: 'Total Tax to pay:'
-status_townblock_plottax: 'Plot Tax:'
+status_townblock_plottax: 'Plot Tax: '
 status_townblock_untaxed: 'Untaxed'
 
 # Added in 0.45


### PR DESCRIPTION


<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->


Adds `Plot Tax:` to the townblock status screen.

API: PlotToggleTaxedEvent
  - Cancellable event that stops a mayor toggling taxation off/on on a townblock.


____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->

New Command: /plot toggle taxed
  - Uses the towny.command.plot.asmayor permission node
  - Allows a mayor to decide whether a plot will require the plotowner to pay the plot taxes.
____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #3675.

____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
