### PR TITLE
Add nation_resident LuckPerms context

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1484,7 +1484,7 @@ public enum ConfigNodes {
 			"*",
 			"",
 			"# Configure what contexts to enable/disable here, contexts must be separated by a comma.",
-			"# Available contexts: towny:resident, towny:mayor, towny:king, towny:insidetown, towny:insideowntown, towny:insideownplot, towny:townrank",
+			"# Available contexts: towny:resident, towny:nation_resident, towny:mayor, towny:king, towny:insidetown, towny:insideowntown, towny:insideownplot, towny:townrank",
 			"# towny:nationrank, towny:town, towny:nation"
 	),
 	

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/hooks/LuckPermsContexts.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/hooks/LuckPermsContexts.java
@@ -35,6 +35,7 @@ public class LuckPermsContexts implements ContextCalculator<Player> {
 
 	public LuckPermsContexts(@NotNull Towny plugin) {
 		registerContext("towny:resident", resident -> Collections.singleton(String.valueOf(resident.hasTown())), () -> Arrays.asList("true", "false"));
+		registerContext("towny:nation_resident", resident -> Collections.singleton(String.valueOf(resident.hasNation())), () -> Arrays.asList("true", "false"));
 		registerContext("towny:mayor", resident -> Collections.singleton(String.valueOf(resident.isMayor())), () -> Arrays.asList("true", "false"));
 		registerContext("towny:king", resident -> Collections.singleton(String.valueOf(resident.isKing())), () -> Arrays.asList("true", "false"));
 		registerContext("towny:insidetown", resident -> {


### PR DESCRIPTION
#### Description: 
Add the `towny:nation_resident` LuckPerms context. This is the nation equivalent of already existing resident LuckPerms context.

____
#### New Nodes/Commands/ConfigOptions: 
No new permission nodes.


____
#### Relevant Towny Issue ticket:
No relevant issues.


____
- [x] I have tested this pull request for defects on a server. (tested on Folia 1.20.2)

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.