### PR TITLE
Set mappings namespace in manifest

### DIFF
--- a/Towny/pom.xml
+++ b/Towny/pom.xml
@@ -112,12 +112,6 @@
             <artifactId>VaultAPI</artifactId>
             <version>1.7.1</version>
             <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.bukkit</groupId>
-                    <artifactId>bukkit</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.github.ElgarL</groupId>
@@ -143,11 +137,6 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
             <version>1.26.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-text</artifactId>
-            <version>1.12.0</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
@@ -250,6 +239,7 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
     <pluginRepositories>
         <pluginRepository>
             <id>apache.snapshots</id>
@@ -357,35 +347,12 @@
                     <configuration>
                         <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
                         <artifactSet>
-                            <includes>
-                                <include>net.kyori:adventure-platform-bukkit</include>
-                                <include>net.kyori:adventure-platform-api</include>
-                                <include>net.kyori:adventure-api</include>
-                                <include>net.kyori:adventure-text-serializer-craftbukkit</include>
-                                <include>net.kyori:adventure-platform-facet</include>
-                                <include>net.kyori:adventure-text-serializer-gson</include>
-                                <include>net.kyori:adventure-text-serializer-legacy</include>
-                                <include>net.kyori:adventure-key</include>
-                                <include>net.kyori:adventure-text-serializer-gson-legacy-impl</include>
-                                <include>net.kyori:adventure-text-serializer-bungeecord</include>
-                                <include>net.kyori:adventure-platform-viaversion</include>
-                                <include>net.kyori:adventure-nbt</include>
-                                <include>net.kyori:examination-api</include>
-                                <include>net.kyori:examination-string</include>
-                                <include>net.kyori:adventure-text-serializer-plain</include>
-                                <include>net.kyori:adventure-text-minimessage</include>
-                                <include>com.zaxxer:HikariCP</include>
-                                <include>io.papermc:paperlib</include>
-                                <include>org.apache.commons:commons-compress</include>
-                                <include>org.apache.commons:commons-text</include>
-                                <include>org.bstats:bstats-bukkit</include>
-                                <include>org.bstats:bstats-base</include>
-                                <include>org.json:json</include>
-                                <include>solar.squares:pixel-width-core</include>
-                                <include>com.palmergames.bukkit.towny:towny-base-providers</include>
-                                <include>com.palmergames.bukkit.towny:towny-folia-provider</include>
-                                <include>com.palmergames.bukkit.towny:towny-paper-provider</include>
-                            </includes>
+                            <excludes>
+                                <exclusion>org.slf4j:slf4j-api</exclusion>
+                                <exclusion>commons-io:commons-io</exclusion>
+                                <exclusion>commons-codec:commons-codec</exclusion>
+                                <exclusion>org.apache.commons:commons-lang3</exclusion>
+                            </excludes>
                         </artifactSet>
                         <relocations>
                             <relocation>
@@ -399,10 +366,6 @@
                             <relocation>
                                 <pattern>org.apache.commons.compress</pattern>
                                 <shadedPattern>com.palmergames.compress</shadedPattern>
-                            </relocation>
-                            <relocation>
-                                <pattern>org.apache.commons.text</pattern>
-                                <shadedPattern>com.palmergames.text</shadedPattern>
                             </relocation>
                             <relocation>
                                 <pattern>net.kyori.adventure</pattern>
@@ -425,14 +388,16 @@
                             <filter>
                                 <artifact>*:*</artifact>
                                 <excludes>
-                                    <exclude>META-INF/*.MF</exclude>
+                                    <exclude>META-INF/MANIFEST.MF</exclude>
+                                    <exclude>META-INF/**/module-info.class</exclude>
                                 </excludes>
                             </filter>
-                            <filter>
-                                <artifact>net.kyori:*</artifact>
-                                <excludes>META-INF/versions/9/module-info.class</excludes>
-                            </filter>
                         </filters>
+                        <transformers>
+                            <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"> </transformer>
+                            <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"> </transformer>
+                            <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"> </transformer>
+                        </transformers>
                         <minimizeJar>true</minimizeJar>
                     </configuration>
                     <executions>
@@ -465,6 +430,18 @@
                     <version>3.2.5</version>
                     <configuration>
                         <skipTests>${skipTests}</skipTests>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.4.1</version>
+                    <configuration>
+                        <archive>
+                            <manifestEntries>
+                                <paperweight-mappings-namespace>mojang</paperweight-mappings-namespace>
+                            </manifestEntries>
+                        </archive>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Since we don't do any intensive reflection into internals, the plugin doesn't need any remapping done, setting the manifest entry prevents that.

Also some other general pom file maintenance:
- Removed exclusion for the bukkit api from vault api, 1.7.1 no longer exposes it
- Removed commons text, we don't use it anywhere
- Changed inclusions to exclusions in the shade plugin
- Added transformers to the shade plugin
  - manifest transformer: makes sure that our manifest.mf ends up in the final jar
  - apache license transformer: prevents apache licenses from ending up in our manifest
  - apache notice transformer: combines notices together into one NOTICE file
____
- [N/A] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
