### PR TITLE
Fix nation deleted message showing when a predeletenationevent is cancelled.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -1062,8 +1062,12 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 			}
 
 			Confirmation.runOnAccept(() -> {
-				TownyMessaging.sendGlobalMessage(Translatable.of("msg_del_nation", nation.getName()));
 				TownyUniverse.getInstance().getDataSource().removeNation(nation);
+				if (nation.exists()) { // The PreDeleteNationEvent was cancelled.
+					TownyMessaging.sendErrorMsg(player, Translatable.of("msg_err_you_cannot_delete_this_nation"));
+					return;
+				}
+				TownyMessaging.sendGlobalMessage(Translatable.of("msg_del_nation", nation.getName()));
 				if (tooManyResidents)
 					ResidentUtil.reduceResidentCountToFitTownMaxPop(town);
 			})
@@ -1076,8 +1080,12 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 
 		Nation nation = getNationOrThrow(split[0]);
 		Confirmation.runOnAccept(() -> {
-			TownyMessaging.sendGlobalMessage(Translatable.of("msg_del_nation", nation.getName()));
 			TownyUniverse.getInstance().getDataSource().removeNation(nation);
+			if (nation.exists()) {// The PreDeleteNationEvent was cancelled.
+				TownyMessaging.sendErrorMsg(player, Translatable.of("msg_err_you_cannot_delete_this_nation"));
+				return;
+			}
+			TownyMessaging.sendGlobalMessage(Translatable.of("msg_del_nation", nation.getName()));
 		}).sendTo(player);
 	}
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -1663,11 +1663,14 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		case "delete":
 			checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_NATION_DELETE.getNode());
 			Confirmation.runOnAccept(() -> {
+				TownyUniverse.getInstance().getDataSource().removeNation(nation);
+				if (nation.exists()) {
+					TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_err_you_cannot_delete_this_nation"));
+					return;
+				}
+				TownyMessaging.sendGlobalMessage(Translatable.of("MSG_DEL_NATION", nation.getName()));
 				if (sender instanceof Player)
 					TownyMessaging.sendMsg(sender, Translatable.of("nation_deleted_by_admin", nation.getName()));
-				
-				TownyUniverse.getInstance().getDataSource().removeNation(nation);
-				TownyMessaging.sendGlobalMessage(Translatable.of("MSG_DEL_NATION", nation.getName()));
 			}).sendTo(sender);
 			break;
 		case "meta":

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
@@ -14,6 +14,7 @@ import com.palmergames.bukkit.towny.event.BedExplodeEvent;
 import com.palmergames.bukkit.towny.event.ChunkNotificationEvent;
 import com.palmergames.bukkit.towny.event.NewTownEvent;
 import com.palmergames.bukkit.towny.event.PlayerChangePlotEvent;
+import com.palmergames.bukkit.towny.event.PreDeleteNationEvent;
 import com.palmergames.bukkit.towny.event.SpawnEvent;
 import com.palmergames.bukkit.towny.event.TownAddResidentEvent;
 import com.palmergames.bukkit.towny.event.TownBlockPermissionChangeEvent;
