### PR TITLE
Add ability to limit setting spawn points lower than a configurable Y level.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1427,6 +1427,16 @@ public enum ConfigNodes {
 			"",
 			"# Number of seconds that must pass before a player who is not a member or ally can use /n spawn."),
 
+	SPAWNING_Y_LIMITS_ROOT("spawning.y_limits","",""),
+	SPAWNING_Y_LIMITS_ENABLED("spawning.y_limits.enabled",
+			"false",
+			"",
+			"# Should towns, nations be limited in how low they can set a spawn point, or an outpost spawn point?"),
+	SPAWNING_Y_LIMITS_LOWEST_Y_ALLOWED("spawning.y_limits.lowest_y_allowed",
+			"0",
+			"",
+			"# When limiting is configured, what is the lowest y level allowed?"),
+
 	SPAWNING_RESPAWN_ROOT("spawning.respawning","",""),
 	SPAWNING_TOWN_RESPAWN(
 			"spawning.respawning.town_respawn",

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -3780,5 +3780,13 @@ public class TownySettings {
 	public static double maxBuyTownPrice() {
 		return getDouble(ConfigNodes.GTOWN_SETTINGS_MAX_BUYTOWN_PRICE);
 	}
+
+	public static boolean isSpawnYLevelLimitingEnabled() {
+		return getBoolean(ConfigNodes.SPAWNING_Y_LIMITS_ENABLED);
+	}
+
+	public static double getSpawningLowestYLevelAllowed() {
+		return getDouble(ConfigNodes.SPAWNING_Y_LIMITS_LOWEST_Y_ALLOWED);
+	}
 }
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
@@ -21,7 +21,10 @@ import com.palmergames.bukkit.towny.event.TownClaimEvent;
 import com.palmergames.bukkit.towny.event.TownRemoveResidentEvent;
 import com.palmergames.bukkit.towny.event.damage.TownyPlayerDamagePlayerEvent;
 import com.palmergames.bukkit.towny.event.nation.NationPreTownLeaveEvent;
+import com.palmergames.bukkit.towny.event.nation.NationSetSpawnEvent;
 import com.palmergames.bukkit.towny.event.town.TownPreUnclaimCmdEvent;
+import com.palmergames.bukkit.towny.event.town.TownSetOutpostSpawnEvent;
+import com.palmergames.bukkit.towny.event.town.TownSetSpawnEvent;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.CellSurface;
 import com.palmergames.bukkit.towny.object.PlayerCache;
@@ -321,5 +324,32 @@ public class TownyCustomListener implements Listener {
 		if (cache == null || !cache.getLastTownBlock().equals(worldCoord) || PlayerCacheUtil.isOwnerCache(cache))
 			return;
 		Towny.getPlugin().resetCache(player);
+	}
+
+	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+	public void onTownSetSpawn(TownSetSpawnEvent event) {
+		if (!TownySettings.isSpawnYLevelLimitingEnabled() 
+			|| event.getNewSpawn().getY() >= TownySettings.getSpawningLowestYLevelAllowed())
+			return;
+		event.setCancelMessage(Translatable.of("msg_err_you_cannot_set_this_spawn_point_below", TownySettings.getSpawningLowestYLevelAllowed()).forLocale(event.getPlayer()));
+		event.setCancelled(true);
+	}
+
+	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+	public void onTownSetOutpostSpawn(TownSetOutpostSpawnEvent event) {
+		if (!TownySettings.isSpawnYLevelLimitingEnabled() 
+			|| event.getNewSpawn().getY() >= TownySettings.getSpawningLowestYLevelAllowed())
+			return;
+		event.setCancelMessage(Translatable.of("msg_err_you_cannot_set_this_spawn_point_below", TownySettings.getSpawningLowestYLevelAllowed()).forLocale(event.getPlayer()));
+		event.setCancelled(true);
+	}
+
+	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+	public void onNationSetSpawn(NationSetSpawnEvent event) {
+		if (!TownySettings.isSpawnYLevelLimitingEnabled() 
+			|| event.getNewSpawn().getY() >= TownySettings.getSpawningLowestYLevelAllowed())
+			return;
+		event.setCancelMessage(Translatable.of("msg_err_you_cannot_set_this_spawn_point_below", TownySettings.getSpawningLowestYLevelAllowed()).forLocale(event.getPlayer()));
+		event.setCancelled(true);
 	}
 }

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -2525,3 +2525,5 @@ msg_recieved_refund_for_deleted_object: "You have received the bank balance of y
 msg_err_you_already_own_this_plot: "You already own this plot."
 
 msg_err_you_cannot_delete_this_nation: "You have been prevented from deleting this nation."
+
+msg_err_you_cannot_set_this_spawn_point_below: "You cannot set this spawn point below y level %s."


### PR DESCRIPTION


<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
```
  - New Config Option: spawning.y_limits.enabled
    - Default: false
    - Should towns, nations be limited in how low they can set a spawn point, or a outpost spawn point?
  - New Config Option: spawning.y_limits.lowest_y_allowed
    - Default: 0
    - When limiting is configured, what is the lowest y level allowed?
```
____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


Closes #7306

____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
