### PR TITLE
Feat/max capitalized name letters

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1690,6 +1690,12 @@ public enum ConfigNodes {
 			"",
 			"# Maximum length of Town and Nation names. Setting this to a number below your current max_name_length could result in",
 			"# safe mode if the new value is below of your existing town and nation name lengths."),
+	FILTERS_MAX_NAME_CAPITAL_LETTERS(
+			"filters_colour_chat.modify_chat.max_name_capital_letters",
+			"-1",
+			"",
+			"# Maximum number of capital letters that can be used in Town and Nation names.",
+			"# Use this value to prevent towns or nations being named with all capital letters, or too many capital letters."),
 	FILTERS_MAX_TAG_LENGTH(
 			"filters_colour_chat.modify_chat.max_tag_length",
 			"4",

--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1694,7 +1694,7 @@ public enum ConfigNodes {
 			"filters_colour_chat.modify_chat.max_name_capital_letters",
 			"-1",
 			"",
-			"# Maximum number of capital letters that can be used in Town and Nation names.",
+			"# Maximum number of capital letters that can be used in Town and Nation names. Set to -1 to disable this feature.",
 			"# This count does not include the first letter of a town, and does not count capitalized letters that come after a _ character.",
 			"# This means that a town named New_York would register 0 capitals. While McDonalds would register 1. COOLTOWN would register 7 capital letters."),
 	FILTERS_MAX_TAG_LENGTH(

--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1696,7 +1696,7 @@ public enum ConfigNodes {
 			"",
 			"# Maximum number of capital letters that can be used in Town and Nation names.",
 			"# This count does not include the first letter of a town, and does not count capitalized letters that come after a _ character.",
-			"# This means that a town names New York would register 0 capitals. While McDonalds would register 1."),
+			"# This means that a town named New_York would register 0 capitals. While McDonalds would register 1. COOLTOWN would register 7 capital letters."),
 	FILTERS_MAX_TAG_LENGTH(
 			"filters_colour_chat.modify_chat.max_tag_length",
 			"4",

--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1695,7 +1695,8 @@ public enum ConfigNodes {
 			"-1",
 			"",
 			"# Maximum number of capital letters that can be used in Town and Nation names.",
-			"# Use this value to prevent towns or nations being named with all capital letters, or too many capital letters."),
+			"# This count does not include the first letter of a town, and does not count capitalized letters that come after a _ character.",
+			"# This means that a town names New York would register 0 capitals. While McDonalds would register 1."),
 	FILTERS_MAX_TAG_LENGTH(
 			"filters_colour_chat.modify_chat.max_tag_length",
 			"4",

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -1458,6 +1458,11 @@ public class TownySettings {
 		return getInt(ConfigNodes.FILTERS_MAX_NAME_LGTH);
 	}
 
+	public static int getMaxNameCapitalLetters() {
+
+		return getInt(ConfigNodes.FILTERS_MAX_NAME_CAPITAL_LETTERS);
+	}
+
 	public static long getDeleteTime() {
 
 		return getSeconds(ConfigNodes.RES_SETTING_DELETE_OLD_RESIDENTS_TIME);

--- a/Towny/src/main/java/com/palmergames/bukkit/util/NameValidation.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/NameValidation.java
@@ -299,12 +299,24 @@ public class NameValidation {
 			return;
 
 		int capitals = 0;
+		boolean skip = true;
 		for (char letter : name.toCharArray()) {
-			if (Character.isLowerCase(letter))
+			if (skip) { // First character of the name or character after a _.
+				skip = false;
 				continue;
+			}
+
+			if (letter == '_') { // Next character will be allowed to be capitalized.
+				skip = true;
+				continue;
+			}
+
+			if (Character.isLowerCase(letter)) // Not a capital.
+				continue;
+
 			capitals++;
 			if (capitals > maxCapitals)
-				throw new InvalidNameException(Translatable.of("msg_err_name_validation_too_many_capitals", name, maxCapitals));
+				throw new InvalidNameException(Translatable.of("msg_err_name_validation_too_many_capitals", name, capitals, maxCapitals));
 		}
 	}
 

--- a/Towny/src/main/java/com/palmergames/bukkit/util/NameValidation.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/NameValidation.java
@@ -315,9 +315,10 @@ public class NameValidation {
 				continue;
 
 			capitals++;
-			if (capitals > maxCapitals)
-				throw new InvalidNameException(Translatable.of("msg_err_name_validation_too_many_capitals", name, capitals, maxCapitals));
 		}
+
+		if (capitals > maxCapitals)
+			throw new InvalidNameException(Translatable.of("msg_err_name_validation_too_many_capitals", name, capitals, maxCapitals));
 	}
 
 	/**

--- a/Towny/src/main/java/com/palmergames/bukkit/util/NameValidation.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/NameValidation.java
@@ -80,6 +80,8 @@ public class NameValidation {
 
 		testForImproperNameAndThrow(out);
 
+		testCapitalization(out);
+
 		testForSubcommand(out);
 
 		if (out.startsWith(TownySettings.getTownAccountPrefix()))
@@ -103,6 +105,8 @@ public class NameValidation {
 		testForNumbersInNationName(out);
 
 		testForImproperNameAndThrow(out);
+
+		testCapitalization(out);
 
 		testForSubcommand(out);
 
@@ -281,6 +285,27 @@ public class NameValidation {
 			if (letter != '_')
 				return;
 		throw new InvalidNameException(Translatable.of("msg_err_name_validation_is_all_underscores", name));
+	}
+
+	/**
+	 * Stops objects being named with too many capital letters.
+	 * 
+	 * @param name String submitted for testing.
+	 * @throws InvalidNameException when the name uses too many capital letters.
+	 */
+	private static void testCapitalization(String name) throws InvalidNameException {
+		int maxCapitals = TownySettings.getMaxNameCapitalLetters();
+		if (maxCapitals == -1)
+			return;
+
+		int capitals = 0;
+		for (char letter : name.toCharArray()) {
+			if (Character.isLowerCase(letter))
+				continue;
+			capitals++;
+			if (capitals > maxCapitals)
+				throw new InvalidNameException(Translatable.of("msg_err_name_validation_too_many_capitals", name, maxCapitals));
+		}
 	}
 
 	/**

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -2461,6 +2461,8 @@ msg_err_name_validation_is_not_permitted: "%s is not permitted."
 
 msg_err_name_validation_is_all_underscores: "%s is entirely underscores."
 
+msg_err_name_validation_too_many_capitals: "%s contains more capital letters than is allowed, use less than %s."
+
 msg_err_name_validation_contains_harmful_characters: "%s contains symbols that could be harmful."
 
 msg_err_name_validation_contains_numbers: "%s contains numbers which aren't allowed in names."

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -2461,7 +2461,7 @@ msg_err_name_validation_is_not_permitted: "%s is not permitted."
 
 msg_err_name_validation_is_all_underscores: "%s is entirely underscores."
 
-msg_err_name_validation_too_many_capitals: "%s contains more capital letters than is allowed, use less than %s."
+msg_err_name_validation_too_many_capitals: "%s contains %s capital letters which were not allowed, use less than %s."
 
 msg_err_name_validation_contains_harmful_characters: "%s contains symbols that could be harmful."
 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->

```
  - Add the ability to limit the number of capital letters used in Town and Nation names.
    - Closes 7497.
  - New Config Option: filters_colour_chat.modify_chat.max_name_capital_letters
    - Default: -1
    - Maximum number of capital letters that can be used in Town and Nation names.
    - This count does not include the first letter of a town, and does not count capitalized letters that come after a _ character.			
    - This means that a town named New_York would register 0 capitals. While McDonalds would register 1. COOLTOWN would register 7 capital letters.
```


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

Closes https://github.com/TownyAdvanced/Towny/issues/7497
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
