### PR TITLE
Add method to ProximityUtil to determine ability to claim land,

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyAPI.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyAPI.java
@@ -953,4 +953,17 @@ public class TownyAPI {
 
 		ProximityUtil.allowTownClaimOrThrow(coordToClaim.getTownyWorld(), coordToClaim, town, outpost);
 	}
+
+	/**
+	 * Test a WorldCoord to see if Towny would allow the area to be unclaimed by the
+	 * given town.
+	 * 
+	 * @param town           Town that would unclaim the land.
+	 * @param coordToUnclaim WorldCoord which is to be unclaimed.
+	 * @throws TownyException thrown when Towny would not allow the unclaim, with
+	 *                        message for the reason why.
+	 */
+	public void testTownUnlaimOrThrow(Town town, WorldCoord coordToUnclaim) throws TownyException {
+		ProximityUtil.allowTownUnclaimOrThrow(coordToUnclaim.getTownyWorld(), coordToUnclaim, town);
+	}
 }

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyAPI.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyAPI.java
@@ -963,7 +963,7 @@ public class TownyAPI {
 	 * @throws TownyException thrown when Towny would not allow the unclaim, with
 	 *                        message for the reason why.
 	 */
-	public void testTownUnlaimOrThrow(Town town, WorldCoord coordToUnclaim) throws TownyException {
+	public void testTownUnclaimOrThrow(Town town, WorldCoord coordToUnclaim) throws TownyException {
 		ProximityUtil.allowTownUnclaimOrThrow(coordToUnclaim.getTownyWorld(), coordToUnclaim, town);
 	}
 }

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyAPI.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyAPI.java
@@ -19,6 +19,7 @@ import com.palmergames.bukkit.towny.object.metadata.CustomDataField;
 import com.palmergames.bukkit.towny.permissions.PermissionNodes;
 import com.palmergames.bukkit.towny.tasks.TeleportWarmupTimerTask;
 import com.palmergames.bukkit.towny.utils.CombatUtil;
+import com.palmergames.bukkit.towny.utils.ProximityUtil;
 import com.palmergames.bukkit.util.BukkitTools;
 import com.palmergames.util.MathUtil;
 
@@ -931,5 +932,25 @@ public class TownyAPI {
 
 			// Nothing to complain about, this resident is the owner of the townblock's town or an admin.
 		}
+	}
+
+	/**
+	 * Test a WorldCoord to see if Towny would allow the area to be claimed by the
+	 * given town.
+	 * 
+	 * @param town         Town who would become owner of the land.
+	 * @param coordToClaim WorldCoord which is to be claimed.
+	 * @param outpost      whether this would be an outpost, with no connected town
+	 *                     land.
+	 * @param newTown      whether this would be a brand new town claiming their
+	 *                     first plot.
+	 * @throws TownyException thrown when Towny would not allow the claim, with
+	 *                        message for the reason why.
+	 */
+	public void testTownClaimOrThrow(Town town, WorldCoord coordToClaim, boolean outpost, boolean newTown) throws TownyException {
+		if (newTown)
+			ProximityUtil.allowTownHomeBlockOrThrow(coordToClaim.getTownyWorld(), coordToClaim, town, true);
+
+		ProximityUtil.allowTownClaimOrThrow(coordToClaim.getTownyWorld(), coordToClaim, town, outpost);
 	}
 }

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -2471,20 +2471,6 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 	 * @throws TownyException when a new town isn't allowed.
 	 */
 	public static void newTown(Player player, String name, Resident resident, boolean noCharge) throws TownyException {
-		newTown(player, name, resident, noCharge, false);
-	}
-
-	/**
-	 * Create a new town. Command: /town new [townname] or /ta town new [townname]
-	 *
-	 * @param player Player using the command.
-	 * @param name Name of town
-	 * @param resident The resident in charge of the town.
-	 * @param noCharge Charging for creation - /ta town new NAME MAYOR has no charge.
-	 * @param adminCreated true when an admin has used /ta town new [NAME].
-	 * @throws TownyException when a new town isn't allowed.
-	 */
-	public static void newTown(Player player, String name, Resident resident, boolean noCharge, boolean adminCreated) throws TownyException {
 		if (TownySettings.hasTownLimit() && TownyUniverse.getInstance().getTowns().size() >= TownySettings.getTownLimit())
 			throw new TownyException(Translatable.of("msg_err_universe_limit"));
 
@@ -2512,18 +2498,16 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		if (!TownyAPI.getInstance().isWilderness(spawnLocation))
 			throw new TownyException(Translatable.of("msg_already_claimed_1", key));
 
-		if (!adminCreated) {
-			// Check that a town isn't being formed inside of a biome that isn't allowed to be claimed.
-			if (TownySettings.isUnwantedBiomeClaimingEnabled() || TownySettings.isOceanClaimingBlocked()) {
-				List<WorldCoord> selection = Arrays.asList(WorldCoord.parseWorldCoord(spawnLocation));
-				selection = AreaSelectionUtil.filterOutUnwantedBiomeWorldCoords(player, selection);
-				selection = AreaSelectionUtil.filterOutOceanBiomeWorldCoords(player, selection);
-				if (selection.isEmpty())
-					throw new TownyException("msg_err_cannot_begin_town_in_this_biome");
-			}
-	
-			ProximityUtil.allowTownHomeBlockOrThrow(world, key, null, true);
+		// Check that a town isn't being formed inside of a biome that isn't allowed to be claimed.
+		if (TownySettings.isUnwantedBiomeClaimingEnabled() || TownySettings.isOceanClaimingBlocked()) {
+			List<WorldCoord> selection = Arrays.asList(WorldCoord.parseWorldCoord(spawnLocation));
+			selection = AreaSelectionUtil.filterOutUnwantedBiomeWorldCoords(player, selection);
+			selection = AreaSelectionUtil.filterOutOceanBiomeWorldCoords(player, selection);
+			if (selection.isEmpty())
+				throw new TownyException("msg_err_cannot_begin_town_in_this_biome");
 		}
+
+		ProximityUtil.allowTownHomeBlockOrThrow(world, key, null, true);
 
 		// If the town doesn't cost money to create, just make the Town.
 		if (noCharge || !TownyEconomyHandler.isActive()) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -2471,6 +2471,20 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 	 * @throws TownyException when a new town isn't allowed.
 	 */
 	public static void newTown(Player player, String name, Resident resident, boolean noCharge) throws TownyException {
+		newTown(player, name, resident, noCharge, false);
+	}
+
+	/**
+	 * Create a new town. Command: /town new [townname] or /ta town new [townname]
+	 *
+	 * @param player Player using the command.
+	 * @param name Name of town
+	 * @param resident The resident in charge of the town.
+	 * @param noCharge Charging for creation - /ta town new NAME MAYOR has no charge.
+	 * @param adminCreated true when an admin has used /ta town new [NAME].
+	 * @throws TownyException when a new town isn't allowed.
+	 */
+	public static void newTown(Player player, String name, Resident resident, boolean noCharge, boolean adminCreated) throws TownyException {
 		if (TownySettings.hasTownLimit() && TownyUniverse.getInstance().getTowns().size() >= TownySettings.getTownLimit())
 			throw new TownyException(Translatable.of("msg_err_universe_limit"));
 
@@ -2498,16 +2512,18 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		if (!TownyAPI.getInstance().isWilderness(spawnLocation))
 			throw new TownyException(Translatable.of("msg_already_claimed_1", key));
 
-		// Check that a town isn't being formed inside of a biome that isn't allowed to be claimed.
-		if (TownySettings.isUnwantedBiomeClaimingEnabled() || TownySettings.isOceanClaimingBlocked()) {
-			List<WorldCoord> selection = Arrays.asList(WorldCoord.parseWorldCoord(spawnLocation));
-			selection = AreaSelectionUtil.filterOutUnwantedBiomeWorldCoords(player, selection);
-			selection = AreaSelectionUtil.filterOutOceanBiomeWorldCoords(player, selection);
-			if (selection.isEmpty())
-				throw new TownyException("msg_err_cannot_begin_town_in_this_biome");
+		if (!adminCreated) {
+			// Check that a town isn't being formed inside of a biome that isn't allowed to be claimed.
+			if (TownySettings.isUnwantedBiomeClaimingEnabled() || TownySettings.isOceanClaimingBlocked()) {
+				List<WorldCoord> selection = Arrays.asList(WorldCoord.parseWorldCoord(spawnLocation));
+				selection = AreaSelectionUtil.filterOutUnwantedBiomeWorldCoords(player, selection);
+				selection = AreaSelectionUtil.filterOutOceanBiomeWorldCoords(player, selection);
+				if (selection.isEmpty())
+					throw new TownyException("msg_err_cannot_begin_town_in_this_biome");
+			}
+	
+			ProximityUtil.allowTownHomeBlockOrThrow(world, key, null, true);
 		}
-
-		ProximityUtil.allowTownHomeBlockOrThrow(world, key, null, true);
 
 		// If the town doesn't cost money to create, just make the Town.
 		if (noCharge || !TownyEconomyHandler.isActive()) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -3570,18 +3570,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		}
 
 		// Prevent unclaiming land that would reduce the number of adjacent claims of neighbouring plots below the threshold.
-		int minAdjacentBlocks = TownySettings.getMinAdjacentBlocks();
-		if (minAdjacentBlocks > 0 && ProximityUtil.townHasClaimedEnoughLandToBeRestrictedByAdjacentClaims(town, minAdjacentBlocks)) {
-			WorldCoord firstWorldCoord = selection.get(0);
-			for (WorldCoord wc : firstWorldCoord.getCardinallyAdjacentWorldCoords(true)) {
-				if (wc.isWilderness() || !wc.hasTown(town))
-					continue;
-				int numAdjacent = ProximityUtil.numAdjacentTownOwnedTownBlocks(town, wc);
-				// The number of adjacement TBs is not enough and there is not a nearby outpost.
-				if (numAdjacent - 1 < minAdjacentBlocks && ProximityUtil.numAdjacentOutposts(town, wc) == 0)
-					throw new TownyException(Translatable.of("msg_err_cannot_unclaim_not_enough_adjacent_claims", wc.getX(), wc.getZ(), numAdjacent));
-			}
-		}
+		ProximityUtil.testAdjacentUnclaimsRulesOrThrow(selection.get(0), town);
 
 		BukkitTools.ifCancelledThenThrow(new TownPreUnclaimCmdEvent(town, resident, world, selection));
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/TownClaim.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/TownClaim.java
@@ -260,7 +260,7 @@ public class TownClaim implements Runnable {
 		// Check if a plot snapshot exists for this townblock already (inactive, unqueued regeneration.)
 		if (!TownyUniverse.getInstance().getDataSource().hasPlotData(townBlock)) {
 			// Queue to have a snapshot made if there is not already an earlier snapshot.
-			plugin.getScheduler().run(worldCoord.getLowerMostCornerLocation(), () -> TownyRegenAPI.handleNewSnapshot(townBlock));
+			plugin.getScheduler().runAsync(() -> TownyRegenAPI.handleNewSnapshot(townBlock));
 		}
 	}
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/ProximityUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/ProximityUtil.java
@@ -2,6 +2,7 @@ package com.palmergames.bukkit.towny.utils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.jetbrains.annotations.Nullable;
@@ -13,6 +14,7 @@ import com.palmergames.bukkit.towny.object.Coord;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
+import com.palmergames.bukkit.towny.object.TownBlockOwner;
 import com.palmergames.bukkit.towny.object.TownyWorld;
 import com.palmergames.bukkit.towny.object.Translatable;
 import com.palmergames.bukkit.towny.object.WorldCoord;
@@ -61,6 +63,78 @@ public class ProximityUtil {
 				distanceToNextNearestHomeblock > TownySettings.getMaxDistanceBetweenHomeblocks())
 				throw new TownyException(Translatable.of("msg_too_far"));
 		}
+	}
+
+	public static void allowTownClaimOrThrow(TownyWorld world, WorldCoord townBlockToClaim, @Nullable Town town, boolean outpost) throws TownyException {
+		// Check if the town has claims available.
+		if (!town.hasUnlimitedClaims() && town.availableTownBlocks() <= 0)
+			throw new TownyException(Translatable.of("msg_err_not_enough_blocks"));
+
+		// Check if this is already claimed by someone.
+		if (!townBlockToClaim.isWilderness())
+			throw new TownyException(Translatable.of("msg_already_claimed", townBlockToClaim.getTownOrNull()));
+
+		// Check distance to other homeblocks.
+		if (AreaSelectionUtil.isTooCloseToHomeBlock(townBlockToClaim, town))
+			throw new TownyException(Translatable.of("msg_too_close2", Translatable.of("homeblock")));
+
+		// Check distance to other townblocks.
+		if (world.getMinDistanceFromOtherTownsPlots(townBlockToClaim, town) >= TownySettings.getMinDistanceFromTownPlotblocks())
+			throw new TownyException(Translatable.of("msg_too_close2", Translatable.of("townblock")));
+
+		// Check adjacent claims rules.
+		testAdjacentClaimsRulesOrThrow(townBlockToClaim, town, outpost);
+
+		// Check that we're on an edge if it is not an outpost.
+		if (!outpost && !isEdgeBlock(town, townBlockToClaim) && !town.getTownBlocks().isEmpty())
+			throw new TownyException(Translatable.of("msg_err_not_attached_edge"));
+	}
+
+	public static void testAdjacentClaimsRulesOrThrow(WorldCoord townBlockToClaim, Town town, boolean outpost) throws TownyException {
+		int minAdjacentBlocks = TownySettings.getMinAdjacentBlocks();
+		if (!outpost && minAdjacentBlocks > 0 && townHasClaimedEnoughLandToBeRestrictedByAdjacentClaims(town, minAdjacentBlocks)) {
+			// Only consider the first worldCoord, larger selection-claims will automatically "bubble" anyways.
+			int numAdjacent = numAdjacentTownOwnedTownBlocks(town, townBlockToClaim);
+			// The number of adjacement TBs is not enough and there is not a nearby outpost.
+			if (numAdjacent < minAdjacentBlocks && numAdjacentOutposts(town, townBlockToClaim) == 0)
+				throw new TownyException(Translatable.of("msg_min_adjacent_blocks", minAdjacentBlocks, numAdjacent));
+		}
+	}
+
+	public static boolean townHasClaimedEnoughLandToBeRestrictedByAdjacentClaims(Town town, int minAdjacentBlocks) {
+		if (minAdjacentBlocks == 3 && town.getTownBlocks().size() < 5)
+			// Special rule that makes sure a town can claim a fifth plot after claiming a 2x2 square.
+			return false;
+		return town.getTownBlocks().size() > minAdjacentBlocks;
+	}
+
+	public static int numAdjacentTownOwnedTownBlocks(Town town, WorldCoord worldCoord) {
+		return (int) worldCoord.getCardinallyAdjacentWorldCoords(true).stream()
+			.filter(wc -> wc.hasTown(town))
+			.count();
+	}
+
+	public static int numAdjacentOutposts(Town town, WorldCoord worldCoord) {
+		return (int) worldCoord.getCardinallyAdjacentWorldCoords(true).stream()
+			.filter(wc -> wc.hasTown(town))
+			.map(WorldCoord::getTownBlockOrNull)
+			.filter(Objects::nonNull)
+			.filter(TownBlock::isOutpost)
+			.count();
+	}
+
+	private static boolean isEdgeBlock(TownBlockOwner owner, WorldCoord worldCoord) {
+
+		for (WorldCoord wc : worldCoord.getCardinallyAdjacentWorldCoords()) {
+			if (wc.isWilderness()) {
+				continue;
+			}
+			if (!wc.getTownBlockOrNull().isOwner(owner)) {
+				continue;
+			}
+			return true;
+		}
+		return false;
 	}
 
 	/*


### PR DESCRIPTION
Adds TownyAPI methods to give other plugins an easy way to determine if a town can claim or unclaim an area.

```
testTownClaimOrThrow(Town town, WorldCoord coordToClaim, boolean outpost, boolean newTown)
testTownUnclaimOrThrow(Town town, WorldCoord coordToUnclaim)
```

Moves responsibility for more of the distance code out of the TownCommand into the ProximityUtil.

Closes #6004.

<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
