### PR TITLE
Add safe-teleport detection to spawn points.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1280,6 +1280,7 @@ public enum ConfigNodes {
 	SPAWNING_SAFE_TELEPORT(
 		"spawning.safe_teleport",
 		"false",
+		"",
 		"# If enabled tries to find a safe location when teleporting to a town spawn/nation spawn/outpost",
 		"# can be used to prevent players from making kill boxes at those locations."
 	),

--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -36,6 +36,13 @@ public enum ConfigNodes {
 			"# Your players will select what locale that Towny shows them ",
 			"# by changing their Minecraft client's locale."),
 	
+	SAFE_TELEPORT(
+		"safety.teleport",
+		"false",
+		"# If enabled tries to find a safe location when teleporting to a town spawn/nation spawn/outpost",
+		"# can be used to prevent players from making kill boxes at those locations."
+	),
+	
 	ENABLED_LANGUAGES(
 			"language.enabled_languages",
 			"*",

--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -36,13 +36,6 @@ public enum ConfigNodes {
 			"# Your players will select what locale that Towny shows them ",
 			"# by changing their Minecraft client's locale."),
 	
-	SAFE_TELEPORT(
-		"safety.teleport",
-		"false",
-		"# If enabled tries to find a safe location when teleporting to a town spawn/nation spawn/outpost",
-		"# can be used to prevent players from making kill boxes at those locations."
-	),
-	
 	ENABLED_LANGUAGES(
 			"language.enabled_languages",
 			"*",
@@ -1284,6 +1277,12 @@ public enum ConfigNodes {
 			"# +------------------------------------------------------+ #",
 			"############################################################",
 			""),
+	SPAWNING_SAFE_TELEPORT(
+		"spawning.safe_teleport",
+		"false",
+		"# If enabled tries to find a safe location when teleporting to a town spawn/nation spawn/outpost",
+		"# can be used to prevent players from making kill boxes at those locations."
+	),
 	SPAWNING_COST_SPAWN_WARNINGS(
 			"spawning.spawn_cost_warnings",
 			"true",

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -3663,6 +3663,10 @@ public class TownySettings {
 		return getString(ConfigNodes.PLUGIN_WEB_MAP_URL);
 	}
 	
+	public static boolean getSafetyTeleport() { 
+		return getBoolean(ConfigNodes.SAFE_TELEPORT);
+	}
+	
 	public static Map<Integer, TownLevel> getConfigTownLevel() {
 		return configTownLevel;
 	}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -3664,7 +3664,7 @@ public class TownySettings {
 	}
 	
 	public static boolean getSafetyTeleport() { 
-		return getBoolean(ConfigNodes.SAFE_TELEPORT);
+		return getBoolean(ConfigNodes.SPAWNING_SAFE_TELEPORT);
 	}
 	
 	public static Map<Integer, TownLevel> getConfigTownLevel() {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -3663,7 +3663,7 @@ public class TownySettings {
 		return getString(ConfigNodes.PLUGIN_WEB_MAP_URL);
 	}
 	
-	public static boolean getSafetyTeleport() { 
+	public static boolean isSafeTeleportUsed() { 
 		return getBoolean(ConfigNodes.SPAWNING_SAFE_TELEPORT);
 	}
 	

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/SpawnUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/SpawnUtil.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-
 import com.palmergames.bukkit.towny.event.NationSpawnEvent;
 import com.palmergames.bukkit.towny.event.SpawnEvent;
 import com.palmergames.bukkit.towny.event.TownSpawnEvent;
@@ -466,8 +465,8 @@ public class SpawnUtil {
 	 * @return A safe location nearby, same location if already safe
 	 */
 	private static Location getSafeLocation(Location location) {
-		//if safety teleport isn't enabled do nothing
-		if (!TownySettings.getSafetyTeleport()) {
+		//if safety teleport isn't enabled do anything
+		if (!TownySettings.isSafeTeleportUsed()) {
 			return location;
 		}
 		

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/SpawnUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/SpawnUtil.java
@@ -1,6 +1,6 @@
 package com.palmergames.bukkit.towny.utils;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -475,8 +475,10 @@ public class SpawnUtil {
 			return location;
 		}
 
-		LinkedList<Boolean> isLiquidMap = new LinkedList<>();
-		LinkedList<Boolean> isSolidMap = new LinkedList<>();
+		final int range = 20;
+		
+		ArrayList<Boolean> isLiquidMap = new ArrayList<>(range * 2);
+		ArrayList<Boolean> isSolidMap = new ArrayList<>(range * 2);
 		
 		
 		// look for 20 blocks up and down for a safe location, 
@@ -484,7 +486,6 @@ public class SpawnUtil {
 		// maybe add a translation key and add the player 
 		// as a parameter to print him an error message
 		
-		final int range = 20;
 		Location temp = location.clone().subtract(0, range, 0);
 		
 		//build the linked lists

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/SpawnUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/SpawnUtil.java
@@ -445,16 +445,16 @@ public class SpawnUtil {
 							return player.getWorld().getSpawnLocation();
 					});
 				} else if (town != null && town.hasSpawn())
-					yield CompletableFuture.completedFuture(getSafeLocation(town.getSpawnOrNull()));
+					yield CompletableFuture.completedFuture(getSafeLocation(town.getSpawnOrNull(), player));
 				else
 					yield CompletableFuture.completedFuture(player.getWorld().getSpawnLocation());
 			case TOWN:
 				if (outpost)
-					yield CompletableFuture.completedFuture(getSafeLocation(getOutpostSpawnLocation(town, split)));
+					yield CompletableFuture.completedFuture(getSafeLocation(getOutpostSpawnLocation(town, split), player));
 				else
-					yield CompletableFuture.completedFuture(getSafeLocation(town.getSpawn()));
+					yield CompletableFuture.completedFuture(getSafeLocation(town.getSpawn(), player));
 			case NATION:
-				yield CompletableFuture.completedFuture(getSafeLocation(nation.getSpawn()));
+				yield CompletableFuture.completedFuture(getSafeLocation(nation.getSpawn(), player));
 		};
 	}
 
@@ -465,7 +465,7 @@ public class SpawnUtil {
 	 * @param location Starting location
 	 * @return A safe location nearby, same location if already safe
 	 */
-	private static Location getSafeLocation(Location location) {
+	private static Location getSafeLocation(Location location, Player p) {
 		//if safety teleport isn't enabled do anything
 		if (!TownySettings.isSafeTeleportUsed()) {
 			return location;
@@ -516,6 +516,7 @@ public class SpawnUtil {
 			return location.clone().add(0, i + 1- range, 0);
 		}
 		
+		TownyMessaging.sendErrorMsg(p, Translatable.of("msg_spawn_fail_safe_teleport"));
 		return null;
 	}
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/SpawnUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/SpawnUtil.java
@@ -1,5 +1,6 @@
 package com.palmergames.bukkit.towny.utils;
 
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -474,24 +475,45 @@ public class SpawnUtil {
 			return location;
 		}
 
-		Location up = location.clone();
-		Location down = location.clone();
+		LinkedList<Boolean> isLiquidMap = new LinkedList<>();
+		LinkedList<Boolean> isSolidMap = new LinkedList<>();
+		
 		
 		// look for 20 blocks up and down for a safe location, 
 		// if you can't find it fail the teleport
 		// maybe add a translation key and add the player 
 		// as a parameter to print him an error message
-		for(int i = 0; i < 20; i++) {
-			up = up.add(0,1,0);
-			down = down.subtract(0, 1, 0);
+		
+		final int range = 20;
+		Location temp = location.clone().subtract(0, range, 0);
+		
+		//build the linked lists
+		for(int i = 0; i < range * 2; i++) {
+			Material type = temp.getBlock().getType();
 			
-			if (isSafeLocation(up)) {
-				return up;
+			isLiquidMap.add(ItemLists.LIQUID_BLOCKS.contains(type));
+			isSolidMap.add(!ItemLists.NOT_SOLID_BLOCKS.contains(type));
+			
+			temp = temp.add(0,1,0);
+		}
+		
+		for (int i = 0; i < (range * 2) - 2; i++) {
+			// i 	 = bottom block
+			// i + 1 = middle block
+			// i + 2 = top block
+			if(!isSolidMap.get(i) || isLiquidMap.get(i)) {
+				continue;
 			}
 			
-			if (isSafeLocation(down)) {
-				return down;
+			if (isSolidMap.get(i+1) || isLiquidMap.get(i+1)) {
+				continue;
 			}
+			
+			if (isSolidMap.get(i+2) || isLiquidMap.get(i+2)) {
+				continue;
+			}
+			
+			return location.clone().add(0, i + 1- range, 0);
 		}
 		
 		return null;

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/SpawnUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/SpawnUtil.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+
 import com.palmergames.bukkit.towny.event.NationSpawnEvent;
 import com.palmergames.bukkit.towny.event.SpawnEvent;
 import com.palmergames.bukkit.towny.event.TownSpawnEvent;
@@ -475,7 +476,7 @@ public class SpawnUtil {
 			return location;
 		}
 
-		final int range = 20;
+		final int range = 22;
 
 		BitSet isLiquidMap = new BitSet(range * 2);
 		BitSet isSolidMap = new BitSet(range * 2);
@@ -502,27 +503,40 @@ public class SpawnUtil {
 			temp = temp.add(0,1,0);
 		}
 		
-		for (int i = 0; i < (range * 2) - 2; i++) {
-			// i 	 = bottom block
-			// i + 1 = middle block
-			// i + 2 = top block
-			if(!isSolidMap.get(i) || isLiquidMap.get(i)) {
+		// 0 1 -1 2 -2 ...
+		for (int i = 0; Math.abs(i) < range - 2; i = next(i) ) {
+			// value 	 = bottom block
+			// value + 1 = middle block
+			// value + 2 = top block
+			int value = i + range;
+			
+			if(!isSolidMap.get(value) || isLiquidMap.get(value)) {
 				continue;
 			}
 			
-			if (isSolidMap.get(i+1) || isLiquidMap.get(i+1)) {
+			if (isSolidMap.get(value+1) || isLiquidMap.get(value+1)) {
 				continue;
 			}
 			
-			if (isSolidMap.get(i+2) || isLiquidMap.get(i+2)) {
+			if (isSolidMap.get(value+2) || isLiquidMap.get(value+2)) {
 				continue;
 			}
 			
-			return location.clone().add(0, i + 1- range, 0);
+			return location.clone().add(0, value + 1, 0);
 		}
 		
 		TownyMessaging.sendErrorMsg(p, Translatable.of("msg_spawn_fail_safe_teleport"));
 		return null;
+	}
+	
+	private static int next(int i) {
+		if (i <= 0) {
+			i = -i;
+			i++;
+		} else {
+			i = -i;
+		}
+		return i;
 	}
 
 	private static boolean isSafeLocation(Location location) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/SpawnUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/SpawnUtil.java
@@ -1,6 +1,6 @@
 package com.palmergames.bukkit.towny.utils;
 
-import java.util.ArrayList;
+import java.util.BitSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -476,10 +476,9 @@ public class SpawnUtil {
 		}
 
 		final int range = 20;
-		
-		ArrayList<Boolean> isLiquidMap = new ArrayList<>(range * 2);
-		ArrayList<Boolean> isSolidMap = new ArrayList<>(range * 2);
-		
+
+		BitSet isLiquidMap = new BitSet(range * 2);
+		BitSet isSolidMap = new BitSet(range * 2);
 		
 		// look for 20 blocks up and down for a safe location, 
 		// if you can't find it fail the teleport
@@ -492,8 +491,13 @@ public class SpawnUtil {
 		for(int i = 0; i < range * 2; i++) {
 			Material type = temp.getBlock().getType();
 			
-			isLiquidMap.add(ItemLists.LIQUID_BLOCKS.contains(type));
-			isSolidMap.add(!ItemLists.NOT_SOLID_BLOCKS.contains(type));
+			if (ItemLists.LIQUID_BLOCKS.contains(type)) {
+				isLiquidMap.set(i);
+			}
+			
+			if (!ItemLists.NOT_SOLID_BLOCKS.contains(type)) {
+				isSolidMap.set(i);
+			}
 			
 			temp = temp.add(0,1,0);
 		}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/SpawnUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/SpawnUtil.java
@@ -540,7 +540,7 @@ public class SpawnUtil {
 		// Check if block below is lava or water or nothing
 		Block belowBlock = world.getBlockAt(location.clone().subtract(0, 1, 0));
 		Material belowType = belowBlock.getType();
-		if (ItemLists.AIR_TYPES.contains(belowType) || ItemLists.LIQUID_BLOCKS.contains(type)) {
+		if (ItemLists.NOT_SOLID_BLOCKS.contains(belowType) || ItemLists.LIQUID_BLOCKS.contains(type)) {
 			return false;
 		}
 

--- a/Towny/src/main/java/com/palmergames/bukkit/util/ItemLists.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/ItemLists.java
@@ -324,7 +324,7 @@ public class ItemLists extends AbstractRegistryList<Material> {
 			.add("SAND", "RED_SAND", "GRAVEL", "SUSPICIOUS_SAND", "SUSPICIOUS_GRAVEL")
 			.endsWith("_CONCRETE_POWDER")
 			.build();
-	
+
 	/**
 	 * List of blocks which, when exploded, will not have their drops set to false, despite our asking.
 	 */

--- a/Towny/src/main/java/com/palmergames/bukkit/util/ItemLists.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/ItemLists.java
@@ -4,7 +4,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -258,6 +257,11 @@ public class ItemLists extends AbstractRegistryList<Material> {
 	public static final ItemLists CAULDRON_FILLABLE = newBuilder().add("WATER_BUCKET", "LAVA_BUCKET", "POWDER_SNOW_BUCKET").build();
 
 	/**
+	 * List of liquid blocks
+	 */
+	public static final ItemLists LIQUID_BLOCKS = newBuilder().add("WATER", "LAVA", "BUBBLE_COLUMN").build();
+	
+	/**
 	 * List of hoes
 	 */
 	public static final ItemLists HOES = newBuilder().withTag(Tag.REGISTRY_ITEMS, minecraft("hoes")).endsWith("_hoe").build();
@@ -278,11 +282,49 @@ public class ItemLists extends AbstractRegistryList<Material> {
 			.includeList(PLANTABLES)
 			.add("TALL_GRASS","LARGE_FERN","VINE","TWISTING_VINES_PLANT","WEEPING_VINES_PLANT","NETHER_WART_BLOCK","CRIMSON_ROOTS","WARPED_ROOTS","NETHER_SPROUTS","BIG_DRIPLEAF","SMALL_DRIPLEAF").build();
 
+	/**
+	 * Minecraft uses 3 types of air
+	 */
+	public static final ItemLists AIR_TYPES = newBuilder()
+		.add("AIR")
+		.add("CAVE_AIR")
+		.add("VOID_AIR").build();
+
+	/**
+	 * List of all the banners
+	 */
+	public static final ItemLists BANNERS = newBuilder().endsWith("_BANNER").build();
+
+	/**
+	 * List of wall coral fans, players can fall through these
+	 */
+	public static final ItemLists CORAL_FANS = newBuilder()
+		.endsWith("_WALL_FAN")
+		.build();
+		
+	/**
+	 * List of solid blocks
+	 */
+	public static final ItemLists NOT_SOLID_BLOCKS = newBuilder()
+			.add("TRIPWIRE", "TRIPWIRE_HOOK")
+			.add("REDSTONE_WIRE","COMPARATOR","REPEATER","LEVER")
+			.includeList(CORAL_FANS)
+			.includeList(AIR_TYPES)
+			.includeList(SIGNS)
+			.includeList(BUTTONS)
+			.includeList(PRESSURE_PLATES)
+			.includeList(FENCE_GATES) //if open they are basically air
+			.includeList(TRAPDOORS) //if open they are basically air
+			.includeList(DOORS) ////if open they are basically air
+			.includeList(TORCHES)
+			.includeList(BANNERS)
+			.includeList(PLANTS).build();
+	
 	public static final ItemLists FALLING_BLOCKS = newBuilder()
 			.add("SAND", "RED_SAND", "GRAVEL", "SUSPICIOUS_SAND", "SUSPICIOUS_GRAVEL")
 			.endsWith("_CONCRETE_POWDER")
 			.build();
-
+	
 	/**
 	 * List of blocks which, when exploded, will not have their drops set to false, despite our asking.
 	 */

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -1108,6 +1108,7 @@ msg_err_public_nation_spawn_forbidden: '&cPublic spawn travel to other nations i
 msg_err_public_nation_spawn_forbidden_war: '&cPublic spawn travel to other nations is only allowed during war.'
 msg_err_public_nation_spawn_forbidden_peace: '&cPublic spawn travel to other nations is forbidden during war.'
 msg_spawn_cost_set_to: '&b%s has set the price of using /%s spawn to %s'
+msg_spawn_fail_safe_teleport: '&cTeleportation failed, the location is not safe, ask the mayor of your town to change the teleport location.'
 msg_err_cannot_set_spawn_cost_more_than: '&cYou cannot set the spawn cost higher than %s'
 msg_err_ally_isnt_public: '&cYour ally, %s, does not have public spawning enabled. Teleport denied.'
 msg_nation_changed_public: '&cThe Nation''s public status is now %s.'


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Teleport a player near a safe location when teleporting to town spawn/outpost/nation spawn, for now it only fails the teleport

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
#7463 


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
