### PR TITLE
Add consumer methods to the task scheduler

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/Towny.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/Towny.java
@@ -437,6 +437,7 @@ public class Towny extends JavaPlugin {
 
 		this.townyUniverse = null;
 
+		// Used to be required, but in the latest versions the server will cancel these tasks for us as well.
 		if (this.scheduler instanceof FoliaTaskScheduler foliaScheduler)
 			foliaScheduler.cancelTasks();
 

--- a/providers/BaseProviders/src/main/java/com/palmergames/bukkit/towny/scheduling/TaskScheduler.java
+++ b/providers/BaseProviders/src/main/java/com/palmergames/bukkit/towny/scheduling/TaskScheduler.java
@@ -115,10 +115,10 @@ public interface TaskScheduler {
 	}
 	
 	default ScheduledTask runAsyncLater(Runnable runnable, long delay) {
-		return runAsyncLater(task -> runnable.run(), delay, TimeUnit.MILLISECONDS);
+		return runAsyncLater(task -> runnable.run(), delay * 50, TimeUnit.MILLISECONDS);
 	}
 	
 	default ScheduledTask runAsyncRepeating(Runnable runnable, long delay, long period) {
-		return runAsyncRepeating(task -> runnable.run(), delay, period, TimeUnit.MILLISECONDS);
+		return runAsyncRepeating(task -> runnable.run(), delay * 50, period * 50, TimeUnit.MILLISECONDS);
 	}
 }

