### PR TITLE
Add a new plotgroup mode for residents to toggle.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/PlotCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/PlotCommand.java
@@ -1216,15 +1216,13 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 	public void parsePlotGroupAdd(String[] split, TownBlock townBlock, Player player, Town town) throws TownyException {
 		checkPermOrThrow(player, PermissionNodes.TOWNY_COMMAND_PLOT_GROUP_ADD.getNode());
 
-		if (split.length == 1) {
-			TownyMessaging.sendErrorMsg(player, Translatable.of("msg_err_you_must_specify_a_group_name"));
-			return;
-		}
+		Resident resident = getResidentOrThrow(player);
 
-		if (split.length != 2)
+		if (split.length != 2 && !resident.hasPlotGroupName())
 			throw new TownyException(Translatable.of("msg_err_plot_group_name_required"));
 
-		String plotGroupName = NameValidation.filterName(split[1]);
+		String plotGroupName = split.length == 2 ? NameValidation.filterName(split[1]) : 
+				resident.hasPlotGroupName() ? resident.getPlotGroupName() : null;
 		plotGroupName = NameValidation.filterCommas(plotGroupName);
 
 		if (town.hasPlotGroupName(plotGroupName)) {
@@ -1251,6 +1249,7 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 				} else 
 					oldGroup.save();
 				createOrAddOnToPlotGroup(townBlock, town, name);
+				resident.setPlotGroupName(name);
 				TownyMessaging.sendMsg(player, Translatable.of("msg_townblock_transferred_from_x_to_x_group", oldGroup.getName(), townBlock.getPlotObjectGroup().getName()));
 			})
 			.setTitle(Translatable.of("msg_plot_group_already_exists_did_you_want_to_transfer", townBlock.getPlotObjectGroup().getName(), split[1]))
@@ -1258,6 +1257,7 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 		} else {
 			// Create a brand new plot group.
 			createOrAddOnToPlotGroup(townBlock, town, plotGroupName);
+			resident.setPlotGroupName(plotGroupName);
 			TownyMessaging.sendMsg(player, Translatable.of("msg_plot_was_put_into_group_x", townBlock.getX(), townBlock.getZ(), townBlock.getPlotObjectGroup().getName()));
 		}
 	}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/ResidentCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/ResidentCommand.java
@@ -80,6 +80,7 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 		"ignoreplots",
 		"bordertitles",
 		"townclaim",
+		"plotgroup",
 		"map",
 		"spy",
 		"reset",
@@ -556,6 +557,7 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 			TownyMessaging.sendMessage(player, ChatTools.formatCommand("Mode", "map", "", Translatable.of("mode_1").forLocale(player)));
 			TownyMessaging.sendMessage(player, ChatTools.formatCommand("Mode", "townclaim", "", Translatable.of("mode_2").forLocale(player)));
 			TownyMessaging.sendMessage(player, ChatTools.formatCommand("Mode", "townunclaim", "", Translatable.of("mode_3").forLocale(player)));
+			TownyMessaging.sendMessage(player, ChatTools.formatCommand("Mode", "plotrgoup", "", "runs /plot group add with your last-used plot group name."));
 			TownyMessaging.sendMessage(player, ChatTools.formatCommand("Mode", "tc", "", Translatable.of("mode_4").forLocale(player)));
 			TownyMessaging.sendMessage(player, ChatTools.formatCommand("Mode", "nc", "", Translatable.of("mode_5").forLocale(player)));
 			TownyMessaging.sendMessage(player, ChatTools.formatCommand("Mode", "ignoreplots", "", ""));

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
@@ -73,6 +73,8 @@ public class TownyCustomListener implements Listener {
 				TownCommand.parseTownClaimCommand(player, new String[] {});
 			if (resident.hasMode("townunclaim"))
 				TownCommand.parseTownUnclaimCommand(player, new String[] {});
+			if (resident.hasMode("plotgroup") && resident.hasPlotGroupName()) 
+				Towny.getPlugin().getScheduler().runLater(player, () -> Bukkit.dispatchCommand(player, "plot group add " + resident.getPlotGroupName()), 1l);
 		} catch (TownyException e) {
 			TownyMessaging.sendErrorMsg(player, e.getMessage(player));
 		}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Resident.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Resident.java
@@ -82,6 +82,7 @@ public class Resident extends TownyObject implements InviteReceiver, EconomyHand
 	private SelectionType guiSelectionType;
 	private ScheduledTask respawnProtectionTask = null;
 	private boolean respawnPickupWarningShown = false; // Prevents chat spam when a player attempts to pick up an item while under respawn protection.
+	private String plotGroupName = null;
 
 	public Resident(String name) {
 		super(name);
@@ -1004,5 +1005,17 @@ public class Resident extends TownyObject implements InviteReceiver, EconomyHand
 	public boolean isSeeingBorderTitles() {
 		BooleanDataField borderMeta = new BooleanDataField("bordertitles");
 		return !MetaDataUtil.hasMeta(this, borderMeta) || MetaDataUtil.getBoolean(this, borderMeta);
+	}
+
+	public boolean hasPlotGroupName() {
+		return plotGroupName != null;
+	}
+
+	public String getPlotGroupName() {
+		return plotGroupName;
+	}
+
+	public void setPlotGroupName(String plotGroupName) {
+		this.plotGroupName = plotGroupName;
 	}
 }


### PR DESCRIPTION


<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Allows a resident to set /res toggle plotgroup, which will auto-group walked-into plots, as long as the resident has a plotgroupname set in memory.

The plotgroupname is automatically set when a resident successfully runs /plot group add NAME.


____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->

Adds /res toggle plotgroup

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


Closes #6404.

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
