### PR TITLE
Add sanctioned towns hover component to nation status screen

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -518,7 +518,7 @@ public class TownyFormatter {
 				HoverEvent.showText(TownyComponents.miniMessage(getFormattedStrings(translator.of("status_nation_sanctioned_towns"), sanctionedTowns, nation.getSanctionedTowns().size()))
 					.append(Component.newline())
 					.append(translator.component("status_hover_click_for_more"))),
-				ClickEvent.runCommand("/towny:nation sanctiontown list"));
+				ClickEvent.runCommand("/towny:nation sanctiontown list " + nation.getName()));
 
 		// Add any metadata which opt to be visible.
 		List<Component> fields = getExtraFields(nation);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -508,7 +508,7 @@ public class TownyFormatter {
 						.append(translator.component("status_hover_click_for_more"))),
 				ClickEvent.runCommand("/towny:nation enemylist " + nation.getName()));
 		
-		// Sanctioned Towns [3]: Prague, Berlin, Vienna
+		// [Sanctioned Towns] with hover showing Sanctioned Towns [3]: Prague, Berlin, Vienna
 		List<String> sanctionedTowns = getFormattedNames(nation.getSanctionedTowns());
 		if (sanctionedTowns.size() > 10)
 			shortenOverLengthList(sanctionedTowns, 11, translator);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -507,6 +507,18 @@ public class TownyFormatter {
 						.append(Component.newline())
 						.append(translator.component("status_hover_click_for_more"))),
 				ClickEvent.runCommand("/towny:nation enemylist " + nation.getName()));
+		
+		// Sanctioned Towns [3]: Prague, Berlin, Vienna
+		List<String> sanctionedTowns = getFormattedNames(nation.getSanctionedTowns());
+		if (sanctionedTowns.size() > 10)
+			shortenOverLengthList(sanctionedTowns, 11, translator);
+		
+		if (sanctionedTowns.size() > 0)
+			screen.addComponentOf("sanctionedtowns", colourHoverKey(translator.of("status_nation_sanctioned_towns")),
+				HoverEvent.showText(TownyComponents.miniMessage(getFormattedStrings(translator.of("status_nation_sanctioned_towns"), sanctionedTowns, nation.getSanctionedTowns().size()))
+					.append(Component.newline())
+					.append(translator.component("status_hover_click_for_more"))),
+				ClickEvent.runCommand("/towny:nation sanctiontown list"));
 
 		// Add any metadata which opt to be visible.
 		List<Component> fields = getExtraFields(nation);

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -2427,3 +2427,5 @@ msg_err_unable_to_use_bank_outside_bank_plot_no_homeblock: 'You cannot use that 
 msg_err_you_cannot_outlaw_your_mayor: "You cannot outlaw your town's mayor."
 
 msg_err_you_cannot_outlaw_because_of_rank: "You cannot outlaw %s because of a town rank they hold."
+    
+status_nation_sanctioned_towns: "Sanctioned Towns"


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This adds a "[Sanctioned Towns]" section to the end of the nation status screen, it acts just like the enemies, allies, towns etc. hover components, clicking runs the list command (pictured below)

![image](https://github.com/TownyAdvanced/Towny/assets/49851457/cd21fd10-99ab-4f8b-8318-28c40036c9f7)
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
N/A
____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
N/A
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
