### PR TITLE
- Add config option to toggle namespaced command sending for map comm…

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -3146,7 +3146,14 @@ public enum ConfigNodes {
 			"27",
 			"",
 			"# The width of the map shown in /towny map and /res toggle map.",
-			"# Minimum 7, maximum 27, only odd numbers are accepted.");
+			"# Minimum 7, maximum 27, only odd numbers are accepted."),
+	ASCII_MAP_SEND_COMMANDS_NAMESPACED("ascii_map_symbols.send_commands_namespaced",
+			"true",
+			"",
+			"# Whether commands send when a player clicks on the map",
+			"# should start with the towny namespace.",
+			"# If this is true: /towny:plot ...",
+			"# If this is false: /plot ...");
 	
 	private final String Root;
 	private final String Default;

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyAsciiMap.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyAsciiMap.java
@@ -214,9 +214,10 @@ public class TownyAsciiMap {
 						.append(claimedAtComponent)
 						.append(translator.component("towny_map_detailed_information").color(NamedTextColor.DARK_GREEN));
 					
+					String command = "/" + (TownySettings.sendMapOnClickCommandsNamespaced() ? "towny:" : "") + "plot";
 					ClickEvent clickEvent = forSaleComponent.equals(Component.empty()) 
-						? ClickEvent.runCommand("/towny:plot info " + tby + " " + tbx)
-						: ClickEvent.runCommand("/towny:plot claim " + world.getName() + " x" + tby + " z" + tbx);
+						? ClickEvent.runCommand(command + " info " + tby + " " + tbx)
+						: ClickEvent.runCommand(command + " claim " + world.getName() + " x" + tby + " z" + tbx);
 					
 					townyMap[y][x] = townyMap[y][x].hoverEvent(HoverEvent.showText(hoverComponent)).clickEvent(clickEvent);
 				} else {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -3710,6 +3710,10 @@ public class TownySettings {
 		return getInt(ConfigNodes.ASCII_MAP_WIDTH);
 	}
 
+	public static boolean sendMapOnClickCommandsNamespaced() {
+		return getBoolean(ConfigNodes.ASCII_MAP_SEND_COMMANDS_NAMESPACED);
+	}
+
 	public static void addReloadListener(NamespacedKey key, @NotNull Consumer<CommentedConfiguration> consumer) {
 		if (key == null)
 			throw new IllegalArgumentException("Key cannot be null");

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/event/asciimap/WildernessMapEvent.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/event/asciimap/WildernessMapEvent.java
@@ -1,5 +1,6 @@
 package com.palmergames.bukkit.towny.event.asciimap;
 
+import com.palmergames.bukkit.towny.TownySettings;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
@@ -14,7 +15,7 @@ public class WildernessMapEvent extends Event {
 	private static final HandlerList handlers = new HandlerList();
 	private String mapSymbol = TownyAsciiMap.wildernessSymbol;
 	private TextComponent hoverText;
-	private String clickCommand = "/towny:townyworld";
+	private String clickCommand = "/" + (TownySettings.sendMapOnClickCommandsNamespaced() ? "towny:" : "") + "townyworld";
 	final private WorldCoord worldCoord;
 	
 	public WildernessMapEvent(WorldCoord worldCoord) {


### PR DESCRIPTION
#### Description: 
Adds config option for toggling namespaces in onclick commands. (default value is true, which means by default behavior remains unchanged)

____
#### New Nodes/Commands/ConfigOptions: 
New config option:
```yaml
ascii_map_symbols:
  # ...
  
  # Whether commands send when a player clicks on the map
  # should start with the towny namespace.
  # If this is true: /towny:plot ...
  # If this is false: /plot ...
  send_commands_namespaced: 'true'
```


____
#### Relevant Towny Issue ticket:
No relevant issues.


____
- [x] I have tested this pull request for defects on a server. (on Folia 1.20.2, tested with the new config option set to true and false, for both options clicking on a cell on the map that was: wilderness, for sale, and claimed but not for sale) (also migrating from older config) 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
