### PR TITLE
Add MinJoinDays and MaxJoinDays to TownBlocks

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -117,6 +117,13 @@ public class TownyFormatter {
 		if (TownyEconomyHandler.isActive())
 			screen.addComponentOf("plottax", colourKeyValue(translator.of("status_townblock_plottax"), townBlock.isTaxed() ? formatMoney(townBlock.getPlotTax()) : translator.of("status_townblock_untaxed")));
 
+		if (townBlock.hasMinTownMembershipDays() && townBlock.hasMaxTownMembershipDays())
+			screen.addComponentOf("minAndMaxJoinDate", colourKey(translator.of("status_townblock_max_and_minjoindays", townBlock.getMinTownMembershipDays(), townBlock.getMaxTownMembershipDays())));
+		else if (townBlock.hasMinTownMembershipDays())
+			screen.addComponentOf("minJoinDate", colourKey(translator.of("status_townblock_minjoindays", townBlock.getMinTownMembershipDays())));
+		else if (townBlock.hasMaxTownMembershipDays())
+			screen.addComponentOf("maxJoinDate", colourKey(translator.of("status_townblock_maxjoindays", townBlock.getMaxTownMembershipDays())));
+
 		// Add any metadata which opt to be visible.
 		List<Component> fields = getExtraFields(townBlock);
 		if (!fields.isEmpty())

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/HelpMenu.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/HelpMenu.java
@@ -862,6 +862,8 @@ public enum HelpMenu {
 			return new MenuBuilder("plot set")
 				.add("[plottype]", Translatable.of("plot_set_help_0"))
 				.add("outpost", Translatable.of("plot_set_help_1"))
+				.add("minjoindays", Translatable.of("plot_set_help_1.5"))
+				.add("maxjoindays", Translatable.of("plot_set_help_1.6"))
 				.add("reset", Translatable.of("plot_set_help_2"))
 				.add("[name]", Translatable.of("plot_set_help_3"))
 				.add("Valid Levels: [resident/ally/outsider]")

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/PlotCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/PlotCommand.java
@@ -534,10 +534,10 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 			throw new TownyException(Translatable.of("msg_err_plot_belongs_to_group_set"));
 
 		switch(split[0].toLowerCase(Locale.ROOT)) {
-		case "minJoinDays":
+		case "minjoindays":
 			parsePlotSetMinJoinDays(player, resident, townBlock, StringMgmt.remFirstArg(split));
 			break;
-		case "maxJoinDays":
+		case "maxjoindays":
 			parsePlotSetMaxJoinDays(player, resident, townBlock, StringMgmt.remFirstArg(split));
 			break;
 		case "perm":

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/PlotCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/PlotCommand.java
@@ -62,6 +62,7 @@ import com.palmergames.bukkit.util.BukkitTools;
 import com.palmergames.bukkit.util.ChatTools;
 import com.palmergames.bukkit.util.Colors;
 import com.palmergames.bukkit.util.NameValidation;
+import com.palmergames.util.MathUtil;
 import com.palmergames.util.StringMgmt;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -128,6 +129,8 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 		"jail",
 		"farm",
 		"bank",
+		"minjoindays",
+		"maxjoindays",
 		"outpost",
 		"name",
 		"perm"
@@ -199,6 +202,11 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 					}
 					if (args.length == 3 && args[1].equalsIgnoreCase("outpost")) {
 						return Arrays.asList("spawn");
+					}
+					if (args.length == 3 && (args[1].equalsIgnoreCase("minjoindays") || args[1].equalsIgnoreCase("maxjoindays"))) {
+						List<String> numbersAndClear = new ArrayList<>(numbers);
+						numbersAndClear.add("clear");
+						return NameUtil.filterByStart(numbersAndClear, args[2]);
 					}
 					if (args.length > 2 && args[1].equalsIgnoreCase("perm")) {
 						return permTabComplete(StringMgmt.remArgs(args, 2));
@@ -338,7 +346,9 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 		}
 
 		// Filter to just plots that are for sale, which can actually be bought by the
-		// resident, (ie: outsiders can only buy Embassy plots.)
+		// resident, (ie: outsiders can only buy Embassy plots, some residents cannot 
+		// purchase a plot because they have been a resident of town for too little or 
+		// too long.)
 		selection = AreaSelectionUtil.filterPlotsForSale(resident, selection);
 
 		// Filter out plots already owned by the player.
@@ -524,6 +534,12 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 			throw new TownyException(Translatable.of("msg_err_plot_belongs_to_group_set"));
 
 		switch(split[0].toLowerCase(Locale.ROOT)) {
+		case "minJoinDays":
+			parsePlotSetMinJoinDays(player, resident, townBlock, StringMgmt.remFirstArg(split));
+			break;
+		case "maxJoinDays":
+			parsePlotSetMaxJoinDays(player, resident, townBlock, StringMgmt.remFirstArg(split));
+			break;
 		case "perm":
 			checkPermOrThrow(player, PermissionNodes.TOWNY_COMMAND_PLOT_SET_PERM.getNode());
 			TownyAPI.getInstance().testPlotOwnerOrThrow(resident, townBlock); // Test we are allowed to work on this plot
@@ -549,6 +565,52 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 			 */
 			tryPlotSetType(player, resident, townBlock, split);
 		}
+	}
+
+	private void parsePlotSetMinJoinDays(Player player, Resident resident, TownBlock townBlock, String[] args) throws TownyException {
+		checkPermOrThrow(player, PermissionNodes.TOWNY_COMMAND_PLOT_ASMAYOR.getNode());
+		TownyAPI.getInstance().testPlotOwnerOrThrow(resident, townBlock); // Test we are allowed to work on this plot
+
+		if (args.length == 0 || args[0].equalsIgnoreCase("?")) {
+			HelpMenu.PLOT_SET.send(player);
+			return;
+		}
+		if (args[0].equalsIgnoreCase("clear")) {
+			townBlock.setMinTownMembershipDays(-1);
+			townBlock.save();
+			TownyMessaging.sendMsg(player, Translatable.of("msg_townblock_min_join_days_removed"));
+			return;
+		}
+
+		int days = MathUtil.getPositiveIntOrThrow(args[0]);
+		if (days == 0)
+			throw new TownyException(Translatable.of("msg_err_days_must_be_greater_than_0"));
+		townBlock.setMinTownMembershipDays(days);
+		townBlock.save();
+		TownyMessaging.sendMsg(player, Translatable.of("msg_townblock_min_join_days_set_to", townBlock.getMinTownMembershipDays()));
+	}
+
+	private void parsePlotSetMaxJoinDays(Player player, Resident resident, TownBlock townBlock, String[] args) throws TownyException {
+		checkPermOrThrow(player, PermissionNodes.TOWNY_COMMAND_PLOT_ASMAYOR.getNode());
+		TownyAPI.getInstance().testPlotOwnerOrThrow(resident, townBlock); // Test we are allowed to work on this plot
+
+		if (args.length == 0 || args[0].equalsIgnoreCase("?")) {
+			HelpMenu.PLOT_SET.send(player);
+			return;
+		}
+		if (args[0].equalsIgnoreCase("clear")) {
+			townBlock.setMaxTownMembershipDays(-1);
+			townBlock.save();
+			TownyMessaging.sendMsg(player, Translatable.of("msg_townblock_max_join_days_removed"));
+			return;
+		}
+
+		int days = MathUtil.getPositiveIntOrThrow(args[0]);
+		if (days == 0)
+			throw new TownyException(Translatable.of("msg_err_days_must_be_greater_than_0"));
+		townBlock.setMaxTownMembershipDays(days);
+		townBlock.save();
+		TownyMessaging.sendMsg(player, Translatable.of("msg_townblock_max_join_days_set_to", townBlock.getMaxTownMembershipDays()));
 	}
 
 	private void tryPlotSetType(Player player, Resident resident, TownBlock townBlock, String[] split) throws TownyException {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/SQLSchema.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/SQLSchema.java
@@ -336,6 +336,8 @@ public class SQLSchema {
 		columns.add("`claimedAt` BIGINT NOT NULL");
 		columns.add("`trustedResidents` mediumtext DEFAULT NULL");
 		columns.add("`customPermissionData` mediumtext DEFAULT NULL");
+		columns.add("`minTownMembershipDays` SMALLINT NOT NULL DEFAULT '-1'");
+		columns.add("`maxTownMembershipDays` SMALLINT NOT NULL DEFAULT '-1'");
 		return columns;
 	}
 	

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -1754,7 +1754,15 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 						try {
 							townBlock.setClaimedAt(Long.parseLong(line));
 						} catch (Exception ignored) {}
-					
+
+					line = keys.get("minTownMembershipDays");
+					if (line != null && !line.isEmpty())
+						townBlock.setMinTownMembershipDays(Integer.valueOf(line));
+
+					line = keys.get("maxTownMembershipDays");
+					if (line != null && !line.isEmpty())
+						townBlock.setMaxTownMembershipDays(Integer.valueOf(line));
+
 					line = keys.get("metadata");
 					if (line != null && !line.isEmpty())
 						MetadataLoader.getInstance().deserializeMetadata(townBlock, line.trim());
@@ -2380,7 +2388,13 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 		list.add("changed=" + townBlock.isChanged());
 
 		list.add("claimedAt=" + townBlock.getClaimedAt());
-		
+
+		if (townBlock.hasMinTownMembershipDays())
+			list.add("minTownMembershipDays=" + townBlock.getMinTownMembershipDays());
+
+		if (townBlock.hasMaxTownMembershipDays())
+			list.add("maxTownMembershipDays=" + townBlock.getMaxTownMembershipDays());
+
 		// Metadata
 		list.add("metadata=" + serializeMetadata(townBlock));
 		

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -1853,6 +1853,15 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 
 				townBlock.setClaimedAt(rs.getLong("claimedAt"));
 
+				
+				line = rs.getString("minTownMembershipDays");
+				if (line != null && !line.isEmpty())
+					townBlock.setMinTownMembershipDays(Integer.valueOf(line));
+
+				line = rs.getString("maxTownMembershipDays");
+				if (line != null && !line.isEmpty())
+					townBlock.setMaxTownMembershipDays(Integer.valueOf(line));
+
 				try {
 					line = rs.getString("metadata");
 					if (line != null && !line.isEmpty()) {
@@ -2488,6 +2497,8 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 					(townBlock.isChanged()) ? townBlock.getPermissions().toString().replaceAll(",", "#") : "");
 			tb_hm.put("changed", townBlock.isChanged());
 			tb_hm.put("claimedAt", townBlock.getClaimedAt());
+			tb_hm.put("minTownMembershipDays", townBlock.getMinTownMembershipDays());
+			tb_hm.put("maxTownMembershipDays", townBlock.getMaxTownMembershipDays());
 			if (townBlock.hasPlotObjectGroup())
 				tb_hm.put("groupID", townBlock.getPlotObjectGroup().getUUID().toString());
 			else

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownBlock.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownBlock.java
@@ -18,6 +18,7 @@ import com.palmergames.bukkit.towny.tasks.CooldownTimerTask;
 import com.palmergames.bukkit.towny.tasks.CooldownTimerTask.CooldownType;
 import com.palmergames.bukkit.towny.utils.JailUtil;
 import com.palmergames.bukkit.util.BukkitTools;
+import com.palmergames.util.TimeTools;
 
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -36,6 +37,8 @@ public class TownBlock extends TownyObject {
 
 	private Town town = null;
 	private Resident resident = null;
+	private int minTownMembershipDays = -1;
+	private int maxTownMembershipDays = -1;
 	private TownBlockType type = TownBlockType.RESIDENTIAL;
 	private final WorldCoord worldCoord;
 	private double plotPrice = -1;
@@ -80,6 +83,8 @@ public class TownBlock extends TownyObject {
 				setClaimedAt(System.currentTimeMillis());
 			
 			permissionOverrides.clear();
+			minTownMembershipDays = -1;
+			maxTownMembershipDays = -1;
 		} catch (AlreadyRegisteredException | NullPointerException ignored) {}
 	}
 
@@ -627,6 +632,90 @@ public class TownBlock extends TownyObject {
 		this.setPlotPrice(-1);
 		this.setType(getType());
 		this.save();
+	}
+
+	/**
+	 * Tests whether a Resident's Town membership age (join date) is too high or
+	 * low, preventing them from claiming this TownBlock personally with /plot
+	 * claim.
+	 * 
+	 * @param resident Resident who wants to buy the TownBlock.
+	 * @throws TownyException thrown with error message when the Resident is not
+	 *                        allowed to claim the land.
+	 */
+	public void testTownMembershipAgePreventsThisClaimOrThrow(Resident resident) throws TownyException {
+		if ((this.getType().equals(TownBlockType.EMBASSY) && !town.hasResident(resident)) 
+				|| (!hasMinTownMembershipDays() && !hasMaxTownMembershipDays()))
+			return;
+
+		Town residentTown = resident.getTownOrNull();
+		if (residentTown == null || !residentTown.equals(this.town))
+			return;
+
+		long joinDate = resident.getJoinedTownAt();
+
+		if (hasMaxTownMembershipDays() && TimeTools.getTimeInMillisXDaysAgo(getMaxTownMembershipDays()) > joinDate)
+			throw new TownyException(Translatable.of("msg_err_cannot_claim_plot_join_date_too_high", getMaxTownMembershipDays()));
+
+		if (hasMinTownMembershipDays() && TimeTools.getTimeInMillisXDaysAgo(getMinTownMembershipDays()) < joinDate)
+			throw new TownyException(Translatable.of("msg_err_cannot_claim_plot_join_date_too_low", getMinTownMembershipDays()));
+	}
+
+	/**
+	 * @return does this plot have a min number of days the player has to be a
+	 *         member of the town, before they can claim?
+	 */
+	public boolean hasMinTownMembershipDays() {
+		return minTownMembershipDays > 0; 
+	}
+
+	/**
+	 * @return how many days a town member has to be a part of the town in order to
+	 *         claim this plot personally using /plot claim.
+	 */
+	public int getMinTownMembershipDays() {
+		return minTownMembershipDays;
+	}
+
+	/**
+	 * Sets the number of days that a town member must be a part of the town before
+	 * they can claim the plot personally using /plot claim.
+	 * 
+	 * @param minTownMembershipDays days they have to be a part of the town for,
+	 *                              before they can claim.
+	 */
+	public void setMinTownMembershipDays(int minTownMembershipDays) {
+		// 32766 because this is stored as a SMALLINT when MYSQL is used.
+		this.minTownMembershipDays = Math.max(32766, minTownMembershipDays);
+	}
+
+	/**
+	 * @return does this plot have a max number of days the player can be a member
+	 *         of the town, before they cannot claim?
+	 */
+	public boolean hasMaxTownMembershipDays() {
+		return maxTownMembershipDays > 0; 
+	}
+
+	/**
+	 * @return how the maximum number of days a town member can be a part of the
+	 *         town before they are unable to claim this plot personally using /plot
+	 *         claim.
+	 */
+	public int getMaxTownMembershipDays() {
+		return maxTownMembershipDays;
+	}
+
+	/**
+	 * Sets the maximum number of days that a town member can be a part of the town
+	 * before they unable to claim the plot personally using /plot claim.
+	 * 
+	 * @param maxTownMembershipDays days they can be a part of the town for, until
+	 *                              they cannot claim.
+	 */
+	public void setMaxTownMembershipDays(int maxTownMembershipDays) {
+		// 32766 because this is stored as a SMALLINT when MYSQL is used.
+		this.maxTownMembershipDays = Math.max(32766, maxTownMembershipDays);
 	}
 
 	@ApiStatus.Internal

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownBlock.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownBlock.java
@@ -686,7 +686,7 @@ public class TownBlock extends TownyObject {
 	 */
 	public void setMinTownMembershipDays(int minTownMembershipDays) {
 		// 32766 because this is stored as a SMALLINT when MYSQL is used.
-		this.minTownMembershipDays = Math.max(32766, minTownMembershipDays);
+		this.minTownMembershipDays = Math.min(32766, minTownMembershipDays);
 	}
 
 	/**
@@ -715,7 +715,7 @@ public class TownBlock extends TownyObject {
 	 */
 	public void setMaxTownMembershipDays(int maxTownMembershipDays) {
 		// 32766 because this is stored as a SMALLINT when MYSQL is used.
-		this.maxTownMembershipDays = Math.max(32766, maxTownMembershipDays);
+		this.maxTownMembershipDays = Math.min(32766, maxTownMembershipDays);
 	}
 
 	@ApiStatus.Internal

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/AreaSelectionUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/AreaSelectionUtil.java
@@ -523,6 +523,13 @@ public class AreaSelectionUtil {
 	}
 
 	private static boolean residentCanBuyTownBlock(Resident resident, TownBlock townBlock) {
+		try {
+			townBlock.testTownMembershipAgePreventsThisClaimOrThrow(resident);
+		} catch (TownyException e) {
+			if (resident.isOnline())
+				TownyMessaging.sendErrorMsg(e.getMessage(resident.getPlayer()));
+			return false;
+		}
 		Town town = townBlock.getTownOrNull();
 		return town != null && townBlockIsForSale(townBlock) && (town.hasResident(resident) || townBlock.getType().equals(TownBlockType.EMBASSY));
 	}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/AreaSelectionUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/AreaSelectionUtil.java
@@ -527,7 +527,7 @@ public class AreaSelectionUtil {
 			townBlock.testTownMembershipAgePreventsThisClaimOrThrow(resident);
 		} catch (TownyException e) {
 			if (resident.isOnline())
-				TownyMessaging.sendErrorMsg(e.getMessage(resident.getPlayer()));
+				TownyMessaging.sendErrorMsg(resident.getPlayer(), e.getMessage(resident.getPlayer()));
 			return false;
 		}
 		Town town = townBlock.getTownOrNull();

--- a/Towny/src/main/java/com/palmergames/util/TimeTools.java
+++ b/Towny/src/main/java/com/palmergames/util/TimeTools.java
@@ -9,6 +9,11 @@ import java.util.regex.Pattern;
  */
 public class TimeTools {
 
+	private static final long MILLIS_PER_SECOND = 1000L;
+	private static final long MILLIS_PER_MINUTE = MILLIS_PER_SECOND * 60L;
+	private static final long MILLIS_PER_HOUR = MILLIS_PER_MINUTE * 60L;
+	private static final long MILLIS_PER_DAY = MILLIS_PER_HOUR * 24L;
+
 	/**
 	 * This will parse a time string such as 2d30m to an equivalent amount of
 	 * seconds.
@@ -88,5 +93,25 @@ public class TimeTools {
     
 	public static int getHours(long milliSeconds) {
 		return (int) ((milliSeconds /1000) / 60) /60;
+	}
+
+	public static int getDays(long milliSeconds) {
+		return (int) (((milliSeconds /1000) / 60) /60) /24;
+	}
+
+	public static long getTimeInMillisXSecondsAgo(int seconds) {
+		return System.currentTimeMillis() - (MILLIS_PER_SECOND * seconds); 
+	}
+
+	public static long getTimeInMillisXMinutesAgo(int minutes) {
+		return System.currentTimeMillis() - (MILLIS_PER_MINUTE * minutes); 
+	}
+
+	public static long getTimeInMillisXHoursAgo(int hours) {
+		return System.currentTimeMillis() - (MILLIS_PER_HOUR * hours); 
+	}
+
+	public static long getTimeInMillisXDaysAgo(int days) {
+		return System.currentTimeMillis() - (MILLIS_PER_DAY * days); 
 	}
 }

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -471,6 +471,8 @@ plot_group_toggle_help_4: "Toggles the taxed status of the plot group."
 
 plot_set_help_0: "Ex: Inn, Wilds, Farm, Embassy, etc."
 plot_set_help_1: "Sets a plot to an Outpost."
+plot_set_help_1.5: "Sets the minimum number of days a player must be a town member to purchase the plot."
+plot_set_help_1.6: "Sets the maximum number of days a player must be a town member to purchase the plot."
 plot_set_help_2: "Removes a plot type."
 plot_set_help_3: "Names a plot."
 plot_set_help_4: "Toggle all permissions."

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -1058,6 +1058,9 @@ status_res_plottax: 'Total Plot Taxes:'
 status_res_totaltax: 'Total Tax to pay:'
 status_townblock_plottax: 'Plot Tax: '
 status_townblock_untaxed: 'Untaxed'
+status_townblock_max_and_minjoindays: 'Town membership of between %s and %s days required for plot purchase.'
+status_townblock_minjoindays: 'Town membership more than %s days required for plot purchase.'
+status_townblock_maxjoindays: 'Town membership less than %s days required for plot purchase.'
 
 # Added in 0.45
 msg_err_unable_to_use_bank_outside_nation_capital: 'You cannot make use of your nation bank outside of the nation capital.'
@@ -2498,3 +2501,15 @@ msg_town_cede_plot_denied: "%s has declined your offer."
 msg_town_cede_plot_unable_to_accept: "%s was unable to accept your offer."
 
 msg_town_cede_plot_you_have_accepted: "You have gained control of the plot at %s."
+
+msg_err_cannot_claim_plot_join_date_too_low: "You cannot claim this plot until you have been a town resident for %s days."
+
+msg_err_cannot_claim_plot_join_date_too_high: "You cannot claim this plot, it is for residents who have been town members for less than %s days."
+
+msg_townblock_min_join_days_removed: "This TownBlock has had its min-join-days requirement removed."
+
+msg_townblock_max_join_days_removed: "This TownBlock has had its max-join-days requirement removed."
+
+msg_townblock_min_join_days_set_to: "This TownBlock has had its min-join-days requirement set to %s. Only players joined for more than that number of days will be able to use /plot claim."
+
+msg_townblock_max_join_days_set_to: "This TownBlock has had its max-join-days requirement set to %s. Only players joined for less than that number of days will be able to use /plot claim."


### PR DESCRIPTION



<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Limits who can claim plots in towns, based on their join date, allowing mayors to set aside land for new players or old players.

Does not affect embassy plots.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


New Command: /plot set minjoindays {number|clear}
New Command: /plot set maxjoindays {number|clear}

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


Closes #7164.
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
