### PR TITLE
Area effect cloud protection improvements

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPaperEvents.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPaperEvents.java
@@ -4,17 +4,13 @@ import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.event.executors.TownyActionEventExecutor;
-import com.palmergames.bukkit.towny.object.TownBlock;
-import com.palmergames.bukkit.towny.object.TownyWorld;
 import com.palmergames.bukkit.towny.utils.BorderUtil;
-import com.palmergames.bukkit.towny.utils.CombatUtil;
 import com.palmergames.util.JavaUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
 import org.bukkit.entity.AreaEffectCloud;
-import org.bukkit.entity.DragonFireball;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
@@ -29,10 +25,8 @@ import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.player.PlayerEvent;
 import org.bukkit.projectiles.BlockProjectileSource;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.Nullable;
 
 import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.logging.Level;
@@ -50,13 +44,13 @@ public class TownyPaperEvents implements Listener {
 
 	private static final String DRAGON_FIREBALL_HIT_EVENT = "com.destroystokyo.paper.event.entity.EnderDragonFireballHitEvent";
 
-	public static final MethodHandle SIGN_OPEN_GET_CAUSE = getMethodHandle(USED_SIGN_OPEN_EVENT, "getCause");
-	private static final MethodHandle SIGN_OPEN_GET_SIGN = getMethodHandle(USED_SIGN_OPEN_EVENT, "getSign");
+	public static final MethodHandle SIGN_OPEN_GET_CAUSE = JavaUtil.getMethodHandle(USED_SIGN_OPEN_EVENT, "getCause");
+	private static final MethodHandle SIGN_OPEN_GET_SIGN = JavaUtil.getMethodHandle(USED_SIGN_OPEN_EVENT, "getSign");
 
-	private static final MethodHandle GET_ORIGIN = getMethodHandle(Entity.class, "getOrigin");
-	private static final MethodHandle GET_PRIMER_ENTITY = getMethodHandle(PAPER_PRIME_EVENT, "getPrimerEntity");
+	private static final MethodHandle GET_ORIGIN = JavaUtil.getMethodHandle(Entity.class, "getOrigin");
+	private static final MethodHandle GET_PRIMER_ENTITY = JavaUtil.getMethodHandle(PAPER_PRIME_EVENT, "getPrimerEntity");
 
-	public static final MethodHandle DRAGON_FIREBALL_GET_EFFECT_CLOUD = getMethodHandle(DRAGON_FIREBALL_HIT_EVENT, "getAreaEffectCloud");
+	public static final MethodHandle DRAGON_FIREBALL_GET_EFFECT_CLOUD = JavaUtil.getMethodHandle(DRAGON_FIREBALL_HIT_EVENT, "getAreaEffectCloud");
 	
 	public TownyPaperEvents(Towny plugin) {
 		this.plugin = plugin;
@@ -194,21 +188,5 @@ public class TownyPaperEvents implements Listener {
 			if (TownyEntityListener.discardAreaEffectCloud(effectCloud))
 				((Cancellable) event).setCancelled(true);
 		};
-	}
-
-	private static @Nullable MethodHandle getMethodHandle(String className, String methodName) {
-		try {
-			return getMethodHandle(Class.forName(className), methodName);
-		} catch (ClassNotFoundException e) {
-			return null;
-		}
-	}
-
-	private static @Nullable MethodHandle getMethodHandle(Class<?> clazz, String methodName) {
-		try {
-			return MethodHandles.publicLookup().unreflect(clazz.getMethod(methodName));
-		} catch (ReflectiveOperationException e) {
-			return null;
-		}
 	}
 }

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -43,6 +43,7 @@ import com.palmergames.bukkit.util.BukkitTools;
 import com.palmergames.bukkit.util.ChatTools;
 import com.palmergames.bukkit.util.EntityLists;
 import com.palmergames.bukkit.util.ItemLists;
+import com.palmergames.util.JavaUtil;
 import com.palmergames.util.StringMgmt;
 
 import io.papermc.lib.PaperLib;
