### PR TITLE
Remove version check from potion effect name method

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
@@ -928,11 +928,9 @@ public class TownyEntityListener implements Listener {
 
 				// Account for PotionEffect#getType possibly returning the new name post enum removal.
 				final String legacyName = POTION_LEGACY_NAMES.inverse().get(name);
-				if (legacyName != null && detrimentalPotions.contains(legacyName))
-					return true;
 
-				return false;
-			});
+                return legacyName != null && detrimentalPotions.contains(legacyName);
+            });
 	}
 	
 	@ApiStatus.Internal

--- a/Towny/src/main/java/com/palmergames/bukkit/util/BukkitTools.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/BukkitTools.java
@@ -335,10 +335,9 @@ public class BukkitTools {
 			? player.getBedSpawnLocation() : player.getRespawnLocation();
 	}
 
-	@SuppressWarnings("deprecation")
-	public static String potionEffectName(PotionEffectType type) {
-		return MinecraftVersion.CURRENT_VERSION.isOlderThanOrEquals(MinecraftVersion.MINECRAFT_1_20_3)
-			? type.getName().toLowerCase(Locale.ROOT) : type.getKey().getKey().toLowerCase(Locale.ROOT);
+	@SuppressWarnings({"deprecation", "ConstantValue"})
+	public static String potionEffectName(final @NotNull PotionEffectType type) {
+		return ((Object) type instanceof Keyed keyed ? keyed.getKey().getKey() : type.getName()).toLowerCase(Locale.ROOT);
 	}
 
 	@SuppressWarnings("deprecation")

--- a/Towny/src/main/java/com/palmergames/bukkit/util/BukkitTools.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/BukkitTools.java
@@ -335,9 +335,9 @@ public class BukkitTools {
 			? player.getBedSpawnLocation() : player.getRespawnLocation();
 	}
 
-	@SuppressWarnings({"deprecation", "ConstantValue"})
+	@SuppressWarnings({"deprecation", "RedundantCast", "ConstantValue"})
 	public static String potionEffectName(final @NotNull PotionEffectType type) {
-		return ((Object) type instanceof Keyed keyed ? keyed.getKey().getKey() : type.getName()).toLowerCase(Locale.ROOT);
+		return (type instanceof Keyed ? ((Keyed) type).getKey().getKey() : type.getName()).toLowerCase(Locale.ROOT);
 	}
 
 	@SuppressWarnings("deprecation")


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
PotionEffectType has implemented Keyed since around 1.18 and not 1.20.3, but with this approach we shouldn't need any version checks for it at all
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
