### PR TITLE
Enhance Nation Requires Proximity Feature

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -950,14 +950,6 @@ public enum ConfigNodes {
 			"",
 			"# If set to true, if a nation is disbanded due to a lack of residents, the capital will be refunded the cost of nation creation."
 	),
-	GTOWN_SETTINGS_NATION_REQUIRES_PROXIMITY(
-			"global_town_settings.nation_requires_proximity",
-			"0.0",
-			"",
-			"# The maximum number of townblocks a town can be away from a nation capital,",
-			"# Automatically precludes towns from one world joining a nation in another world.",
-			"# If the number is 0, towns will not a proximity to a nation."
-	),
 	GTOWN_FARM_ANIMALS(
 			"global_town_settings.farm_animals",
 			"PIG,COW,CHICKEN,SHEEP,MOOSHROOM",
@@ -1313,7 +1305,38 @@ public enum ConfigNodes {
 			"-1",
 			"",
 			"# The maximum amount of allies that a nation can have, set to -1 to have no limit."),
-
+	GNATION_SETTINGS_PROXIMITY_ROOT(
+			"global_nation_settings.proximity", "", ""),
+	GNATION_SETTINGS_NATION_PROXIMITY_TO_CAPITAL(
+			"global_nation_settings.proximity.nation_proximity_to_capital_city",
+			"0.0",
+			"",
+			"# The maximum number of townblocks a town's homeblock can be away from their nation capital's homeblock.",
+			"# Automatically precludes towns from one world joining a nation in another world.",
+			"# If the number is 0, towns will not a proximity to a nation."
+	),
+	GNATION_SETTINGS_NATION_PROXIMITY_TO_OTHER_NATION_TOWNS(
+			"global_nation_settings.proximity.nation_proximity_to_other_nation_towns",
+			"0.0",
+			"",
+			"# The maximum number of townblocks a town's homeblock can be away from other towns's homeblocks in the nation.",
+			"# This setting is only used when nation_proximity_to_capital_city is above 0.",
+			"# When used, and a town is out of range of their capital city, the remaining towns in the nation will be parsed,",
+			"# if one of those towns' homeblocks is close enough to the town's homeblock, the town can remain in the nation.",
+			"# Leave this setting at 0.0 in order to de-activate nations' towns granting further range for towns in the nation."
+	),
+	GNATION_SETTINGS_NATION_PROXIMITY_TO_CAPITAL_CAP(
+			"global_nation_settings.proximity.absolute_distance_from_capital",
+			"0.0",
+			"",
+			"# The maximum number of townblocks a town's homeblock can be away from their nation's capital's homeblock,",
+			"# when the town is being allowed to go further out from the capital because of the nation_proximity_to_other_nation_towns",
+			"# setting above.",
+			"# This setting is what will stop a nation being able to go incredibly wide due to towns 'chaining' together.",
+			"# This setting is only used when nation_proximity_to_capital_city is above 0.",
+			"# Leave this setting at 0.0 in order to allow nations to chain towns together to go as wide as they like."
+	),
+	
 	GNATION_SETTINGS_ALLOW_NUMBERS_IN_NATION_NAME(
 		"global_nation_settings.allow_numbers_in_nation_name",
 		"true",

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -3050,8 +3050,25 @@ public class TownySettings {
 		return getBoolean(ConfigNodes.GTOWN_SETTINGS_REFUND_DISBAND_LOW_RESIDENTS);
 	}
 	
+	/**
+	 * @deprecated since 0.100.0.9, use {@link #getNationProximityToCapital()} instead.
+	 * @return getNationProximityToCapital()
+	 */
+	@Deprecated
 	public static double getNationRequiresProximity() {
-		return getDouble(ConfigNodes.GTOWN_SETTINGS_NATION_REQUIRES_PROXIMITY);
+		return getNationProximityToCapital();
+	}
+
+	public static double getNationProximityToCapital() {
+		return getDouble(ConfigNodes.GNATION_SETTINGS_NATION_PROXIMITY_TO_CAPITAL);
+	}
+
+	public static double getNationProximityToOtherNationTowns() {
+		return getDouble(ConfigNodes.GNATION_SETTINGS_NATION_PROXIMITY_TO_OTHER_NATION_TOWNS);
+	}
+
+	public static double getNationProximityAbsoluteMaximum() {
+		return getDouble(ConfigNodes.GNATION_SETTINGS_NATION_PROXIMITY_TO_CAPITAL_CAP);
 	}
 
 	public static List<String> getFarmAnimals() {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -53,6 +53,7 @@ import com.palmergames.bukkit.towny.utils.AreaSelectionUtil;
 import com.palmergames.bukkit.towny.utils.JailUtil;
 import com.palmergames.bukkit.towny.utils.MoneyUtil;
 import com.palmergames.bukkit.towny.utils.NameUtil;
+import com.palmergames.bukkit.towny.utils.ProximityUtil;
 import com.palmergames.bukkit.towny.utils.ResidentUtil;
 import com.palmergames.bukkit.towny.utils.SpawnUtil;
 import com.palmergames.bukkit.towny.utils.TownRuinUtil;
@@ -1647,7 +1648,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			break;
 		case "recheck":
 			checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_NATION_RECHECK.getNode());
-			nation.removeOutOfRangeTowns();
+			ProximityUtil.removeOutOfRangeTowns(nation);
 			TownyMessaging.sendMsg(sender, Translatable.of("nation_rechecked_by_admin", nation.getName()));
 			break;
 		case "rename":

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Nation.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Nation.java
@@ -17,9 +17,9 @@ import com.palmergames.bukkit.towny.invites.exceptions.TooManyInvitesException;
 import com.palmergames.bukkit.towny.object.SpawnPoint.SpawnPointType;
 import com.palmergames.bukkit.towny.object.metadata.CustomDataField;
 import com.palmergames.bukkit.towny.permissions.TownyPerms;
+import com.palmergames.bukkit.towny.utils.ProximityUtil;
 import com.palmergames.bukkit.towny.utils.TownyComponents;
 import com.palmergames.bukkit.util.BukkitTools;
-import com.palmergames.util.MathUtil;
 import net.kyori.adventure.audience.Audience;
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -398,44 +398,25 @@ public class Nation extends Government {
 	 * nation capital homeblock. Results in towns whose homeblocks are no 
 	 * longer close enough to the capital homeblock being removed from 
 	 * the nation.
+	 * 
+	 * @deprecated since 0.100.0.9 use {@link ProximityUtil#removeOutOfRangeTowns(Nation)} instead.
 	 */
+	@Deprecated
 	public void removeOutOfRangeTowns() {
-		if(capital != null && TownySettings.getNationRequiresProximity() > 0) {
-			List<Town> toRemove = gatherOutOfRangeTowns(new ArrayList<>(getTowns()), capital);
-			if (!toRemove.isEmpty())
-				toRemove.stream().forEach(town -> {
-					TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_town_left_nation", this.getName()));
-					TownyMessaging.sendPrefixedNationMessage(this, Translatable.of("msg_nation_town_left", town.getName()));
-					town.removeNation();
-					town.save();
-				});
-		}
+		ProximityUtil.removeOutOfRangeTowns(this);
 	}
 	
 	/**
 	 * A method which returns a list of Towns too far from the given capital town.
 	 * 
+	 * @deprecated since 0.100.0.9 use {@link ProximityUtil#gatherOutOfRangeTowns(Nation)} instead.
 	 * @param towns - The list of towns to check.
 	 * @param capital - The Town from which to check the distance.
 	 * @return removedTowns - A list of Towns which would be removed by removeOutOfRangeTowns().
 	 */
+	@Deprecated
 	public List<Town> gatherOutOfRangeTowns(List<Town> towns, Town capital) {
-		List<Town> removedTowns = new ArrayList<>();
-		final TownBlock capitalHomeBlock = capital.getHomeBlockOrNull();
-		if (capital.hasHomeBlock() && TownySettings.getNationRequiresProximity() > 0 && capitalHomeBlock != null) {
-			final Coord capitalCoord = capitalHomeBlock.getCoord();
-			
-			for (Town town : towns) {
-				TownBlock townHomeBlock = town.getHomeBlockOrNull();
-				if (town.hasHomeBlock() && capital.getHomeblockWorld().equals(town.getHomeblockWorld()) && townHomeBlock != null) {
-					Coord townCoord = townHomeBlock.getCoord();
-					final double distance = MathUtil.distance(capitalCoord.getX(), townCoord.getX(), capitalCoord.getZ(), townCoord.getZ());
-					if (distance > TownySettings.getNationRequiresProximity())
-						removedTowns.add(town);
-				}
-			}
-		}
-		return removedTowns;
+		return ProximityUtil.gatherOutOfRangeTowns(this);
 	}	
 
 	public void setKing(Resident king) throws TownyException {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Town.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Town.java
@@ -35,9 +35,9 @@ import com.palmergames.bukkit.towny.object.metadata.CustomDataField;
 import com.palmergames.bukkit.towny.permissions.TownyPerms;
 import com.palmergames.bukkit.towny.utils.CombatUtil;
 import com.palmergames.bukkit.towny.utils.MoneyUtil;
+import com.palmergames.bukkit.towny.utils.ProximityUtil;
 import com.palmergames.bukkit.towny.utils.TownyComponents;
 import com.palmergames.bukkit.util.BukkitTools;
-import com.palmergames.util.MathUtil;
 import net.kyori.adventure.audience.Audience;
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -307,6 +307,8 @@ public class Town extends Government implements TownBlockOwner {
 		
 		this.save();
 		BukkitTools.fireEvent(new NationRemoveTownEvent(this, oldNation));
+
+		ProximityUtil.removeOutOfRangeTowns(oldNation);
 	}
 	
 	public void setNation(Nation nation) throws AlreadyRegisteredException {
@@ -640,6 +642,13 @@ public class Town extends Government implements TownBlockOwner {
 		this.purchasedBlocks += purchasedBlocks;
 	}
 
+	public void playerSetsHomeBlock(TownBlock townBlock, Location location, Player player) {
+		setHomeBlock(townBlock);
+		setSpawn(location);
+		setMovedHomeBlockAt(System.currentTimeMillis());
+		TownyMessaging.sendMsg(player, Translatable.of("msg_set_town_home", townBlock.getCoord().toString()));
+	}
+
 	/**
 	 * Sets the HomeBlock of a town
 	 * 
@@ -662,30 +671,16 @@ public class Town extends Government implements TownBlockOwner {
 			spawn = null;
 		}
 
-		Nation townNation = TownyAPI.getInstance().getTownNationOrNull(this);
-		if (this.hasNation() && townNation != null && !townNation.getCapital().equals(this) 
-			&& TownySettings.getNationRequiresProximity() > 0
-			&& townNation.getCapital().hasHomeBlock() && hasHomeBlock()) {
-			
-			WorldCoord capitalCoord = townNation.getCapital().getHomeBlockOrNull().getWorldCoord();
-			WorldCoord townCoord = this.getHomeBlockOrNull().getWorldCoord();
-			
-			if (!townNation.getCapital().getHomeblockWorld().equals(getHomeblockWorld())) {
-				TownyMessaging.sendNationMessagePrefixed(townNation, Translatable.of("msg_nation_town_moved_their_homeblock_too_far", getName()));
-				removeNation();
-			}
-			
-			int x1 = capitalCoord.getX();
-			int x2 = townCoord.getX();
-			int y1 = capitalCoord.getZ();
-			int y2 = townCoord.getZ();
-			double  distance = MathUtil.distance(x1, x2, y1, y2);
-			
-			if (distance > TownySettings.getNationRequiresProximity()) {
-				TownyMessaging.sendNationMessagePrefixed(townNation, Translatable.of("msg_nation_town_moved_their_homeblock_too_far", getName()));
-				removeNation();
-			}
-		}
+		if (!hasNation() || TownySettings.getNationProximityToCapital() <= 0 || isCapital())
+			return;
+
+		Nation townNation = getNationOrNull();
+		if (townNation == null || !townNation.getCapital().hasHomeBlock()
+			|| !ProximityUtil.isTownTooFarFromNation(this, townNation))
+			return;
+
+		TownyMessaging.sendNationMessagePrefixed(townNation, Translatable.of("msg_nation_town_moved_their_homeblock_too_far", getName()));
+		removeNation();
 	}
 	
 	/**

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Town.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Town.java
@@ -676,7 +676,7 @@ public class Town extends Government implements TownBlockOwner {
 
 		Nation townNation = getNationOrNull();
 		if (townNation == null || !townNation.getCapital().hasHomeBlock()
-			|| !ProximityUtil.isTownTooFarFromNation(this, townNation))
+			|| !ProximityUtil.isTownTooFarFromNation(this, townNation.getCapital(), townNation.getTowns()))
 			return;
 
 		TownyMessaging.sendNationMessagePrefixed(townNation, Translatable.of("msg_nation_town_moved_their_homeblock_too_far", getName()));

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/ProximityUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/ProximityUtil.java
@@ -41,12 +41,11 @@ public class ProximityUtil {
 		return gatherOutOfRangeTowns(nation, nation.getCapital());
 	}
 
-	public static List<Town> gatherOutOfRangeTowns(Nation nation, Town newCapital) {
+	public static List<Town> gatherOutOfRangeTowns(Nation nation, Town capital) {
 		List<Town> removedTowns = new ArrayList<>();
 		if (TownySettings.getNationProximityToCapital() <= 0)
 			return removedTowns;
 
-		Town capital = newCapital;
 		final TownBlock capitalHomeBlock = capital.getHomeBlockOrNull();
 		// This is unlikely to happen but if a capital has no homeblock by some error we don't want to remove every town.
 		if (capitalHomeBlock == null)
@@ -57,7 +56,7 @@ public class ProximityUtil {
 		List<Town> localRemovedTowns = townsToCheck;
 		// We want to parse over the towns to check until we're no longer getting an above 0 amount of towns being removed.
 		while (localRemovedTowns.size() > 0) {
-			localRemovedTowns = getListOfOutOfRangeTownsFromList(townsToCheck, newCapital, capitalCoord);
+			localRemovedTowns = getListOfOutOfRangeTownsFromList(townsToCheck, capital, capitalCoord);
 			for (Town localTown : localRemovedTowns) {
 				if (!removedTowns.contains(localTown))
 					removedTowns.add(localTown);
@@ -67,26 +66,15 @@ public class ProximityUtil {
 		return removedTowns;
 	}
 
-	private static List<Town> getListOfOutOfRangeTownsFromList(List<Town> towns, Town newCapital, WorldCoord capitalCoord) {
+	private static List<Town> getListOfOutOfRangeTownsFromList(List<Town> towns, Town capital, WorldCoord capitalCoord) {
 		List<Town> removedTowns = new ArrayList<>();
-		WorldCoord townCoord;
 		for (Town town : towns) {
 			// Town is the capital we're measuring against.
-			if (town.equals(newCapital))
+			if (town.equals(capital))
 				continue;
-			// Town missing homeblock, they shouldn't be in the nation any more.
-			if (!town.hasHomeBlock()) {
-				removedTowns.add(town);
-				continue;
-			}
-			townCoord = town.getHomeBlockOrNull().getWorldCoord();
-			// Town homeblock in the wrong world, they shouldn't be in the nation any more.
-			if (capitalCoord.getWorldName().equals(townCoord.getWorldName())){
-				removedTowns.add(town);
-				continue;
-			}
-			// Town homeblock too far away, they shouldn't be in the nation any more.
-			if (isTownTooFarFromNation(town, newCapital, towns))
+			// Check that the town missing is not missing a homeblock, and that the
+			// homeblocks are in the same world, and the distance between.
+			if (isTownTooFarFromNation(town, capital, towns))
 				removedTowns.add(town);
 		}
 		return removedTowns;

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/ProximityUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/ProximityUtil.java
@@ -32,7 +32,7 @@ public class ProximityUtil {
 			throw new TownyException(Translatable.of("msg_err_nation_homeblock_in_another_world"));
 		}
 
-		if (!closeEnoughToCapital(town, capital)) {
+		if (isTownTooFarFromNation(town, capital, nation.getTowns())) {
 			throw new TownyException(Translatable.of("msg_err_town_not_close_enough_to_nation", town.getName()));
 		}
 	}
@@ -97,9 +97,7 @@ public class ProximityUtil {
 	}
 
 	public static boolean isTownTooFarFromNation(Town town, Town newCapital, List<Town> towns) {
-		if (closeEnoughToCapital(town, newCapital))
-			return false;
-		if (closeEnoughToOtherNationTowns(town, newCapital, towns))
+		if (closeEnoughToCapital(town, newCapital) || closeEnoughToOtherNationTowns(town, newCapital, towns))
 			return false;
 		return true;
 	}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/ProximityUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/ProximityUtil.java
@@ -1,0 +1,128 @@
+package com.palmergames.bukkit.towny.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import com.palmergames.bukkit.towny.TownyMessaging;
+import com.palmergames.bukkit.towny.TownySettings;
+import com.palmergames.bukkit.towny.exceptions.TownyException;
+import com.palmergames.bukkit.towny.object.Nation;
+import com.palmergames.bukkit.towny.object.Town;
+import com.palmergames.bukkit.towny.object.TownBlock;
+import com.palmergames.bukkit.towny.object.Translatable;
+import com.palmergames.bukkit.towny.object.WorldCoord;
+import com.palmergames.util.MathUtil;
+
+public class ProximityUtil {
+
+	public static void testTownProximityToNation(Town town, Nation nation) throws TownyException {
+		if (TownySettings.getNationProximityToCapital() <= 0)
+			return;
+
+		if (!nation.getCapital().hasHomeBlock() || !town.hasHomeBlock()) {
+			throw new TownyException(Translatable.of("msg_err_homeblock_has_not_been_set"));
+		}
+
+		WorldCoord capitalCoord = nation.getCapital().getHomeBlockOrNull().getWorldCoord();
+		WorldCoord townCoord = town.getHomeBlockOrNull().getWorldCoord();
+
+		if (!capitalCoord.getWorldName().equalsIgnoreCase(townCoord.getWorldName())) {
+			throw new TownyException(Translatable.of("msg_err_nation_homeblock_in_another_world"));
+		}
+
+		if (!closeEnoughToCapital(town, nation)) {
+			throw new TownyException(Translatable.of("msg_err_town_not_close_enough_to_nation", town.getName()));
+		}
+	}
+
+	public static List<Town> gatherOutOfRangeTowns(Nation nation) {
+		return gatherOutOfRangeTowns(nation, nation.getCapital());
+	}
+
+	public static List<Town> gatherOutOfRangeTowns(Nation nation, Town newCapital) {
+		List<Town> removedTowns = new ArrayList<>();
+		if (TownySettings.getNationProximityToCapital() <= 0)
+			return removedTowns;
+
+		Town capital = newCapital;
+		final TownBlock capitalHomeBlock = capital.getHomeBlockOrNull();
+		// This is unlikely to happen but if a capital has no homeblock by some error we don't want to remove every town.
+		if (capitalHomeBlock == null)
+			return removedTowns;
+
+		final WorldCoord capitalCoord = capitalHomeBlock.getWorldCoord();
+		WorldCoord townCoord;
+		for (Town town : nation.getTowns()) {
+			// Town is the capital we're measuring against.
+			if (town.equals(newCapital))
+				continue;
+			// Town missing homeblock, they shouldn't be in the nation any more.
+			if (!town.hasHomeBlock()) {
+				removedTowns.add(town);
+				continue;
+			}
+			townCoord = town.getHomeBlockOrNull().getWorldCoord();
+			// Town homeblock in the wrong world, they shouldn't be in the nation any more.
+			if (capitalCoord.getWorldName().equals(townCoord.getWorldName())){
+				removedTowns.add(town);
+				continue;
+			}
+			// Town homeblock too far away, they shouldn't be in the nation any more.
+			if (isTownTooFarFromNation(town, nation))
+				removedTowns.add(town);
+		}
+		return removedTowns;
+	}
+
+	public static void removeOutOfRangeTowns(Nation nation) {
+		if (!nation.hasCapital() || TownySettings.getNationProximityToCapital() <= 0)
+			return;
+
+		List<Town> toRemove = gatherOutOfRangeTowns(nation);
+		if (toRemove.isEmpty())
+			return;
+
+		toRemove.stream().forEach(town -> {
+			TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_town_left_nation", nation.getName()));
+			TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_nation_town_left", town.getName()));
+			town.removeNation();
+			town.save();
+		});
+	}
+
+	public static boolean isTownTooFarFromNation(Town town, Nation nation) {
+		if (closeEnoughToCapital(town, nation))
+			return false;
+		if (closeEnoughToOtherNationTowns(town, nation))
+			return false;
+		return true;
+	}
+
+	private static boolean closeEnoughToCapital(Town town, Nation nation) {
+		return closeEnoughToTown(town, nation.getCapital(), TownySettings.getNationProximityToCapital());
+	}
+
+	private static boolean closeEnoughToOtherNationTowns(Town town, Nation nation) {
+		double maxDistanceFromOtherTowns = TownySettings.getNationProximityToOtherNationTowns();
+		double maxDistanceFromTheCapital = TownySettings.getNationProximityAbsoluteMaximum();
+
+		// The town is too far from the nation's absolute cap on proximity from the capital homeblock.
+		if (maxDistanceFromTheCapital > 0 && !closeEnoughToTown(town, nation.getCapital(), maxDistanceFromTheCapital))
+			return false;
+
+		// Try to find at least one town in the nation which is close enough to this town.
+		return nation.getTowns().stream()
+				.filter(t -> !t.equals(town) && !t.isCapital())
+				.anyMatch(t -> closeEnoughToTown(town, t, maxDistanceFromOtherTowns));
+	}
+
+	private static boolean closeEnoughToTown(Town town1, Town town2, double maxDistance) {
+		if (!town1.hasHomeBlock() || !town2.hasHomeBlock())
+			return false;
+
+		WorldCoord town1Coord = town1.getHomeBlockOrNull().getWorldCoord();
+		WorldCoord town2Coord = town2.getHomeBlockOrNull().getWorldCoord();
+		if (!town1Coord.getWorldName().equals(town2Coord.getWorldName()))
+			return false;
+		return MathUtil.distance(town1Coord, town2Coord) <= maxDistance;
+	}
+}

--- a/Towny/src/main/resources/config-migration.json
+++ b/Towny/src/main/resources/config-migration.json
@@ -517,4 +517,14 @@
       }
     ]
   }
+  {
+    "version": "0.100.0.9",
+    "changes": [
+      {
+        "type": "MOVE",
+        "path": "global_town_settings.nation_requires_proximity",
+        "value": "global_nation_settings.proximity.nation_proximity_to_capital_city"
+      }
+    ]
+  }
 ]


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Optionally, towns in a nation can grant nearby towns the ability to bypass the proximity-to-the-nation-capital value.

Also Optionally, there can be a hard-cap on how far a town can be from the nation capital, even when a nation-town is nearby, preventing nations going "wide."

Renames/moves the config settings into the Global Nation Settings section & migrates old configs' settings.

Adds a new ProximityUtil where all the heavy lifting is done.

Spruced up the code in the various methods that used the proximity settings.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->

```
  - Moved Config Option: global_town_settings.nation_requires_proximity -> global_nation_settings.proximity.nation_proximity_to_capital_city
    - Your config's setting value will be transferred to the new location.
  - New Config Option: global_nation_settings.proximity.nation_proximity_to_other_nation_towns
    - Default: 0.0
    - The maximum number of townblocks a town's homeblock can be away from other towns's homeblocks in the nation.
    - This setting is only used when nation_proximity_to_capital_city is above 0.
    - When used, and a town is out of range of their capital city, the remaining towns in the nation will be parsed, if one of those
      towns' homeblocks is close enough to the town's homeblock, the town can remain in the nation.
    - Leave this setting at 0.0 in order to de-activate nations' towns granting further range for towns in the nation.
  - New Config Option: global_nation_settings.proximity.absolute_distance_from_capital
    - Default: 0.0
    - The maximum number of townblocks a town's homeblock can be away from their nation's capital's homeblock, when the town is
      being allowed to go further out from the capital because of the nation_proximity_to_other_nation_towns setting above.
    - This setting is what will stop a nation being able to go incredibly wide due to towns 'chaining' together.
    - This setting is only used when nation_proximity_to_capital_city is above 0.
    - Leave this setting at 0.0 in order to allow nations to chain towns together to go as wide as they like.
```
____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

Closes #5025

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
