### PR TITLE
Fix dragon egg teleportation on left click

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -506,7 +506,7 @@ public class TownyPlayerListener implements Listener {
 		if (block.getType() != Material.DRAGON_EGG)
 			return;
 		
-		if (TownyActionEventExecutor.canSwitch(player, block.getLocation(), Material.DRAGON_EGG))
+		if (TownyActionEventExecutor.canDestroy(player, block))
 			return;
 		
 		event.setCancelled(true);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -487,6 +487,32 @@ public class TownyPlayerListener implements Listener {
 		}
 	}
 
+	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+	public void onDragonEggLeftClick(PlayerInteractEvent event) {
+		
+		if (plugin.isError()) {
+			event.setCancelled(true);
+			return;
+		}
+		
+		Player player = event.getPlayer();
+		if (!TownyAPI.getInstance().isTownyWorld(player.getWorld()))
+			return;
+		
+		if (!event.hasBlock() || event.getAction() != Action.LEFT_CLICK_BLOCK)
+			return;
+		
+		Block block = event.getClickedBlock();
+		if (block.getType() != Material.DRAGON_EGG)
+			return;
+		
+		if (TownyActionEventExecutor.canSwitch(player, block.getLocation(), Material.DRAGON_EGG))
+			return;
+		
+		event.setCancelled(true);
+		
+	}
+
 	/**
 	 * Handles clicking on beds in the nether/respawn anchors in the overworld sending blocks to a map so we can track when explosions occur from beds.
 	 * Spigot API's BlockExplodeEvent#getBlock() always returns AIR for beds/anchors exploding, which is why this is necessary.


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
Dragon eggs currently teleport when an untrusted player left clicks on them (though right click is properly protected). This adds a check for dragon egg left clicks under switching protection to prevent players from teleporting the eggs.

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Towny Issue ticket:
N/A


____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
