### PR TITLE
Alter /t buytown logic to prevent total loss of money

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -4558,10 +4558,12 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 					return;
 				}
 				
-				if (!resident.getAccount().withdraw(town.getForSalePrice(), "Town purchase cost.")) {
+				if (resident.getAccount().getHoldingBalance() < town.getForSalePrice()) {
 					TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_you_need_x_to_pay", town.getForSalePrice()));
 					return;
 				}
+				
+				resident.getAccount().withdraw(town.getForSalePrice(), "Town purchase cost.");
 				
 				try {
 					if (resident.hasTown())


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This PR should fix an error that occurs when players attempt to buy a town when they do not have enough money under certain server configurations

An error will say they don't have enough to pay but it will still take all the money they currently have on them. This changes the logic to first check if they have the required amount of money and then it withdraws it after rather than attempt to take it out anyways and error if it doesn't completely work

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
