### PR TITLE
Make the default resident about configurable

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -2192,6 +2192,11 @@ public enum ConfigNodes {
 			"true",
 			"",
 			"# If true, players who join the server for the first time will be informed about their locale, and about Towny translatable system."),
+	RES_SETTING_DEFAULT_ABOUT(
+			"resident_settings.default_about",
+			"/res set board [board]",
+			"",
+			"# Default resident about"),
 	ECO(
 			"economy",
 			"",

--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -2194,7 +2194,7 @@ public enum ConfigNodes {
 			"# If true, players who join the server for the first time will be informed about their locale, and about Towny translatable system."),
 	RES_SETTING_DEFAULT_ABOUT(
 			"resident_settings.default_about",
-			"/res set board [board]",
+			"/res set about [msg]",
 			"",
 			"# Default resident about"),
 	ECO(

--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -2196,7 +2196,7 @@ public enum ConfigNodes {
 			"resident_settings.default_about",
 			"/res set about [msg]",
 			"",
-			"# Default resident about"),
+			"# The default resident about text, shown in the resident's status screen."),
 	ECO(
 			"economy",
 			"",

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -142,7 +142,7 @@ public class TownyFormatter {
 		screen.addComponentOf("title", ChatTools.formatTitle(resident.getFormattedName() + (playerIsOnlineAndVisible(resident.getName(), sender) ? translator.of("online2") : "")));
 
 		// About: Just a humble farmer
-		if (resident.getAbout() != null && !resident.getAbout().isEmpty())
+		if (!resident.getAbout().isEmpty())
 			screen.addComponentOf("about", colourKeyValue(translator.of("status_about"), resident.getAbout()));
 		
 		// First used if last online is this year, 2nd used if last online is early than this year.

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -3618,5 +3618,8 @@ public class TownySettings {
 		return getBoolean(ConfigNodes.PLUGIN_COREPROTECT_SUPPORT);
 	}
 
+	public static String getDefaultResidentAbout() {
+		return getString(ConfigNodes.RES_SETTING_DEFAULT_ABOUT);
+	}
 }
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/ResidentCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/ResidentCommand.java
@@ -524,7 +524,7 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 			throw new TownyException("Eg: /res set about " + Translatable.of("res_8").forLocale(player));
 
 		if ("reset".equalsIgnoreCase(about)) {
-			about = "/resident set about [msg]";
+			about = TownySettings.getDefaultResidentAbout();
 
 			TownyMessaging.sendMsg(player, Translatable.of("msg_resident_about_reset"));
 		} else if ("none".equalsIgnoreCase(about) || "clear".equalsIgnoreCase(about)) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -1883,7 +1883,8 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 		// surname
 		list.add("surname=" + resident.getSurname());
 		// about
-		list.add("about=" + resident.getAbout());
+		if (!TownySettings.getDefaultResidentAbout().equals(resident.getAbout()))
+			list.add("about=" + resident.getAbout());
 
 		if (resident.hasTown()) {
 			try {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -2153,7 +2153,9 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			res_hm.put("jailBail", resident.getJailBailCost());
 			res_hm.put("title", resident.getTitle());
 			res_hm.put("surname", resident.getSurname());
-			res_hm.put("about", resident.getAbout());
+			
+			if (!TownySettings.getDefaultResidentAbout().equals(resident.getAbout()))
+				res_hm.put("about", resident.getAbout());
 			res_hm.put("town", resident.hasTown() ? resident.getTown().getName() : "");
 			res_hm.put("town-ranks", resident.hasTown() ? StringMgmt.join(resident.getTownRanks(), "#") : "");
 			res_hm.put("nation-ranks", resident.hasTown() ? StringMgmt.join(resident.getNationRanks(), "#") : "");

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Resident.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Resident.java
@@ -1,5 +1,6 @@
 package com.palmergames.bukkit.towny.object;
 
+import com.google.common.base.Preconditions;
 import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.TownySettings;
@@ -63,7 +64,7 @@ public class Resident extends TownyObject implements InviteReceiver, EconomyHand
 	private boolean isNPC = false;
 	private String title = "";
 	private String surname = "";
-	private String about = "/resident set about [msg]";
+	private String about = TownySettings.getDefaultResidentAbout();
 	private final List<String> modes = new ArrayList<>();
 	private transient Confirmation confirmation;
 	private final transient List<Invite> receivedInvites = new ArrayList<>();
@@ -212,10 +213,12 @@ public class Resident extends TownyObject implements InviteReceiver, EconomyHand
 		return !surname.isEmpty();
 	}
 	
-	public void setAbout(String about) {
+	public void setAbout(@NotNull String about) {
+		Preconditions.checkNotNull(about, "about");
 		this.about = about;
 	}
 	
+	@NotNull
 	public String getAbout() {
 		return about;
 	}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Adds a new config option for the resident about section, similar to nation/town statuses. The about is only saved if it's non-default, so that if the value in the config changes, then the message shown in /res will too (after the next database reload).
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
New config node: resident_settings.default_about
Default: /res set about [msg]
The default resident about text, shown in the resident's status screen.
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
