### PR TITLE
Add ability for towns and nations to have a negative fixed-rate tax amount.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -2593,27 +2593,27 @@ public enum ConfigNodes {
 			"",
 			"# Uses total number of plots that the town is overclaimed by, to determine the price_town_overclaimed_upkeep_penalty cost.",
 			"# If set to true the penalty is calculated (# of plots overclaimed X price_town_overclaimed_upkeep_penalty)."),
-	ECO_UPKEEP_PLOTPAYMENTS(
+	ECO_TAXES_ALLOW_PLOT_PAYMENTS(
 			"economy.daily_taxes.use_plot_payments",
 			"false",
 			"",
 			"# If enabled and you set a negative upkeep for the town",
 			"# any funds the town gains via upkeep at a new day",
 			"# will be shared out between the plot owners."),
-	ECO_UPKEEP_PLAYEROWNEDPLOTPAYMENTS(
+	ECO_TAXES_ALLOW_PLAYER_OWNED_PLOT_PAYMENTS(
 			"economy.daily_taxes.allow_negative_plot_tax",
 			"false",
 			"",
 			"# If enabled, if a plot tax is set to a negative amount",
 			"# it will result in the resident that owns it being paid",
 			"# by the town bank (if the town can afford it.)"),
-	ECO_UPKEEP_NEGATIVETOWNTAX(
+	ECO_TAXES_ALLOW_NEGATIVE_TOWN_TAX(
 			"economy.daily_taxes.allow_negative_town_tax",
 			"false",
 			"",
 			"# If enabled, and a town tax is set to a negative amount and is a fixed amount (not percentage,)",
 			"# it will result in every resident being paid by the town bank (if the town can afford it.)"),
-	ECO_UPKEEP_NEGATIVENATIONTAX(
+	ECO_TAXES_ALLOW_NEGATIVE_NATION_TAX(
 			"economy.daily_taxes.allow_negative_nation_tax",
 			"false",
 			"",

--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -157,7 +157,8 @@ public enum ConfigNodes {
 			"0.0",
 			"",
 			"# A required minimum tax amount for the default_tax, will not change any towns which already have a tax set.",
-			"# Do not forget to set the default_tax to more than 0 or new towns will still begin with a tax of zero."),
+			"# Do not forget to set the default_tax to more than 0 or new towns will still begin with a tax of zero.",
+			"# This setting has no effect when negative taxes are allowed."),
 	TOWN_MAX_PURCHASED_BLOCKS(
 			"town.max_purchased_blocks",
 			"0",
@@ -363,7 +364,8 @@ public enum ConfigNodes {
 			"0.0",
 			"",
 			"# A required minimum tax amount for the default_tax, will not change any nations which already have a tax set.",
-			"# Do not forget to set the default_tax to more than 0 or new nations will still begin with a tax of zero."),
+			"# Do not forget to set the default_tax to more than 0 or new nations will still begin with a tax of zero.",
+			"# This setting has no effect when negative taxes are allowed."),
 	NATION_DEF_TAXES_CONQUEREDTAX(
 			"nation.default_taxes.default_nation_conquered_tax",
 			"0",

--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -2607,6 +2607,18 @@ public enum ConfigNodes {
 			"# If enabled, if a plot tax is set to a negative amount",
 			"# it will result in the resident that owns it being paid",
 			"# by the town bank (if the town can afford it.)"),
+	ECO_UPKEEP_NEGATIVETOWNTAX(
+			"economy.daily_taxes.allow_negative_town_tax",
+			"false",
+			"",
+			"# If enabled, and a town tax is set to a negative amount and is a fixed amount (not percentage,)",
+			"# it will result in every resident being paid by the town bank (if the town can afford it.)"),
+	ECO_UPKEEP_NEGATIVENATIONTAX(
+			"economy.daily_taxes.allow_negative_nation_tax",
+			"false",
+			"",
+			"# If enabled, and a nation tax is set to a negative amount and is a fixed amount (not percentage,)",
+			"# it will result in every town in the nation being paid by the nation bank (if the nation can afford it.)"),
 	
 	ECO_BANKRUPTCY("economy.bankruptcy", "", "", 
 			"# The Bankruptcy system in Towny will make it so that when a town cannot pay their upkeep costs,",

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -2077,19 +2077,19 @@ public class TownySettings {
 
 	public static boolean isUpkeepPayingPlots() {
 
-		return getBoolean(ConfigNodes.ECO_UPKEEP_PLOTPAYMENTS);
+		return getBoolean(ConfigNodes.ECO_TAXES_ALLOW_PLOT_PAYMENTS);
 	}
 	
 	public static boolean isNegativePlotTaxAllowed() {
-		return getBoolean(ConfigNodes.ECO_UPKEEP_PLAYEROWNEDPLOTPAYMENTS);
+		return getBoolean(ConfigNodes.ECO_TAXES_ALLOW_PLAYER_OWNED_PLOT_PAYMENTS);
 	}
 
 	public static boolean isNegativeTownTaxAllowed() {
-		return getBoolean(ConfigNodes.ECO_UPKEEP_NEGATIVETOWNTAX);
+		return getBoolean(ConfigNodes.ECO_TAXES_ALLOW_NEGATIVE_TOWN_TAX);
 	}
 
 	public static boolean isNegativeNationTaxAllowed() {
-		return getBoolean(ConfigNodes.ECO_UPKEEP_NEGATIVENATIONTAX);
+		return getBoolean(ConfigNodes.ECO_TAXES_ALLOW_NEGATIVE_NATION_TAX);
 	}
 
 	public static double getTownPenaltyUpkeepCost(Town town) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -2084,6 +2084,14 @@ public class TownySettings {
 		return getBoolean(ConfigNodes.ECO_UPKEEP_PLAYEROWNEDPLOTPAYMENTS);
 	}
 
+	public static boolean isNegativeTownTaxAllowed() {
+		return getBoolean(ConfigNodes.ECO_UPKEEP_NEGATIVETOWNTAX);
+	}
+
+	public static boolean isNegativeNationTaxAllowed() {
+		return getBoolean(ConfigNodes.ECO_UPKEEP_NEGATIVENATIONTAX);
+	}
+
 	public static double getTownPenaltyUpkeepCost(Town town) {
 		TownUpkeepPenalityCalculationEvent event = new TownUpkeepPenalityCalculationEvent(town, getTownPenaltyUpkeepCostRaw(town));
 		BukkitTools.fireEvent(event);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -2183,21 +2183,17 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 	private static void nationSetTaxes(CommandSender sender, Nation nation, String[] split, boolean admin) throws TownyException {
 		if (split.length < 2)
 			throw new TownyException("Eg: /nation set taxes 70");
-		try {
-			Double amount = Double.parseDouble(split[1]);
-			if (amount < 0 && !TownySettings.isNegativeNationTaxAllowed())
-				throw new TownyException(Translatable.of("msg_err_negative_money"));
-			if (nation.isTaxPercentage() && (amount > 100 || amount < 0.0))
-				throw new TownyException(Translatable.of("msg_err_not_percentage"));
-			if (TownySettings.getNationDefaultTaxMinimumTax() > amount)
-				throw new TownyException(Translatable.of("msg_err_tax_minimum_not_met", TownySettings.getNationDefaultTaxMinimumTax()));
-			nation.setTaxes(amount);
-			if (admin) 
-				TownyMessaging.sendMsg(sender, Translatable.of("msg_town_set_nation_tax", sender.getName(), nation.getTaxes()));
-			TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_town_set_nation_tax", sender.getName(), nation.getTaxes()));
-		} catch (NumberFormatException e) {
-			throw new TownyException(Translatable.of("msg_error_must_be_num"));
-		}
+		Double amount = MathUtil.getDoubleOrThrow(split[1]);
+		if (amount < 0 && !TownySettings.isNegativeNationTaxAllowed())
+			throw new TownyException(Translatable.of("msg_err_negative_money"));
+		if (nation.isTaxPercentage() && (amount > 100 || amount < 0.0))
+			throw new TownyException(Translatable.of("msg_err_not_percentage"));
+		if (TownySettings.getNationDefaultTaxMinimumTax() > amount)
+			throw new TownyException(Translatable.of("msg_err_tax_minimum_not_met", TownySettings.getNationDefaultTaxMinimumTax()));
+		nation.setTaxes(amount);
+		if (admin) 
+			TownyMessaging.sendMsg(sender, Translatable.of("msg_town_set_nation_tax", sender.getName(), nation.getTaxes()));
+		TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_town_set_nation_tax", sender.getName(), nation.getTaxes()));
 	}
 
 	public static void nationSetTaxPercentCap(CommandSender sender, String[] split, Nation nation) throws TownyException {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -2188,7 +2188,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 			throw new TownyException(Translatable.of("msg_err_negative_money"));
 		if (nation.isTaxPercentage() && (amount > 100 || amount < 0.0))
 			throw new TownyException(Translatable.of("msg_err_not_percentage"));
-		if (TownySettings.getNationDefaultTaxMinimumTax() > amount)
+		if (!TownySettings.isNegativeNationTaxAllowed() && TownySettings.getNationDefaultTaxMinimumTax() > amount)
 			throw new TownyException(Translatable.of("msg_err_tax_minimum_not_met", TownySettings.getNationDefaultTaxMinimumTax()));
 		nation.setTaxes(amount);
 		if (admin) 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -2183,15 +2183,21 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 	private static void nationSetTaxes(CommandSender sender, Nation nation, String[] split, boolean admin) throws TownyException {
 		if (split.length < 2)
 			throw new TownyException("Eg: /nation set taxes 70");
-		int amount = MathUtil.getPositiveIntOrThrow(split[1].trim());
-		if (nation.isTaxPercentage() && amount > 100)
-			throw new TownyException(Translatable.of("msg_err_not_percentage"));
-		if (TownySettings.getNationDefaultTaxMinimumTax() > amount)
-			throw new TownyException(Translatable.of("msg_err_tax_minimum_not_met", TownySettings.getNationDefaultTaxMinimumTax()));
-		nation.setTaxes(amount);
-		if (admin) 
-			TownyMessaging.sendMsg(sender, Translatable.of("msg_town_set_nation_tax", sender.getName(), nation.getTaxes()));
-		TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_town_set_nation_tax", sender.getName(), nation.getTaxes()));
+		try {
+			Double amount = Double.parseDouble(split[1]);
+			if (amount < 0 && !TownySettings.isNegativeNationTaxAllowed())
+				throw new TownyException(Translatable.of("msg_err_negative_money"));
+			if (nation.isTaxPercentage() && (amount > 100 || amount < 0.0))
+				throw new TownyException(Translatable.of("msg_err_not_percentage"));
+			if (TownySettings.getNationDefaultTaxMinimumTax() > amount)
+				throw new TownyException(Translatable.of("msg_err_tax_minimum_not_met", TownySettings.getNationDefaultTaxMinimumTax()));
+			nation.setTaxes(amount);
+			if (admin) 
+				TownyMessaging.sendMsg(sender, Translatable.of("msg_town_set_nation_tax", sender.getName(), nation.getTaxes()));
+			TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_town_set_nation_tax", sender.getName(), nation.getTaxes()));
+		} catch (NumberFormatException e) {
+			throw new TownyException(Translatable.of("msg_error_must_be_num"));
+		}
 	}
 
 	public static void nationSetTaxPercentCap(CommandSender sender, String[] split, Nation nation) throws TownyException {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -2294,20 +2294,16 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 	public static void townSetTaxes(CommandSender sender, String[] split, boolean admin, Town town) throws TownyException {
 		if (split.length < 2)
 			throw new TownyException("Eg: /town set taxes 7");
-		try {
-			Double amount = Double.parseDouble(split[1]);
-			if (amount < 0 && !TownySettings.isNegativeTownTaxAllowed())
-				throw new TownyException(Translatable.of("msg_err_negative_money"));
-			if (town.isTaxPercentage() && (amount > 100 || amount < 0.0))
-				throw new TownyException(Translatable.of("msg_err_not_percentage"));
-			if (TownySettings.getTownDefaultTaxMinimumTax() > amount)
-				throw new TownyException(Translatable.of("msg_err_tax_minimum_not_met", TownySettings.getTownDefaultTaxMinimumTax()));
-			town.setTaxes(amount);
-			if (admin) TownyMessaging.sendMsg(sender, Translatable.of("msg_town_set_tax", sender.getName(), town.getTaxes()));
-			TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_town_set_tax", sender.getName(), town.getTaxes()));
-		} catch (NumberFormatException e) {
-			throw new TownyException(Translatable.of("msg_error_must_be_num"));
-		}
+		Double amount = MathUtil.getDoubleOrThrow(split[1]);
+		if (amount < 0 && !TownySettings.isNegativeTownTaxAllowed())
+			throw new TownyException(Translatable.of("msg_err_negative_money"));
+		if (town.isTaxPercentage() && (amount > 100 || amount < 0.0))
+			throw new TownyException(Translatable.of("msg_err_not_percentage"));
+		if (TownySettings.getTownDefaultTaxMinimumTax() > amount)
+			throw new TownyException(Translatable.of("msg_err_tax_minimum_not_met", TownySettings.getTownDefaultTaxMinimumTax()));
+		town.setTaxes(amount);
+		if (admin) TownyMessaging.sendMsg(sender, Translatable.of("msg_town_set_tax", sender.getName(), town.getTaxes()));
+		TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_town_set_tax", sender.getName(), town.getTaxes()));
 	}
 
 	public static void townSetPlotTax(CommandSender sender, String[] split, boolean admin, Town town) throws TownyException {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -2296,9 +2296,9 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 			throw new TownyException("Eg: /town set taxes 7");
 		try {
 			Double amount = Double.parseDouble(split[1]);
-			if (amount < 0)
+			if (amount < 0 && !TownySettings.isNegativeTownTaxAllowed())
 				throw new TownyException(Translatable.of("msg_err_negative_money"));
-			if (town.isTaxPercentage() && amount > 100)
+			if (town.isTaxPercentage() && (amount > 100 || amount < 0.0))
 				throw new TownyException(Translatable.of("msg_err_not_percentage"));
 			if (TownySettings.getTownDefaultTaxMinimumTax() > amount)
 				throw new TownyException(Translatable.of("msg_err_tax_minimum_not_met", TownySettings.getTownDefaultTaxMinimumTax()));

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -2299,7 +2299,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 			throw new TownyException(Translatable.of("msg_err_negative_money"));
 		if (town.isTaxPercentage() && (amount > 100 || amount < 0.0))
 			throw new TownyException(Translatable.of("msg_err_not_percentage"));
-		if (TownySettings.getTownDefaultTaxMinimumTax() > amount)
+		if (!TownySettings.isNegativeTownTaxAllowed() && TownySettings.getTownDefaultTaxMinimumTax() > amount)
 			throw new TownyException(Translatable.of("msg_err_tax_minimum_not_met", TownySettings.getTownDefaultTaxMinimumTax()));
 		town.setTaxes(amount);
 		if (admin) TownyMessaging.sendMsg(sender, Translatable.of("msg_town_set_tax", sender.getName(), town.getTaxes()));

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Government.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Government.java
@@ -296,7 +296,6 @@ public abstract class Government extends TownyObject implements BankEconomyHandl
 	 * @return The tax number.
 	 */
 	public double getTaxes() {
-		setTaxes(taxes); //make sure the tax level is right.
 		return taxes;
 	}
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Nation.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Nation.java
@@ -338,7 +338,7 @@ public class Nation extends Government {
 		this.taxes = Math.min(taxes, isTaxPercentage ? TownySettings.getMaxNationTaxPercent() : TownySettings.getMaxNationTax());
 		
 		// Fix invalid taxes
-		if (this.taxes < 0)
+		if (this.taxes < 0 && !TownySettings.isNegativeNationTaxAllowed())
 			this.taxes = TownySettings.getNationDefaultTax();
 	}
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Town.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Town.java
@@ -183,7 +183,7 @@ public class Town extends Government implements TownBlockOwner {
 		this.taxes = Math.min(taxes, isTaxPercentage ? TownySettings.getMaxTownTaxPercent() : TownySettings.getMaxTownTax());
 		
 		// Fix invalid taxes
-		if (this.taxes < 0)
+		if (this.taxes < 0 && !TownySettings.isNegativeTownTaxAllowed())
 			this.taxes = TownySettings.getTownDefaultTax();
 	}
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
@@ -228,11 +228,9 @@ public class DailyTimerTask extends TownyTimerTask {
 			else
 				TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_town_destroyed_by_nation_tax_multiple").append(StringMgmt.join(localTownsDestroyed, ", ")));
 
-		if (taxCollected > 0.0) {
-			TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_tax_collected_from_towns", prettyMoney(taxCollected)));
-			taxCollected = 0.0;
-		} else if (taxCollected < 0.0) {
-			TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_tax_paid_to_towns", prettyMoney(taxCollected)));
+		if (taxCollected != 0.0) {
+			String msgSlug = taxCollected > 0.0 ? "msg_tax_collected_from_towns" : "msg_tax_paid_to_towns";
+			TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of(msgSlug, prettyMoney(taxCollected)));
 			taxCollected = 0.0;
 		}
 
@@ -386,11 +384,9 @@ public class DailyTimerTask extends TownyTimerTask {
 		 * Taxes paid by or paid to the Residents of the town.
 		 */
 		collectTownResidentTax(town);
-		if (taxCollected > 0.0) {
-			TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_tax_collected_from_residents", prettyMoney(taxCollected)));
-			taxCollected = 0.0;
-		} else if (taxCollected < 0.0) {
-			TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_tax_paid_to_residents", prettyMoney(taxCollected)));
+		if (taxCollected != 0.0) {
+			String msgSlug = taxCollected > 0.0 ? "msg_tax_collected_from_residents" : "msg_tax_paid_to_residents";
+			TownyMessaging.sendPrefixedTownMessage(town, Translatable.of(msgSlug, prettyMoney(taxCollected)));
 			taxCollected = 0.0;
 		}
 
@@ -398,11 +394,9 @@ public class DailyTimerTask extends TownyTimerTask {
 		 * Taxes paid by or paid to the Residents that own Town land personally.
 		 */
 		collecTownPlotTax(town);
-		if (taxCollected > 0.0) {
-			TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_tax_collected_from_plots", prettyMoney(taxCollected)));
-			taxCollected = 0.0;
-		} else if (taxCollected < 0.0) {
-			TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_tax_paid_to_residents_for_plots", prettyMoney(taxCollected)));
+		if (taxCollected != 0.0) {
+			String msgSlug = taxCollected > 0.0 ? "msg_tax_collected_from_plots" : "msg_tax_paid_to_residents_for_plots";
+			TownyMessaging.sendPrefixedTownMessage(town, Translatable.of(msgSlug, prettyMoney(taxCollected)));
 			taxCollected = 0.0;
 		}
 	}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
@@ -174,6 +174,14 @@ public class DailyTimerTask extends TownyTimerTask {
 	 */
 	protected void collectNationTaxes(Nation nation) {
 
+		double tax = nation.getTaxes();
+		if (tax == 0)
+			return;
+
+		// Don't allow negative taxes if the nation uses a tax percentage or negative naiton tax is explicitly disallowed.
+		if (tax < 0 && (!TownySettings.isNegativeNationTaxAllowed() || nation.isTaxPercentage()))
+			return;
+
 		List<String> newlyDelinquentTowns = new ArrayList<>();
 		List<String> localTownsDestroyed = new ArrayList<>();
 		List<Town> towns = new ArrayList<>(nation.getTowns());
@@ -223,6 +231,10 @@ public class DailyTimerTask extends TownyTimerTask {
 		if (taxCollected > 0.0) {
 			TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_tax_collected_from_towns", prettyMoney(taxCollected)));
 			taxCollected = 0.0;
+		} else if (taxCollected < 0.0) {
+			// TODO: A negative Lang String.
+			TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_tax_collected_from_towns", prettyMoney(taxCollected)));
+			taxCollected = 0.0;
 		}
 
 		if (conqueredTaxCollected > 0.0) {
@@ -256,8 +268,8 @@ public class DailyTimerTask extends TownyTimerTask {
 		taxAmount = event.getTax();
 
 		// Town is going to be paid if the nation can afford it.
-		if (!nation.isTaxPercentage() && taxAmount < 0) {
-			payNationTaxToTown(taxAmount, town, nation);
+		if (taxAmount < 0 && !town.isConquered()) {
+			payNationTaxToTown(nation, town, taxAmount);
 			return "";
 		}
 
@@ -267,7 +279,8 @@ public class DailyTimerTask extends TownyTimerTask {
 		if (nation.getBankCap() != 0 && taxAmount + nation.getAccount().getHoldingBalance() > nation.getBankCap())
 			taxAmount = nation.getBankCap() - nation.getAccount().getHoldingBalance();
 
-		if (taxAmount == 0)
+		// This will stop towns paying $0 and stop conquered towns from getting a less-than-zero tax charge.
+		if (taxAmount <= 0)
 			return "";
 
 		// Town is able to pay the nation's tax.
@@ -331,8 +344,11 @@ public class DailyTimerTask extends TownyTimerTask {
 		return "";
 	}
 
-	private void payNationTaxToTown(double taxAmount, Town town, Nation nation) {
-		// TODO Implement feature.
+	private void payNationTaxToTown(Nation nation, Town town, double tax) {
+		if (!nation.getAccount().canPayFromHoldings(tax))
+			return;
+		nation.getAccount().payTo(tax, town.getAccount(), "Nation Tax Payment To Town");
+		taxCollected += tax;
 	}
 
 	/**
@@ -367,16 +383,28 @@ public class DailyTimerTask extends TownyTimerTask {
 	 * @param town - Town to collect taxes from
 	 */
 	protected void collectTownTaxes(Town town) {
-		// Resident Tax
+		/*
+		 * Taxes paid by or paid to the Residents of the town.
+		 */
 		collectTownResidentTax(town);
 		if (taxCollected > 0.0) {
 			TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_tax_collected_from_residents", prettyMoney(taxCollected)));
 			taxCollected = 0.0;
+		} else if (taxCollected < 0.0) {
+			// TODO: Make a new negative amount lang string.
+			TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_tax_collected_from_residents", prettyMoney(taxCollected)));
+			taxCollected = 0.0;
 		}
 
-		// Plot Tax
+		/*
+		 * Taxes paid by or paid to the Residents that own Town land personally.
+		 */
 		collecTownPlotTax(town);
 		if (taxCollected > 0.0) {
+			TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_tax_collected_from_plots", prettyMoney(taxCollected)));
+			taxCollected = 0.0;
+		} else if (taxCollected < 0.0) {
+			// TODO: Make a new negative amount lang string.
 			TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_tax_collected_from_plots", prettyMoney(taxCollected)));
 			taxCollected = 0.0;
 		}
@@ -385,6 +413,10 @@ public class DailyTimerTask extends TownyTimerTask {
 	private void collectTownResidentTax(Town town) {
 		double tax = town.getTaxes();
 		if (tax == 0)
+			return;
+
+		// Don't allow negative taxes if the town uses a tax percentage or negative town tax is explicitly disallowed.
+		if (tax < 0 && (!TownySettings.isNegativeTownTaxAllowed() || town.isTaxPercentage()))
 			return;
 
 		// Tax is over 0.
@@ -423,7 +455,7 @@ public class DailyTimerTask extends TownyTimerTask {
 
 	private boolean collectTownTaxFromResident(double tax, Resident resident, Town town) {
 		if (tax < 0) {
-			payTownTaxToResidents(town);
+			payTownTaxToResidents(town, resident, tax);
 			return true;
 		}
 
@@ -468,8 +500,11 @@ public class DailyTimerTask extends TownyTimerTask {
 		return false;
 	}
 
-	private void payTownTaxToResidents(Town town) {
-		// TODO Implement feature.
+	private void payTownTaxToResidents(Town town, Resident resident, double tax) {
+		if (!town.getAccount().canPayFromHoldings(tax))
+			return;
+		town.getAccount().payTo(tax, resident.getAccount(), "Town Tax Payment To Resident");
+		taxCollected += tax;
 	}
 
 	private void collecTownPlotTax(Town town) {
@@ -554,6 +589,7 @@ public class DailyTimerTask extends TownyTimerTask {
 		if (!town.getAccount().canPayFromHoldings(tax))
 			return;
 		town.getAccount().payTo(tax, resident.getAccount(), String.format("Plot Tax Payment To Resident (%s)", typeName));
+		taxCollected += tax;
 	}
 
 	/**

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
@@ -232,8 +232,7 @@ public class DailyTimerTask extends TownyTimerTask {
 			TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_tax_collected_from_towns", prettyMoney(taxCollected)));
 			taxCollected = 0.0;
 		} else if (taxCollected < 0.0) {
-			// TODO: A negative Lang String.
-			TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_tax_collected_from_towns", prettyMoney(taxCollected)));
+			TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_tax_paid_to_towns", prettyMoney(taxCollected)));
 			taxCollected = 0.0;
 		}
 
@@ -391,8 +390,7 @@ public class DailyTimerTask extends TownyTimerTask {
 			TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_tax_collected_from_residents", prettyMoney(taxCollected)));
 			taxCollected = 0.0;
 		} else if (taxCollected < 0.0) {
-			// TODO: Make a new negative amount lang string.
-			TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_tax_collected_from_residents", prettyMoney(taxCollected)));
+			TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_tax_paid_to_residents", prettyMoney(taxCollected)));
 			taxCollected = 0.0;
 		}
 
@@ -404,8 +402,7 @@ public class DailyTimerTask extends TownyTimerTask {
 			TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_tax_collected_from_plots", prettyMoney(taxCollected)));
 			taxCollected = 0.0;
 		} else if (taxCollected < 0.0) {
-			// TODO: Make a new negative amount lang string.
-			TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_tax_collected_from_plots", prettyMoney(taxCollected)));
+			TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_tax_paid_to_residents_for_plots", prettyMoney(taxCollected)));
 			taxCollected = 0.0;
 		}
 	}

--- a/Towny/src/main/java/com/palmergames/util/MathUtil.java
+++ b/Towny/src/main/java/com/palmergames/util/MathUtil.java
@@ -57,6 +57,16 @@ public class MathUtil {
 	public static double distance(Coord coord1, Coord coord2) {
 		return distance(coord1.getX(), coord2.getX(), coord1.getZ(), coord2.getZ());
 	}
+
+	public static double getDoubleOrThrow(String input) throws TownyException {
+		double d;
+		try {
+			d = Double.parseDouble(input);
+		} catch (NumberFormatException e) {
+			throw new TownyException(Translatable.of("msg_error_must_be_num"));
+		}
+		return d;
+	}
 	
 	public static int getIntOrThrow(String input) throws TownyException {
 		int i;

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -1954,11 +1954,20 @@ msg_err_cannot_unclaim_not_enough_adjacent_claims: "You cannot unclaim this town
 #Message shown when a nation collects taxes from its towns.
 msg_tax_collected_from_towns: "<aqua>Your nation collected %s in tax from its towns."
 
+#Message shown when a nation pays taxes to its towns.
+msg_tax_paid_to_towns: "<aqua>Your nation paid %s in tax to its towns."
+
 #Message shown when a town collects taxes from its residents.
 msg_tax_collected_from_residents: "<aqua>Your town collected %s in tax from its residents."
 
+#Message shown when a town pays taxes to its residents.
+msg_tax_paid_to_residents: "<aqua>Your town paid %s in tax to its residents."
+
 #Message shown when a town collects taxes from its plottaxes.
 msg_tax_collected_from_plots: "<aqua>Your town collected %s in tax from its plots' taxes."
+
+#Message shown when a town pays taxes to its plottaxes.
+msg_tax_paid_to_residents_for_plots: "<aqua>Your town paid %s in tax to the land owners via plot taxes."
 
 #Message shown when a nation collects taxes from its towns that are conquered.
 msg_tax_collected_from_conquered_towns: "<aqua>Your nation collected %s in extra tax from its conquered towns."


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->

```
  - New Config Option: economy.daily_taxes.allow_negative_town_tax
    - Default: false
    - If enabled, and a town tax is set to a negative amount and is a fixed amount (not percentage,) it will result in every resident being paid by the town bank (if the town can afford it.)
  - New Config Option: economy.daily_taxes.allow_negative_nation_tax
    - Default: false
    - If enabled, and a nation tax is set to a negative amount and is a fixed amount (not percentage,) it will result in every town in the nation being paid by the nation bank (if the nation can afford it.)
```

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

Closes #6705.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
