### PR TITLE
Fix potential NPEs in PlotGroup

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/PlotGroup.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/PlotGroup.java
@@ -122,6 +122,8 @@ public class PlotGroup extends ObjectGroup implements TownBlockOwner, Savable {
 	}
 
 	public Collection<TownBlock> getTownBlocks() {
+		if (townBlocks == null)
+			return Collections.emptyList();
 		return Collections.unmodifiableCollection(townBlocks);
 	}
 	
@@ -131,7 +133,7 @@ public class PlotGroup extends ObjectGroup implements TownBlockOwner, Savable {
 
 	@Override
 	public boolean hasTownBlock(TownBlock townBlock) {
-		return townBlocks.contains(townBlock);
+		return townBlocks != null && townBlocks.contains(townBlock);
 	}
 
 	public void setPrice(double price) {


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This PR adds a null check to `PlotGroup#getTownBlocks` and `PlotGroup#hasTownBlock` like the other methods in the class. This fixes these methods throwing NPEs if the `townBlocks` field has not yet been initialised.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
