### PR TITLE
Fix nation deleted message showing when a predeletenationevent iscancelled.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -1062,10 +1062,11 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 			}
 
 			Confirmation.runOnAccept(() -> {
-				TownyMessaging.sendGlobalMessage(Translatable.of("msg_del_nation", nation.getName()));
-				TownyUniverse.getInstance().getDataSource().removeNation(nation);
-				if (tooManyResidents)
-					ResidentUtil.reduceResidentCountToFitTownMaxPop(town);
+				if (TownyUniverse.getInstance().getDataSource().removeNation(nation)) {
+					TownyMessaging.sendGlobalMessage(Translatable.of("msg_del_nation", nation.getName()));
+					if (tooManyResidents)
+						ResidentUtil.reduceResidentCountToFitTownMaxPop(town);
+				}
 			})
 			.sendTo(player);
 			return;

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -1663,11 +1663,11 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		case "delete":
 			checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_NATION_DELETE.getNode());
 			Confirmation.runOnAccept(() -> {
-				if (sender instanceof Player)
-					TownyMessaging.sendMsg(sender, Translatable.of("nation_deleted_by_admin", nation.getName()));
-				
-				TownyUniverse.getInstance().getDataSource().removeNation(nation);
-				TownyMessaging.sendGlobalMessage(Translatable.of("MSG_DEL_NATION", nation.getName()));
+				if (TownyUniverse.getInstance().getDataSource().removeNation(nation)) {
+					if (sender instanceof Player)
+						TownyMessaging.sendMsg(sender, Translatable.of("nation_deleted_by_admin", nation.getName()));
+					TownyMessaging.sendGlobalMessage(Translatable.of("msg_del_nation", nation.getName()));
+				}
 			}).sendTo(sender);
 			break;
 		case "meta":

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyDataSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyDataSource.java
@@ -298,7 +298,7 @@ public abstract class TownyDataSource {
 
 	abstract public void removeTownBlocks(Town town);
 
-	abstract public void removeNation(Nation nation);
+	abstract public boolean removeNation(Nation nation);
 
 	abstract public @NotNull Resident newResident(String name) throws AlreadyRegisteredException, NotRegisteredException;
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
@@ -463,11 +463,11 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 	}
 
 	@Override
-	public void removeNation(Nation nation) {
+	public boolean removeNation(Nation nation) {
 
 		PreDeleteNationEvent preEvent = new PreDeleteNationEvent(nation);
 		if (BukkitTools.isEventCancelled(preEvent))
-			return;
+			return false;
 
 		Resident king = null;
 		if (nation.hasKing())
@@ -543,6 +543,8 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 		plugin.resetCache();
 
 		BukkitTools.fireEvent(new DeleteNationEvent(nation, king));
+
+		return true;
 	}
 
 	@Override

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/TownUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/TownUtil.java
@@ -52,11 +52,13 @@ public class TownUtil {
 			if (findNewCapital(town, nation))
 				return;
 
+			if (!TownyUniverse.getInstance().getDataSource().removeNation(nation))
+				return;
+
 			// No new capital found, delete the nation and potentially refund the capital town.
 			TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_nation_disbanded_town_not_enough_residents", town.getName()));
-			TownyMessaging.sendGlobalMessage(Translatable.of("msg_del_nation", nation));
-			TownyUniverse.getInstance().getDataSource().removeNation(nation);
 
+			TownyMessaging.sendGlobalMessage(Translatable.of("msg_del_nation", nation));
 			if (TownyEconomyHandler.isActive() && TownySettings.isRefundNationDisbandLowResidents()) {
 				town.getAccount().deposit(TownySettings.getNewNationPrice(), "nation refund");
 				TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_not_enough_residents_refunded", TownySettings.getNewNationPrice()));


### PR DESCRIPTION


<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

Not really happy with the implementation of this, as it changes our DataSource pattern to one where only a single removeObject method returns a boolean. The TownUtil change is also not ideal now or before this PR as the Nation can be prevented from being deleted, while still processing a refund.

Potential alternative solutions:
- Run the message in the DatabaseHandler method, and lose the custom deleted by admin message sent to the admin who deleted the nation.
- Run the PreDeleteNation event before the removeNation(Nation) in order to prevent the TownUtil method being made redundant, and causing issues.


____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

Closes #7380.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
