### PR TITLE
Remove locale message on first join

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -2299,11 +2299,6 @@ public enum ConfigNodes {
 			"false",
 			"",
 			"# If true, players can only use beds in plots they personally own."),
-	RES_SETTING_IS_SHOWING_LOCALE_MESSAGE(
-			"resident_settings.is_showing_locale_message",
-			"true",
-			"",
-			"# If true, players who join the server for the first time will be informed about their locale, and about Towny translatable system."),
 	RES_SETTING_DEFAULT_ABOUT(
 			"resident_settings.default_about",
 			"/res set about [msg]",

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -3595,10 +3595,6 @@ public class TownySettings {
 	public static Map<Integer, NationLevel> getConfigNationLevel() {
 		return configNationLevel;
 	}
-
-	public static boolean isShowingLocaleMessage() {
-		return getBoolean(ConfigNodes.RES_SETTING_IS_SHOWING_LOCALE_MESSAGE);
-	}
 	
 	public static boolean isLanguageEnabled(@NotNull String locale) {
 		// Either all languages are enabled or, we auto-enable English: Addons that only

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/OnPlayerLogin.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/OnPlayerLogin.java
@@ -84,10 +84,6 @@ public class OnPlayerLogin implements Runnable {
 				 */
 				try {
 					resident = universe.getDataSource().newResident(player.getName(), player.getUniqueId());
-					
-					if (TownySettings.isShowingLocaleMessage())
-					    TownyMessaging.sendMsg(resident, Translatable.of("msg_your_locale", player.getLocale()));
-
 					resident.setRegistered(System.currentTimeMillis());
 
 					final Resident finalResident = resident;

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -2015,8 +2015,6 @@ confirmation_unclaiming_costs: 'Unclaiming this land will cost %s, do you want t
 
 #Added in 0.140
 
-#Message shown on first join, making players aware they can change how Towny messages appear using their Client's language setting.
-msg_your_locale: 'Towny uses your client''s locale (%s) to translate its messages. Be aware translations may be missing strings.'
 #Message shown when a player tries to rename their town too quickly.
 msg_you_must_wait_x_seconds_before_renaming_your_town: 'You must wait %s seconds before you can rename your town again.'
 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Something I've wanted to do for a while, removes sending players the message about their locale being used since it's not very relevant for the average player
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