--- a/providers/BaseProviders/src/main/java/com/palmergames/bukkit/towny/scheduling/TaskScheduler.java
+++ b/providers/BaseProviders/src/main/java/com/palmergames/bukkit/towny/scheduling/TaskScheduler.java
@@ -3,7 +3,11 @@ package com.palmergames.bukkit.towny.scheduling;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 @DefaultQualifier(NotNull.class)
 public interface TaskScheduler {
@@ -15,7 +19,64 @@ public interface TaskScheduler {
 
 	boolean isRegionThread(Location location);
 
-	ScheduledTask run(Runnable runnable);
+	ScheduledTask run(Consumer<ScheduledTask> task);
+
+	default ScheduledTask run(Entity entity, Consumer<ScheduledTask> task) {
+		return run(task);
+	}
+
+	default ScheduledTask run(Location location, Consumer<ScheduledTask> task) {
+		return run(task);
+	}
+	
+	ScheduledTask runLater(Consumer<ScheduledTask> task, long delay);
+	
+	default ScheduledTask runLater(Entity entity, Consumer<ScheduledTask> task, long delay) {
+		return runLater(task, delay);
+	}
+	
+	default ScheduledTask runLater(Location location, Consumer<ScheduledTask> task, long delay) {
+		return runLater(task, delay);
+	}
+	
+	ScheduledTask runRepeating(Consumer<ScheduledTask> task, long delay, long period);
+	
+	default ScheduledTask runRepeating(Entity entity, Consumer<ScheduledTask> task, long delay, long period) {
+		return runRepeating(task, delay, period);
+	}
+
+	default ScheduledTask runRepeating(Location location, Consumer<ScheduledTask> task, long delay, long period) {
+		return runRepeating(task, delay, period);
+	}
+	
+	ScheduledTask runAsync(Consumer<ScheduledTask> task);
+	
+	ScheduledTask runAsyncLater(Consumer<ScheduledTask> task, long delay, TimeUnit timeUnit);
+	
+	ScheduledTask runAsyncRepeating(Consumer<ScheduledTask> task, long delay, long period, TimeUnit timeUnit);
+	
+	@ApiStatus.Experimental
+	default ScheduledTask runGlobal(final Consumer<ScheduledTask> task) {
+		return run(task);
+	}
+	
+	@ApiStatus.Experimental
+	default ScheduledTask runGlobalLater(final Consumer<ScheduledTask> task, final long delay) {
+		return runLater(task, delay);
+	}
+	
+	@ApiStatus.Experimental
+	default ScheduledTask runGlobalRepeating(final Consumer<ScheduledTask> task, final long delay, final long period) {
+		return runRepeating(task, delay, period);
+	}
+
+	/*
+	 * Runnable methods
+	 */
+	
+	default ScheduledTask run(Runnable runnable) {
+		return run(task -> runnable.run());
+	}
 
 	default ScheduledTask run(Entity entity, Runnable runnable) {
 		return run(runnable);
@@ -25,7 +86,9 @@ public interface TaskScheduler {
 		return run(runnable);
 	}
 	
-	ScheduledTask runLater(Runnable runnable, long delay);
+	default ScheduledTask runLater(Runnable runnable, long delay) {
+		return runLater(task -> runnable.run(), delay);
+	}
 	
 	default ScheduledTask runLater(Entity entity, Runnable runnable, long delay) {
 		return runLater(runnable, delay);
@@ -35,7 +98,9 @@ public interface TaskScheduler {
 		return runLater(runnable, delay);
 	}
 	
-	ScheduledTask runRepeating(Runnable runnable, long delay, long period);
+	default ScheduledTask runRepeating(Runnable runnable, long delay, long period) {
+		return runRepeating(task -> runnable.run(), delay, period);
+	}
 	
 	default ScheduledTask runRepeating(Entity entity, Runnable runnable, long delay, long period) {
 		return runRepeating(runnable, delay, period);
@@ -45,9 +110,15 @@ public interface TaskScheduler {
 		return runRepeating(runnable, delay, period);
 	}
 	
-	ScheduledTask runAsync(Runnable runnable);
+	default ScheduledTask runAsync(Runnable runnable) {
+		return runAsync(task -> runnable.run());
+	}
 	
-	ScheduledTask runAsyncLater(Runnable runnable, long delay);
+	default ScheduledTask runAsyncLater(Runnable runnable, long delay) {
+		return runAsyncLater(task -> runnable.run(), delay, TimeUnit.MILLISECONDS);
+	}
 	
-	ScheduledTask runAsyncRepeating(Runnable runnable, long delay, long period);
+	default ScheduledTask runAsyncRepeating(Runnable runnable, long delay, long period) {
+		return runAsyncRepeating(task -> runnable.run(), delay, period, TimeUnit.MILLISECONDS);
+	}
 }

--- a/providers/BaseProviders/src/main/java/com/palmergames/bukkit/towny/scheduling/impl/BukkitTaskScheduler.java
+++ b/providers/BaseProviders/src/main/java/com/palmergames/bukkit/towny/scheduling/impl/BukkitTaskScheduler.java
@@ -7,8 +7,14 @@ import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitScheduler;
+import org.checkerframework.framework.qual.DefaultQualifier;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+@DefaultQualifier(NotNull.class)
 public class BukkitTaskScheduler implements TaskScheduler {
 	private final Plugin plugin;
 	private final BukkitScheduler scheduler = Bukkit.getServer().getScheduler();
@@ -28,42 +34,60 @@ public class BukkitTaskScheduler implements TaskScheduler {
 	}
 
 	@Override
-	public boolean isEntityThread(@NotNull Entity entity) {
+	public boolean isEntityThread(Entity entity) {
 		return Bukkit.getServer().isPrimaryThread();
 	}
 
 	@Override
-	public boolean isRegionThread(@NotNull Location location) {
+	public boolean isRegionThread(Location location) {
 		return Bukkit.getServer().isPrimaryThread();
 	}
 
 	@Override
-	public @NotNull ScheduledTask run(@NotNull Runnable runnable) {
-		return new BukkitScheduledTask(this.scheduler.runTask(this.plugin, runnable));
+	public ScheduledTask run(Consumer<ScheduledTask> task) {
+		AtomicReference<ScheduledTask> taskRef = new AtomicReference<>();
+		taskRef.set(new BukkitScheduledTask(this.scheduler.runTask(this.plugin, () -> task.accept(taskRef.get()))));
+		
+		return taskRef.get();
 	}
 
 	@Override
-	public @NotNull ScheduledTask runLater(@NotNull Runnable runnable, long delay) {
-		return new BukkitScheduledTask(this.scheduler.runTaskLater(this.plugin, runnable, delay));
+	public ScheduledTask runLater(Consumer<ScheduledTask> task, long delay) {
+		AtomicReference<ScheduledTask> taskRef = new AtomicReference<>();
+		taskRef.set(new BukkitScheduledTask(this.scheduler.runTaskLater(this.plugin, () -> task.accept(taskRef.get()), delay)));
+		
+		return taskRef.get();
 	}
 
 	@Override
-	public @NotNull ScheduledTask runRepeating(@NotNull Runnable runnable, long delay, long period) {
-		return new BukkitScheduledTask(this.scheduler.runTaskTimer(this.plugin, runnable, delay, period), true);
+	public ScheduledTask runRepeating(Consumer<ScheduledTask> task, long delay, long period) {
+		AtomicReference<ScheduledTask> taskRef = new AtomicReference<>();
+		taskRef.set(new BukkitScheduledTask(this.scheduler.runTaskTimer(this.plugin, () -> task.accept(taskRef.get()), delay, period), true));
+		
+		return taskRef.get();
 	}
 
 	@Override
-	public @NotNull ScheduledTask runAsync(@NotNull Runnable runnable) {
-		return new BukkitScheduledTask(this.scheduler.runTaskAsynchronously(this.plugin, runnable));
+	public ScheduledTask runAsync(Consumer<ScheduledTask> task) {
+		AtomicReference<ScheduledTask> taskRef = new AtomicReference<>();
+		taskRef.set(new BukkitScheduledTask(this.scheduler.runTaskAsynchronously(this.plugin, () -> task.accept(taskRef.get()))));
+		
+		return taskRef.get();
 	}
 
 	@Override
-	public @NotNull ScheduledTask runAsyncLater(@NotNull Runnable runnable, long delay) {
-		return new BukkitScheduledTask(this.scheduler.runTaskLaterAsynchronously(this.plugin, runnable, delay));
+	public ScheduledTask runAsyncLater(Consumer<ScheduledTask> task, long delay, TimeUnit timeUnit) {
+		AtomicReference<ScheduledTask> taskRef = new AtomicReference<>();
+		taskRef.set(new BukkitScheduledTask(this.scheduler.runTaskLaterAsynchronously(this.plugin, () -> task.accept(taskRef.get()), delay)));
+		
+		return taskRef.get();
 	}
 
 	@Override
-	public @NotNull ScheduledTask runAsyncRepeating(@NotNull Runnable runnable, long delay, long period) {
-		return new BukkitScheduledTask(this.scheduler.runTaskTimerAsynchronously(this.plugin, runnable, delay, period), true);
+	public ScheduledTask runAsyncRepeating(Consumer<ScheduledTask> task, long delay, long period, TimeUnit timeUnit) {
+		AtomicReference<ScheduledTask> taskRef = new AtomicReference<>();
+		taskRef.set(new BukkitScheduledTask(this.scheduler.runTaskTimerAsynchronously(this.plugin, () -> task.accept(taskRef.get()), timeUnit.toMillis(delay), timeUnit.toMillis(period)), true));
+		
+		return taskRef.get();
 	}
 }

--- a/providers/BaseProviders/src/main/java/com/palmergames/bukkit/towny/scheduling/impl/BukkitTaskScheduler.java
+++ b/providers/BaseProviders/src/main/java/com/palmergames/bukkit/towny/scheduling/impl/BukkitTaskScheduler.java
@@ -78,7 +78,7 @@ public class BukkitTaskScheduler implements TaskScheduler {
 	@Override
 	public ScheduledTask runAsyncLater(Consumer<ScheduledTask> task, long delay, TimeUnit timeUnit) {
 		AtomicReference<ScheduledTask> taskRef = new AtomicReference<>();
-		taskRef.set(new BukkitScheduledTask(this.scheduler.runTaskLaterAsynchronously(this.plugin, () -> task.accept(taskRef.get()), delay)));
+		taskRef.set(new BukkitScheduledTask(this.scheduler.runTaskLaterAsynchronously(this.plugin, () -> task.accept(taskRef.get()), timeUnit.toMillis(delay) / 50)));
 		
 		return taskRef.get();
 	}
@@ -86,7 +86,7 @@ public class BukkitTaskScheduler implements TaskScheduler {
 	@Override
 	public ScheduledTask runAsyncRepeating(Consumer<ScheduledTask> task, long delay, long period, TimeUnit timeUnit) {
 		AtomicReference<ScheduledTask> taskRef = new AtomicReference<>();
-		taskRef.set(new BukkitScheduledTask(this.scheduler.runTaskTimerAsynchronously(this.plugin, () -> task.accept(taskRef.get()), timeUnit.toMillis(delay), timeUnit.toMillis(period)), true));
+		taskRef.set(new BukkitScheduledTask(this.scheduler.runTaskTimerAsynchronously(this.plugin, () -> task.accept(taskRef.get()), timeUnit.toMillis(delay) / 50, timeUnit.toMillis(period) / 50), true));
 		
 		return taskRef.get();
 	}

--- a/providers/PaperProvider/src/main/java/com/palmergames/bukkit/towny/scheduling/impl/PaperTaskScheduler.java
+++ b/providers/PaperProvider/src/main/java/com/palmergames/bukkit/towny/scheduling/impl/PaperTaskScheduler.java
@@ -1,8 +1,15 @@
 package com.palmergames.bukkit.towny.scheduling.impl;
 
+import com.palmergames.bukkit.towny.scheduling.ScheduledTask;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jetbrains.annotations.NotNull;
 
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+@DefaultQualifier(NotNull.class)
 public class PaperTaskScheduler extends FoliaTaskScheduler {
 	public PaperTaskScheduler(Plugin plugin) {
 		super(plugin);
@@ -12,5 +19,33 @@ public class PaperTaskScheduler extends FoliaTaskScheduler {
 	public boolean isGlobalThread() {
 		// isGlobalThread does not exist on paper, match the bukkit task scheduler's behaviour.
 		return Bukkit.getServer().isPrimaryThread();
+	}
+	
+	/*
+	 * These methods run async on folia, but on paper we expect them to be sync
+	 */
+	
+	@Override
+	public ScheduledTask run(final Consumer<ScheduledTask> task) {
+		final AtomicReference<ScheduledTask> taskRef = new AtomicReference<>();
+		taskRef.set(new FoliaScheduledTask(globalRegionScheduler.run(plugin, t -> task.accept(taskRef.get()))));
+		
+		return taskRef.get();
+	}
+
+	@Override
+	public ScheduledTask runLater(final Consumer<ScheduledTask> task, long delay) {
+		final AtomicReference<ScheduledTask> taskRef = new AtomicReference<>();
+		taskRef.set(new FoliaScheduledTask(globalRegionScheduler.runDelayed(plugin, t -> task.accept(taskRef.get()), delay)));
+
+		return taskRef.get();
+	}
+
+	@Override
+	public ScheduledTask runRepeating(final Consumer<ScheduledTask> task, long delay, long period) {
+		final AtomicReference<ScheduledTask> taskRef = new AtomicReference<>();
+		taskRef.set(new FoliaScheduledTask(globalRegionScheduler.runAtFixedRate(plugin, t -> task.accept(taskRef.get()), delay, period)));
+
+		return taskRef.get();
 	}
 }


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Replaces runnable params with consumers for cases where we'd want to get the task from inside itself.

The run, runLater and runRepeating on methods on folia will also now use the async scheduler by default since there was no reason for them to use the global one, new runGlobal methods have been added for things that actually do need to run on the global thread (currently none)
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
