### PR TITLE
Add listener for Paper's PlayerElytraBoostEvent.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPaperEvents.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPaperEvents.java
@@ -51,7 +51,6 @@ public class TownyPaperEvents implements Listener {
 	private static final String USED_SIGN_OPEN_EVENT = JavaUtil.classExists(SIGN_OPEN_EVENT) ? SIGN_OPEN_EVENT : SPIGOT_SIGN_OPEN_EVENT;
 
 	private static final String PLAYER_ELYTRA_BOOST_EVENT = "com.destroystokyo.paper.event.player.PlayerElytraBoostEvent";
-	private static final MethodHandle GET_BOOSTING_PLAYER = JavaUtil.getMethodHandle(PLAYER_ELYTRA_BOOST_EVENT, "getPlayer");
 
 	private static final String DRAGON_FIREBALL_HIT_EVENT = "com.destroystokyo.paper.event.entity.EnderDragonFireballHitEvent";
 
@@ -92,9 +91,7 @@ public class TownyPaperEvents implements Listener {
 			TownyMessaging.sendDebugMsg("Using " + DRAGON_FIREBALL_GET_EFFECT_CLOUD + " listener.");
 		}
 		
-		if (JavaUtil.classExists(PLAYER_ELYTRA_BOOST_EVENT)) {
-			registerEvent(PLAYER_ELYTRA_BOOST_EVENT, this::playerElytraBoostListener, EventPriority.LOW, true);
-		}
+		registerEvent(PLAYER_ELYTRA_BOOST_EVENT, this::playerElytraBoostListener, EventPriority.LOW, true);
 		
 		if (this.plugin.isFolia()) {
 			registerEvent(ADD_TO_WORLD_EVENT, this::entityAddToWorldListener, EventPriority.MONITOR, false /* n/a */);
@@ -115,16 +112,9 @@ public class TownyPaperEvents implements Listener {
 	}
 	
 	// https://jd.papermc.io/paper/1.15/index.html?com/destroystokyo/paper/event/player/PlayerElytraBoostEvent.html
-	private Consumer<Event> playerElytraBoostListener() {
+	private Consumer<PlayerEvent> playerElytraBoostListener() {
 		return event -> {
-			Player player = null;
-			try {
-				player = (Player) GET_BOOSTING_PLAYER.invoke((PlayerEvent) event);
-			} catch (Throwable e) {
-				// Player never gets set here, causing an NPE.
-				plugin.getLogger().log(Level.WARNING, "An exception occurred while invoking " + PLAYER_ELYTRA_BOOST_EVENT + "#getPlayer reflectively", e);
-				return;
-			}
+			Player player = event.getPlayer();
 			if (!TownySettings.isItemUseMaterial(Material.FIREWORK_ROCKET, player.getLocation()))
 				return;
 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

Currently broken because MethodHandle is always null for the getPlayer...


```
[11:29:35 WARN]: [Towny] An exception occurred while invoking com.destroystokyo.paper.event.player.PlayerElytraBoostEvent#getPlayer reflectively
java.lang.NullPointerException: Cannot invoke "java.lang.invoke.MethodHandle.invoke(org.bukkit.event.player.PlayerEvent)" because "com.palmergames.bukkit.towny.listeners.TownyPaperEvents.GET_BOOSTING_PLAYER" is null
        at com.palmergames.bukkit.towny.listeners.TownyPaperEvents.lambda$playerElytraBoostListener$1(TownyPaperEvents.java:122) ~[towny-0.100.1.18.jar:?]
        at com.palmergames.bukkit.towny.listeners.TownyPaperEvents.lambda$registerEvent$0(TownyPaperEvents.java:114) ~[towny-0.100.1.18.jar:?]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:81) ~[paper-api-1.20.2-R0.1-SNAPSHOT.jar:git-Paper-318]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[paper-api-1.20.2-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54) ~[paper-1.20.2.jar:git-Paper-318]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:126) ~[paper-1.20.2.jar:git-Paper-318]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:615) ~[paper-api-1.20.2-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.event.Event.callEvent(Event.java:45) ~[paper-api-1.20.2-R0.1-SNAPSHOT.jar:?]
        at net.minecraft.world.item.FireworkRocketItem.use(FireworkRocketItem.java:70) ~[?:?]
        at net.minecraft.world.item.ItemStack.use(ItemStack.java:553) ~[paper-1.20.2.jar:git-Paper-318]
        at net.minecraft.server.level.ServerPlayerGameMode.useItem(ServerPlayerGameMode.java:480) ~[?:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.handleUseItem(ServerGamePacketListenerImpl.java:1989) ~[?:?]
        at net.minecraft.network.protocol.game.ServerboundUseItemPacket.handle(ServerboundUseItemPacket.java:32) ~[?:?]
        at net.minecraft.network.protocol.game.ServerboundUseItemPacket.a(ServerboundUseItemPacket.java:8) ~[?:?]
        at net.minecraft.network.protocol.PacketUtils.lambda$ensureRunningOnSameThread$0(PacketUtils.java:53) ~[?:?]
        at net.minecraft.server.TickTask.run(TickTask.java:18) ~[paper-1.20.2.jar:git-Paper-318]
        at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:153) ~[?:?]
        at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[?:?]
        at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1324) ~[paper-1.20.2.jar:git-Paper-318]
        at net.minecraft.server.MinecraftServer.d(MinecraftServer.java:193) ~[paper-1.20.2.jar:git-Paper-318]
        at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:126) ~[?:?]
        at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1301) ~[paper-1.20.2.jar:git-Paper-318]
        at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1294) ~[paper-1.20.2.jar:git-Paper-318]
        at net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:136) ~[?:?]
        at net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:1272) ~[paper-1.20.2.jar:git-Paper-318]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1160) ~[paper-1.20.2.jar:git-Paper-318]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:315) ~[paper-1.20.2.jar:git-Paper-318]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
```


____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

Closes #7286 by making adding Firework Rockets into the item use list.

____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
