### PR TITLE
Add a configurable amount of bonus townblocks given to new towns.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -990,6 +990,12 @@ public enum ConfigNodes {
 			"# The maximum townblocks available to a town is (numResidents * ratio).",
 			"# Setting this value to 0 will instead use the level based jump values determined in the town level config.",
 			"# Setting this to -1 will result in every town having unlimited claims."),
+	CLAIMING_DEF_BONUS_CLAIMS(
+			"claiming.new_town_bonus_claims",
+			"0",
+			"",
+			"# An amount of additional townblocks that a town will receive when it is first created, in addition to any amount given via the town_block_ratio or town_levels.",
+			"# As an example: This can be used to add 10 townblocks to a town when it is made so the borders can be grown a bit more before the mayor has to seek out residents."),
 	CLAIMING_TOWN_BLOCK_LIMIT(
 			"claiming.town_block_limit",
 			"0",

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -1338,6 +1338,10 @@ public class TownySettings {
 		return getInt(ConfigNodes.CLAIMING_TOWN_BLOCK_RATIO);
 	}
 
+	public static int getNewTownBonusBlocks() {
+		return getInt(ConfigNodes.CLAIMING_DEF_BONUS_CLAIMS);
+	}
+
 	public static int getTownBlockSize() {
 
 		return getInt(ConfigNodes.CLAIMING_TOWN_BLOCK_SIZE);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -3707,8 +3707,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 			newResidentsAmount > TownySettings.getMaxResidentsForTown(remainingTown))
 			throw new TownyException(Translatable.of("msg_town_merge_err_too_many_residents", TownySettings.getMaxResidentsForTown(remainingTown)));
 
-		if (!remainingTown.hasUnlimitedClaims() && 
-			(remainingTown.getNumTownBlocks() + succumbingTown.getNumTownBlocks()) > TownySettings.getMaxTownBlocks(remainingTown, newResidentsAmount))
+		if (!remainingTown.hasUnlimitedClaims() && townWouldHaveTooManyTownBlocks(remainingTown, succumbingTown, newResidentsAmount))
 			throw new TownyException(Translatable.of("msg_town_merge_err_too_many_townblocks", TownySettings.getMaxTownBlocks(remainingTown, newResidentsAmount)));
 
 		if ((remainingTown.getPurchasedBlocks() + succumbingTown.getPurchasedBlocks()) > TownySettings.getMaxPurchasedBlocks(remainingTown, newResidentsAmount))
@@ -3729,6 +3728,15 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 
 		if (!BukkitTools.isOnline(succumbingTown.getMayor().getName()) || succumbingTown.getMayor().isNPC())
 			throw new TownyException(Translatable.of("msg_town_merge_other_offline", succumbingTown.getName(), succumbingTown.getMayor().getName()));
+	}
+
+	private static boolean townWouldHaveTooManyTownBlocks(Town remainingTown, Town succumbingTown, int newResidentsAmount) {
+		int newTownBonus = TownySettings.getNewTownBonusBlocks();
+		int succumbingTownTBAmount = succumbingTown.getNumTownBlocks();
+		if (newTownBonus > 0 && succumbingTown.getBonusBlocks() >= newTownBonus)
+			succumbingTownTBAmount = succumbingTownTBAmount - newTownBonus;
+
+		return (remainingTown.getNumTownBlocks() + succumbingTownTBAmount) > TownySettings.getMaxTownBlocks(remainingTown, newResidentsAmount);
 	}
 
 	private static double[] getMergeCosts(Town remainingTown, Town succumbingTown, boolean admin) throws TownyException {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
@@ -1145,7 +1145,12 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 		List<Location> outposts = new ArrayList<Location>(mergeFrom.getAllOutpostSpawns());
 
 		mergeInto.addPurchasedBlocks(mergeFrom.getPurchasedBlocks());
-		mergeInto.addBonusBlocks(mergeFrom.getBonusBlocks());
+
+		int mergeFromBonus = mergeFrom.getBonusBlocks();
+		int newTownBonus = TownySettings.getNewTownBonusBlocks();
+		if (newTownBonus > 0 && mergeFromBonus >= newTownBonus)
+			mergeFromBonus = mergeFromBonus - newTownBonus;
+		mergeInto.addBonusBlocks(mergeFromBonus);
 
 		for (TownBlock tb : mergeFrom.getTownBlocks()) {
 			tb.setTown(mergeInto);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
@@ -115,6 +115,11 @@ public class TownyCustomListener implements Listener {
 			}
 		}, 200L);
 
+		// Award new town with any potential bonus blocks.
+		int bonus = TownySettings.getNewTownBonusBlocks();
+		if (bonus > 0)
+			town.setBonusBlocks(town.getBonusBlocks() + bonus);
+
 		//TODO: at some point it might be nice to have a written_book given to mayors 
 		// which could contain the above advice about depositing money, or containing
 		// links to the commands page on the wiki.


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->


Takes care of a loophole that would let merging towns farm bonus townblocks.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
```
  - New Config Option: claiming.new_town_bonus_claims
    - Default: 0
    - An amount of additional townblocks that a town will receive when it is first created, in addition to any amount given via the town_block_ratio or town_levels.
    - As an example: This can be used to add 10 townblocks to a town when it is made so the borders can be grown a bit more before the mayor has to seek out residents.
```

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

Closes #7195.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
