### PR TITLE
Replace deprecated plugin loader with manager

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyServerListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyServerListener.java
@@ -19,7 +19,7 @@ public class TownyServerListener implements Listener {
 	public void onTownyNameUpdaterEnabled(PluginEnableEvent event) {
 		if (event.getPlugin().getName().equalsIgnoreCase("TownyNameUpdater")) {
 			plugin.getLogger().info("Disabling unneeded TownyNameUpdater.jar, you may delete this .jar.");
-			plugin.getPluginLoader().disablePlugin(event.getPlugin());
+			plugin.getServer().getPluginManager().disablePlugin(event.getPlugin());
 		}
 	}
 	


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Bukkit's plugin loader class is deprecated on paper, PluginManager#disablePlugin is the intended way to disable plugins now
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