@@ -57,6 +58,12 @@ public class TownyCustomListener implements Listener {
 
 	public TownyCustomListener(Towny instance) {
 		plugin = instance;
+	}
+
+	@EventHandler
+	public void onNationDelete(PreDeleteNationEvent event) {
+		System.out.println("Cancelling nation delete.");
+		event.setCancelled(true);
 	}
 
 	@EventHandler(priority = EventPriority.NORMAL)

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
@@ -14,7 +14,6 @@ import com.palmergames.bukkit.towny.event.BedExplodeEvent;
 import com.palmergames.bukkit.towny.event.ChunkNotificationEvent;
 import com.palmergames.bukkit.towny.event.NewTownEvent;
 import com.palmergames.bukkit.towny.event.PlayerChangePlotEvent;
-import com.palmergames.bukkit.towny.event.PreDeleteNationEvent;
 import com.palmergames.bukkit.towny.event.SpawnEvent;
 import com.palmergames.bukkit.towny.event.TownAddResidentEvent;
 import com.palmergames.bukkit.towny.event.TownBlockPermissionChangeEvent;
@@ -58,12 +57,6 @@ public class TownyCustomListener implements Listener {
 
 	public TownyCustomListener(Towny instance) {
 		plugin = instance;
-	}
-
-	@EventHandler
-	public void onNationDelete(PreDeleteNationEvent event) {
-		System.out.println("Cancelling nation delete.");
-		event.setCancelled(true);
 	}
 
 	@EventHandler(priority = EventPriority.NORMAL)

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Town.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Town.java
@@ -292,7 +292,8 @@ public class Town extends Government implements TownBlockOwner {
 			oldNation.removeTown(this);
 		} catch (EmptyNationException e) {
 			TownyUniverse.getInstance().getDataSource().removeNation(oldNation);
-			TownyMessaging.sendGlobalMessage(Translatable.of("msg_del_nation", e.getNation().getName()));
+			if (!nation.exists()) // The PreDeleteNationEvent was not cancelled.
+				TownyMessaging.sendGlobalMessage(Translatable.of("msg_del_nation", e.getNation().getName()));
 		}
 		
 		try {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
@@ -1,6 +1,7 @@
 package com.palmergames.bukkit.towny.tasks;
 
 import com.palmergames.bukkit.towny.Towny;
+import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownyEconomyHandler;
 import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.TownySettings;
@@ -23,6 +24,8 @@ import com.palmergames.util.StringMgmt;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
+
+import org.bukkit.entity.Player;
 
 public class DailyTimerTask extends TownyTimerTask {
 	
@@ -780,9 +783,11 @@ public class DailyTimerTask extends TownyTimerTask {
 				totalNationUpkeep = totalNationUpkeep + upkeep;
 				TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_your_nation_payed_upkeep", prettyMoney(upkeep)));
 			} else {
+				List<Player> onlinePlayers = TownyAPI.getInstance().getOnlinePlayersInNation(nation); 
 				universe.getDataSource().removeNation(nation);
 				if (!nation.exists()) { // The PreDeleteNationEvent was not cancelled.
-					TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_your_nation_couldnt_pay_upkeep", prettyMoney(upkeep)));
+					String formattedUpkeep = prettyMoney(upkeep);
+					onlinePlayers.forEach(p -> TownyMessaging.sendMsg(p, Translatable.of("msg_your_nation_couldnt_pay_upkeep", formattedUpkeep)));
 					removedNations.add(nation.getName());
 					return;
 				}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
@@ -780,9 +780,12 @@ public class DailyTimerTask extends TownyTimerTask {
 				totalNationUpkeep = totalNationUpkeep + upkeep;
 				TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_your_nation_payed_upkeep", prettyMoney(upkeep)));
 			} else {
-				TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_your_nation_couldnt_pay_upkeep", prettyMoney(upkeep)));
 				universe.getDataSource().removeNation(nation);
-				removedNations.add(nation.getName());
+				if (!nation.exists()) { // The PreDeleteNationEvent was not cancelled.
+					TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_your_nation_couldnt_pay_upkeep", prettyMoney(upkeep)));
+					removedNations.add(nation.getName());
+					return;
+				}
 			}
 		} else if (upkeep < 0) {
 			nation.getAccount().withdraw(upkeep, "Negative Nation Upkeep");

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/TownUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/TownUtil.java
@@ -53,9 +53,12 @@ public class TownUtil {
 				return;
 
 			// No new capital found, delete the nation and potentially refund the capital town.
+			TownyUniverse.getInstance().getDataSource().removeNation(nation);
+			if (nation.exists()) // The PreDeleteNationEvent was cancelled.
+				return;
+
 			TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_nation_disbanded_town_not_enough_residents", town.getName()));
 			TownyMessaging.sendGlobalMessage(Translatable.of("msg_del_nation", nation));
-			TownyUniverse.getInstance().getDataSource().removeNation(nation);
 
 			if (TownyEconomyHandler.isActive() && TownySettings.isRefundNationDisbandLowResidents()) {
 				town.getAccount().deposit(TownySettings.getNewNationPrice(), "nation refund");

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/TownUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/TownUtil.java
@@ -3,6 +3,9 @@ package com.palmergames.bukkit.towny.utils;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.bukkit.entity.Player;
+
+import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownyEconomyHandler;
 import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.TownySettings;
@@ -52,13 +55,14 @@ public class TownUtil {
 			if (findNewCapital(town, nation))
 				return;
 
+			List<Player> onlinePlayers = TownyAPI.getInstance().getOnlinePlayersInNation(nation);
 			// No new capital found, delete the nation and potentially refund the capital town.
 			TownyUniverse.getInstance().getDataSource().removeNation(nation);
 			if (nation.exists()) // The PreDeleteNationEvent was cancelled.
 				return;
 
-			TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_nation_disbanded_town_not_enough_residents", town.getName()));
-			TownyMessaging.sendGlobalMessage(Translatable.of("msg_del_nation", nation));
+			onlinePlayers.forEach(p -> TownyMessaging.sendMsg(p, Translatable.of("msg_nation_disbanded_town_not_enough_residents", town.getName())));
+			TownyMessaging.sendGlobalMessage(Translatable.of("msg_del_nation", nation.getName()));
 
 			if (TownyEconomyHandler.isActive() && TownySettings.isRefundNationDisbandLowResidents()) {
 				town.getAccount().deposit(TownySettings.getNewNationPrice(), "nation refund");

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -2525,3 +2525,5 @@ msg_new_resident_spawn_to_town_prompt: "Did you want to spawn to the town you ju
 msg_recieved_refund_for_deleted_object: "You have received the bank balance of your deleted town or nation, a sum of %s."
 
 msg_err_you_already_own_this_plot: "You already own this plot."
+
+msg_err_you_cannot_delete_this_nation: "You have been prevented from deleting this nation."


### PR DESCRIPTION



<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->


Uses the nation.exists to determine if the removal of the nation was successful or not, and displays messages to match the outcome.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

Closes #7380.
Supercedes #7381.

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