@@ -88,7 +89,6 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.metadata.MetadataValue;
 
 import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -115,18 +115,8 @@ public class TownyPlayerListener implements Listener {
 	private int teleportWarmupTime = TownySettings.getTeleportWarmupTime();
 	private boolean isMovementCancellingWarmup = TownySettings.isMovementCancellingSpawnWarmup();
 	
-	private static final MethodHandle GET_RESPAWN_FLAGS;
-	
-	static {
-		MethodHandle temp = null;
-		try {
-			// https://jd.papermc.io/paper/1.20/org/bukkit/event/player/PlayerRespawnEvent.html#getRespawnFlags()
-			//noinspection JavaReflectionMemberAccess
-			temp = MethodHandles.publicLookup().unreflect(PlayerRespawnEvent.class.getMethod("getRespawnFlags"));
-		} catch (Throwable ignored) {}
-		
-		GET_RESPAWN_FLAGS = temp;
-	}
+	// https://jd.papermc.io/paper/1.20/org/bukkit/event/player/PlayerRespawnEvent.html#getRespawnFlags()
+	private static final MethodHandle GET_RESPAWN_FLAGS = JavaUtil.getMethodHandle(PlayerRespawnEvent.class, "getRespawnFlags");
 
 	public TownyPlayerListener(Towny plugin) {
 		this.plugin = plugin;

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Coord.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Coord.java
@@ -80,7 +80,7 @@ public class Coord {
 	 * @param value x/z integer
 	 * @return cell position
 	 */
-	protected static int toCell(int value) {
+	public static int toCell(int value) {
 		// Floor divides means that for negative values will round to the next negative value
 		// and positive value to the previous positive value.
 		return Math.floorDiv(value, getCellSize());

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/TownyPerms.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/TownyPerms.java
@@ -9,6 +9,7 @@ import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownyWorld;
 import com.palmergames.bukkit.util.BukkitTools;
+import com.palmergames.util.JavaUtil;
 import org.bukkit.configuration.MemorySection;
 import org.bukkit.entity.Player;
 import org.bukkit.permissions.Permission;
@@ -20,8 +21,6 @@ import org.jetbrains.annotations.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.reflect.Field;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -37,6 +36,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
@@ -62,18 +62,7 @@ public class TownyPerms {
 		TownyPerms.plugin = plugin;
 	}
 	
-	private static final MethodHandle PERMISSIONS;
-
-	// Setup reflection (Thanks to Codename_B for the reflection source)
-	static {
-		try {
-			Field permissionsField = PermissionAttachment.class.getDeclaredField("permissions");
-			permissionsField.setAccessible(true);
-			PERMISSIONS = MethodHandles.lookup().unreflectGetter(permissionsField);
-		} catch (ReflectiveOperationException e) {
-			throw new RuntimeException(e);
-		}
-	}
+	private static final MethodHandle PERMISSIONS = Objects.requireNonNull(JavaUtil.getFieldHandle(PermissionAttachment.class, "permissions"), "Could not find expected PermissionAttachment.permissions field");
 
 	/**
 	 * Load the townyperms.yml file.

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/MobRemovalTimerTask.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/MobRemovalTimerTask.java
@@ -3,7 +3,6 @@ package com.palmergames.bukkit.towny.tasks;
 import com.palmergames.bukkit.config.ConfigNodes;
 import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.TownyAPI;
-import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.event.MobRemovalEvent;
 import com.palmergames.bukkit.towny.hooks.PluginIntegrations;
@@ -12,6 +11,7 @@ import com.palmergames.bukkit.towny.object.TownyWorld;
 import com.palmergames.bukkit.towny.utils.EntityTypeUtil;
 import com.palmergames.bukkit.util.BukkitTools;
 
+import com.palmergames.util.JavaUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
@@ -25,7 +25,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -40,7 +39,8 @@ public class MobRemovalTimerTask extends TownyTimerTask {
 	private static final Set<String> ignoredSpawnReasons = new HashSet<>();
 	private boolean isRemovingKillerBunny;
 	
-	private static final MethodHandle GET_SPAWN_REASON;
+	// https://jd.papermc.io/paper/1.20/org/bukkit/entity/Entity.html#getEntitySpawnReason()
+	private static final MethodHandle GET_SPAWN_REASON = JavaUtil.getMethodHandle(Entity.class, "getEntitySpawnReason");
 
 	public MobRemovalTimerTask(Towny plugin) {
 		super(plugin);
@@ -177,17 +177,5 @@ public class MobRemovalTimerTask extends TownyTimerTask {
 		ignoredSpawnReasons.clear();
 		for (final String cause : TownySettings.getStrArr(ConfigNodes.PROT_MOB_REMOVE_IGNORED_SPAWN_CAUSES))
 			ignoredSpawnReasons.add(cause.toUpperCase(Locale.ROOT));
-	}
-	
-	static {
-		MethodHandle temp = null;
-		try {
-			// https://jd.papermc.io/paper/1.20/org/bukkit/entity/Entity.html#getEntitySpawnReason()
-			//noinspection JavaReflectionMemberAccess
-			temp = MethodHandles.publicLookup().unreflect(Entity.class.getMethod("getEntitySpawnReason"));
-			TownyMessaging.sendDebugMsg("Using Entity.html#getEntitySpawnReason");
-		} catch (ReflectiveOperationException ignored) {}
-		
-		GET_SPAWN_REASON = temp;
 	}
 }

--- a/Towny/src/main/java/com/palmergames/util/JavaUtil.java
+++ b/Towny/src/main/java/com/palmergames/util/JavaUtil.java
@@ -1,12 +1,17 @@
 package com.palmergames.util;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.BufferedReader;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.CopyOption;
 import java.nio.file.Files;
@@ -78,5 +83,33 @@ public class JavaUtil {
 	public static <T> T make(T initial, Consumer<T> initializer) {
 		initializer.accept(initial);
 		return initial;
+	}
+
+	public static @Nullable MethodHandle getMethodHandle(final @NotNull String className, final @NotNull String methodName) {
+		try {
+			return getMethodHandle(Class.forName(className), methodName);
+		} catch (ClassNotFoundException e) {
+			return null;
+		}
+	}
+
+	public static @Nullable MethodHandle getMethodHandle(final @NotNull Class<?> clazz, final @NotNull String methodName) {
+		try {
+			final Method method = clazz.getDeclaredMethod(methodName);
+			method.setAccessible(true);
+			return MethodHandles.publicLookup().unreflect(method);
+		} catch (ReflectiveOperationException e) {
+			return null;
+		}
+	}
+	
+	public static @Nullable MethodHandle getFieldHandle(final @NotNull Class<?> clazz, final @NotNull String fieldName) {
+		try {
+			final Field field = clazz.getDeclaredField(fieldName);
+			field.setAccessible(true);
+			return MethodHandles.publicLookup().unreflectGetter(field);
+		} catch (ReflectiveOperationException e) {
+			return null;
+		}
 	}
 }

--- a/Towny/src/main/java/com/palmergames/util/JavaUtil.java
+++ b/Towny/src/main/java/com/palmergames/util/JavaUtil.java
@@ -12,6 +12,7 @@ import java.nio.file.CopyOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -72,5 +73,10 @@ public class JavaUtil {
 	
 	public static <T> T make(Supplier<T> supplier) {
 		return supplier.get();
+	}
+	
+	public static <T> T make(T initial, Consumer<T> initializer) {
+		initializer.accept(initial);
+		return initial;
 	}
 }


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
- Fixed 1.16/1.17 compat
- Added forward compat for if PotionEffectType#getName ends up changing
- Added a listener for paper's dragon fireball hit event to discard it as soon as it hits in a townblock with pvp off
- Optimized the code that checks whether to discard detrimental effect clouds to reduce the amount of checks
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
