### PR TITLE
Fix towns being deleted causing a second (pointless) town deletion when the last resident is removed.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
@@ -427,7 +427,7 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 
 		for (Resident resident : toSave) {
 			resident.clearModes();
-			resident.removeTown();
+			resident.removeTown(true);
 		}
 		
 		// Look for residents inside of this town's jail(s) and free them, more than 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
@@ -427,7 +427,7 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 
 		for (Resident resident : toSave) {
 			resident.clearModes();
-			resident.removeTown(true);
+			resident.removeTown();
 		}
 		
 		// Look for residents inside of this town's jail(s) and free them, more than 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Resident.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Resident.java
@@ -296,10 +296,6 @@ public class Resident extends TownyObject implements InviteReceiver, EconomyHand
 	}
 	
 	public void removeTown() {
-		removeTown(false);
-	}
-	
-	public void removeTown(boolean townDeleted) {
 		
 		if (!hasTown())
 			return;
@@ -328,7 +324,7 @@ public class Resident extends TownyObject implements InviteReceiver, EconomyHand
 		try {
 			town.removeResident(this);
 		} catch (EmptyTownException e) {
-			if (!townDeleted)
+			if (town.exists())
 				TownyUniverse.getInstance().getDataSource().removeTown(town, false);
 		} catch (NotRegisteredException ignored) {}
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Resident.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Resident.java
@@ -296,6 +296,10 @@ public class Resident extends TownyObject implements InviteReceiver, EconomyHand
 	}
 	
 	public void removeTown() {
+		removeTown(false);
+	}
+	
+	public void removeTown(boolean townDeleted) {
 		
 		if (!hasTown())
 			return;
@@ -324,7 +328,8 @@ public class Resident extends TownyObject implements InviteReceiver, EconomyHand
 		try {
 			town.removeResident(this);
 		} catch (EmptyTownException e) {
-			TownyUniverse.getInstance().getDataSource().removeTown(town, false);
+			if (!townDeleted)
+				TownyUniverse.getInstance().getDataSource().removeTown(town, false);
 		} catch (NotRegisteredException ignored) {}
 
 		try {


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

A recent commit made it so that we actually act upon a resident removing their town fulfilling the EmptyTownException. 

![image](https://github.com/TownyAdvanced/Towny/assets/879756/8cf5daa6-2cd8-4f8c-924f-35f1fd90cf34)


____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
