### PR TITLE
Add the ability to stop weapons and armour degrading in arena plots.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -748,6 +748,12 @@ public enum ConfigNodes {
 			"# If People should keep their experience on death in an arena townblock.",
 			"# Is not guaranteed to work with other keep experience plugins!"
 	),
+	GTOWN_SETTINGS_PREVENT_ITEM_DEGRADE_IN_ARENAS(
+			"global_town_settings.prevent_item_degrading_in_arenas",
+			"false",
+			"",
+			"# While true, weapons and armour items worn by players in Arena plots will not lose durability."),
+
 	GTOWN_SETTINGS_MAX_BUYTOWN_PRICE(
 			"global_town_settings.max_buytown_price",
 			"999999999",

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -3177,6 +3177,10 @@ public class TownySettings {
 		return getBoolean(ConfigNodes.GTOWN_SETTINGS_KEEP_EXPERIENCE_ON_DEATH_IN_ARENA);
 	}
 	
+	public static boolean arenaPlotPreventArmourDegrade() {
+		return getBoolean(ConfigNodes.GTOWN_SETTINGS_PREVENT_ITEM_DEGRADE_IN_ARENAS);
+	}
+
 	public static boolean getKeepInventoryInArenas() {
 		return getBoolean(ConfigNodes.GTOWN_SETTINGS_KEEP_INVENTORY_ON_DEATH_IN_ARENA);
 	}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -1072,7 +1072,7 @@ public class TownyPlayerListener implements Listener {
 		return keepInventory;
 	}
 
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void onArmourDamageEvent(PlayerItemDamageEvent event) {
 		if (!TownySettings.arenaPlotPreventArmourDegrade())
 			return;

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -82,6 +82,7 @@ import org.bukkit.event.player.PlayerFishEvent;
 import org.bukkit.event.player.PlayerGameModeChangeEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerItemDamageEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
@@ -1069,6 +1070,29 @@ public class TownyPlayerListener implements Listener {
 			keepInventory = true;
 
 		return keepInventory;
+	}
+
+	@EventHandler
+	public void onArmourDamageEvent(PlayerItemDamageEvent event) {
+		if (!TownySettings.arenaPlotPreventArmourDegrade())
+			return;
+
+		if (plugin.isError()) {
+			event.setCancelled(true);
+			return;
+		}
+
+		if (!TownyAPI.getInstance().isTownyWorld(event.getPlayer().getWorld()))
+			return;
+
+		TownBlock tb = TownyAPI.getInstance().getTownBlock(event.getPlayer());
+		if (tb == null || !tb.getType().equals(TownBlockType.ARENA))
+			return;
+
+		if (!ItemLists.ARMOURS.contains(event.getItem()) && !ItemLists.WEAPONS.contains(event.getItem()))
+			return;
+
+		event.setCancelled(true);
 	}
 
 	private boolean tryKeepExperience(PlayerDeathEvent event, TownBlock tb) {

--- a/Towny/src/main/java/com/palmergames/bukkit/util/ItemLists.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/ItemLists.java
@@ -49,6 +49,39 @@ public class ItemLists extends AbstractRegistryList<Material> {
 	public static final ItemLists AXES = newBuilder().withTag(Tag.REGISTRY_ITEMS, minecraft("axes")).endsWith("_AXE").build();
 
 	/**
+	 * List of Sword items.
+	 */
+	public static final ItemLists SWORDS = newBuilder().withTag(Tag.REGISTRY_ITEMS, minecraft("swords")).endsWith("_SWORD").build();
+
+	/**
+	 * List of Bow items.
+	 */
+	public static final ItemLists BOWS = newBuilder().add("BOW","CROSSBOW").build();
+
+	/**
+	 * List of Weapon items.
+	 */
+	public static final ItemLists WEAPONS = newBuilder()
+			.includeList(AXES)
+			.includeList(SWORDS)
+			.includeList(BOWS)
+			.build();
+
+	/**
+	 * List of Armour items.
+	 */
+	public static final ItemLists ARMOURS = newBuilder()
+			.withTag(Tag.REGISTRY_ITEMS, minecraft("chest_armor"))
+			.withTag(Tag.REGISTRY_ITEMS, minecraft("head_armor"))
+			.withTag(Tag.REGISTRY_ITEMS, minecraft("foot_armor"))
+			.withTag(Tag.REGISTRY_ITEMS, minecraft("leg_armor"))
+			.endsWith("_CHESTPLATE")
+			.endsWith("_HELMET")
+			.endsWith("_LEGGINGS")
+			.endsWith("_BOOTS")
+			.build();
+	
+	/**
 	 * List of Dye items.
 	 */
 	public static final ItemLists DYES = newBuilder().endsWith("_DYE").endsWith("INK_SAC").build();


### PR DESCRIPTION

<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
```

  - New Config Option: global_town_settings.prevent_item_degrading_in_arenas
    - Default: false
    - While true, weapons and armour items worn by players in Arena plots will not lose durability.
```

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

Closes #7549.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
