### PR TITLE
Add do-not-overwrite block list to worlds that affects wilderness explosion reverts.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -458,8 +458,17 @@ public enum ConfigNodes {
 	NWS_PLOT_MANAGEMENT_WILD_REVERT_BLOCK_WHITELIST(
 		"new_world_settings.plot_management.wild_revert_on_explosion_block_whitelist",
 		"",
-		"# The list of blocks to regenerate. (if empty all blocks will regenerate)"),
-
+		"# This section is applied to new worlds as default settings when new worlds are detected.",
+		"# The list of blocks to regenerate for block and entity explosions. (if empty all blocks will regenerate)"),
+	NWS_PLOT_MANAGEMENT_WILD_REVERT_BLOCKS_TO_NOT_OVERWRITE(
+			"new_world_settings.plot_management.wild_revert_explosions_blocks_to_not_replace",
+			"",
+			"# This section is applied to new worlds as default settings when new worlds are detected.",
+			"# This is the list of blocks that should not be overwritten by wilderness explosion reverts. (if empty all ",
+			"# blocks placed into regenerating explosions will be overwritten with the original pre-explosion blocks.)",
+			"# This list is useful if you have a death chest plugin which could put a player's inventory inside chest",
+			"# that is inside of a regenerating creeper explosion pit. For Example: By putting CHEST here you can ",
+			"# prevent the chest from being overwritten by the dirt block that used to be there."),
 
 	GTOWN_SETTINGS(
 			"global_town_settings",

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -1517,7 +1517,11 @@ public class TownySettings {
 	public static List<String> getWildExplosionRevertBlockWhitelist() {
 		return getStrArr(ConfigNodes.NWS_PLOT_MANAGEMENT_WILD_REVERT_BLOCK_WHITELIST);
 	}
-	
+
+	public static List<String> getWildExplosionRevertMaterialsToNotOverwrite() {
+		return getStrArr(ConfigNodes.NWS_PLOT_MANAGEMENT_WILD_REVERT_BLOCKS_TO_NOT_OVERWRITE);
+	}
+
 	public static List<String> getWildExplosionProtectionBlocks() {
 		return getStrArr(ConfigNodes.NWS_PLOT_MANAGEMENT_WILD_BLOCK_REVERT_LIST);
 	}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/SQLSchema.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/SQLSchema.java
@@ -308,6 +308,7 @@ public class SQLSchema {
 		columns.add("`usingPlotManagementWildRegen` bool NOT NULL DEFAULT '0'");
 		columns.add("`plotManagementWildRegenEntities` mediumtext NOT NULL");
 		columns.add("`plotManagementWildRegenBlockWhitelist` mediumtext NOT NULL");
+		columns.add("`wildRegenBlocksToNotOverwrite` mediumtext NOT NULL");
 		columns.add("`plotManagementWildRegenSpeed` long NOT NULL");
 		columns.add("`usingPlotManagementWildRegenBlocks` bool NOT NULL DEFAULT '0'");
 		columns.add("`plotManagementWildRegenBlocks` mediumtext NOT NULL");		

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -1518,6 +1518,20 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 					} catch (Exception ignored) {
 					}
 				
+				line = keys.get("wildRegenBlocksToNotOverwrite");
+				if (line != null)
+					try {
+						List<String> mats = new ArrayList<>();
+						for (String s : line.split(","))
+							if (!s.isEmpty())
+								try {
+									mats.add(s.trim());
+								} catch (NumberFormatException ignored) {
+								}
+						world.setWildRevertMaterialsToNotOverwrite(mats);
+					} catch (Exception ignored) {
+					}
+				
 				line = keys.get("usingPlotManagementWildRegenDelay");
 				if (line != null)
 					try {
@@ -2287,6 +2301,11 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 		// Wilderness Explosion Protection entities
 		if (world.getPlotManagementWildRevertBlockWhitelist() != null)
 			list.add("PlotManagementWildRegenBlockWhitelist=" + StringMgmt.join(world.getPlotManagementWildRevertBlockWhitelist(), ","));
+
+		list.add("# The list of blocks to that should not get replaced when an explosion is reverted in the wilderness, ie: a chest placed in a creeper hole that is reverting.");
+		// Wilderness Explosion materials to not overwrite.
+		if (world.getWildRevertMaterialsToNotOverwrite() != null)
+			list.add("wildRegenBlocksToNotOverwrite=" + StringMgmt.join(world.getWildRevertMaterialsToNotOverwrite(), ","));
 
 		list.add("# The delay after which the explosion reverts will begin.");
 		// Using PlotManagement Wild Regen Delay

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -1674,6 +1674,21 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 				} catch (Exception ignored) {
 				}
 
+			line = rs.getString("wildRegenBlocksToNotOverwrite");
+			if (line != null)
+				try {
+					List<String> materials = new ArrayList<>();
+					search = (line.contains("#")) ? "#" : ",";
+					for (String split : line.split(search))
+						if (!split.isEmpty())
+							try {
+								materials.add(split.trim());
+							} catch (NumberFormatException ignored) {
+							}
+					world.setWildRevertMaterialsToNotOverwrite(materials);
+				} catch (Exception ignored) {
+				}
+
 			resultLong = rs.getLong("plotManagementWildRegenSpeed");
 			try {
 				world.setPlotManagementWildRevertDelay(resultLong);
@@ -2421,6 +2436,11 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			if (world.getPlotManagementWildRevertBlockWhitelist() != null)
 				nat_hm.put("PlotManagementWildRegenBlockWhitelist",
 						StringMgmt.join(world.getPlotManagementWildRevertBlockWhitelist(), "#"));
+
+			// Wilderness Explosion Protection Materials to not overwrite.
+			if (world.getWildRevertMaterialsToNotOverwrite() != null)
+				nat_hm.put("wildRegenBlocksToNotOverwrite",
+						StringMgmt.join(world.getWildRevertMaterialsToNotOverwrite(), "#"));
 
 			// Using PlotManagement Wild Regen Delay
 			nat_hm.put("plotManagementWildRegenSpeed", world.getPlotManagementWildRevertDelay());

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownyWorld.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownyWorld.java
@@ -52,6 +52,7 @@ public class TownyWorld extends TownyObject {
 	private long plotManagementWildRevertDelay = TownySettings.getPlotManagementWildRegenDelay();
 	private Set<EntityType> entityExplosionProtection = null;
 	private Set<Material> plotManagementWildRevertBlockWhitelist = null;
+	private Set<Material> wildRevertMaterialsToNotOverwrite = null;
 	
 	private boolean isUsingPlotManagementWildBlockRevert = TownySettings.isUsingPlotManagementWildBlockRegen();
 	private Set<Material> blockExplosionProtection = null;
@@ -393,6 +394,7 @@ public class TownyWorld extends TownyObject {
 		setUsingPlotManagementWildBlockRevert(TownySettings.isUsingPlotManagementWildBlockRegen());
 		blockExplosionProtection = null;
 		plotManagementWildRevertBlockWhitelist = null;
+		wildRevertMaterialsToNotOverwrite = null;
 		// Entities protected from explosions
 		entityExplosionProtection = null;
 	}
@@ -617,6 +619,24 @@ public class TownyWorld extends TownyObject {
 			return !isPlotManagementIgnoreIds(mat);
 		else
 			return isPlotManagementWildRevertWhitelistedBlock(mat);
+	}
+
+	public void setWildRevertMaterialsToNotOverwrite(List<String> mats) {
+		wildRevertMaterialsToNotOverwrite = new HashSet<>();
+		wildRevertMaterialsToNotOverwrite.addAll(TownySettings.toMaterialSet(mats));
+	}
+
+	public Collection<Material> getWildRevertMaterialsToNotOverwrite() {
+		if (wildRevertMaterialsToNotOverwrite == null)
+			setWildRevertMaterialsToNotOverwrite(TownySettings.getWildExplosionRevertMaterialsToNotOverwrite());
+		return wildRevertMaterialsToNotOverwrite;
+	}
+
+	public boolean isMaterialNotAllowedToBeOverwrittenByWildRevert(Material mat) {
+		if (wildRevertMaterialsToNotOverwrite == null)
+			setWildRevertMaterialsToNotOverwrite(TownySettings.getWildExplosionRevertMaterialsToNotOverwrite());
+
+		return wildRevertMaterialsToNotOverwrite.contains(mat);
 	}
 
 	/**


### PR DESCRIPTION

<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Prevents wilderness explosions from overwriting newly placed blocks, ie chests inside of creeper holes.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->

```
  - New Config Option: new_world_settings.plot_management.wild_revert_explosions_blocks_to_not_replace
    - Default: ""
    - This section is applied to new worlds as default settings when new worlds are detected.
    - This is the list of blocks that should not be overwritten by wilderness explosion reverts.
    - (if empty all blocks placed into regenerating explosions will be overwritten with the original pre-explosion blocks.)
    - This list is useful if you have a death chest plugin which could put a player's inventory inside chest that is inside of a regenerating creeper explosion pit.
    - For Example: By putting CHEST here you can prevent the chest from being overwritten by the dirt block that used to be there.
```


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


Closes #7255.
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
