### PR TITLE
Add the ability to block non-allies gaining benefits from Beacons placed in towns.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -524,7 +524,8 @@ public enum ConfigNodes {
 			"# When true players cannot become hungrier when in their own or an allied town."),
 
 	GTOWN_SETTINGS_BEACONS_ROOT(
-			"global_town_settings.beacons","","",""),
+			"global_town_settings.beacons","","",
+			"# These beacons settings will only work on Paper or Paper-derived servers. They will not have any effect on Spigot servers."),
 	GTOWN_SETTINGS_BEACONS_FOR_ALLIES_ONLY(
 			"global_town_settings.beacons.beacons_for_allies_only",
 			"false",

--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -523,6 +523,12 @@ public enum ConfigNodes {
 			"",
 			"# When true players cannot become hungrier when in their own or an allied town."),
 
+	GTOWN_SETTINGS_BEACONS_FOR_ALLIES_ONLY(
+			"global_town_settings.beacons_for_allies_only",
+			"false",
+			"",
+			"# When true, a beacon placed in a town will only affect the allies of the town. This includes residents, nation residents and allied nation residents."),
+
 	GTOWN_SETTINGS_PVP_COOLDOWN_TIMER(
 			"global_town_settings.pvp_cooldown_time",
 			"30",

--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -523,11 +523,18 @@ public enum ConfigNodes {
 			"",
 			"# When true players cannot become hungrier when in their own or an allied town."),
 
+	GTOWN_SETTINGS_BEACONS_ROOT(
+			"global_town_settings.beacons","","",""),
 	GTOWN_SETTINGS_BEACONS_FOR_ALLIES_ONLY(
-			"global_town_settings.beacons_for_allies_only",
+			"global_town_settings.beacons.beacons_for_allies_only",
 			"false",
 			"",
 			"# When true, a beacon placed in a town will only affect the allies of the town. This includes residents, nation residents and allied nation residents."),
+	GTOWN_SETTINGS_BEACONS_EXCLUDE_CONQUERED_TOWNS(
+			"global_town_settings.beacons.exclude_conquered_towns",
+			"false",
+			"",
+			"# When true, conquered towns are not considered allies."),
 
 	GTOWN_SETTINGS_PVP_COOLDOWN_TIMER(
 			"global_town_settings.pvp_cooldown_time",

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -1569,6 +1569,10 @@ public class TownySettings {
 		return getBoolean(ConfigNodes.GTOWN_SETTINGS_BEACONS_FOR_ALLIES_ONLY);
 	}
 
+	public static boolean beaconsExcludeConqueredTowns() {
+		return getBoolean(ConfigNodes.GTOWN_SETTINGS_BEACONS_EXCLUDE_CONQUERED_TOWNS);
+	}
+
 	public static boolean getTownDefaultPublic() {
 
 		return getBoolean(ConfigNodes.TOWN_DEF_PUBLIC);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -1565,6 +1565,10 @@ public class TownySettings {
 		return getBoolean(ConfigNodes.GTOWN_SETTINGS_REGEN_PREVENT_SATURATION_LOSS);
 	}
 
+	public static boolean beaconsForTownMembersOnly() {
+		return getBoolean(ConfigNodes.GTOWN_SETTINGS_BEACONS_FOR_ALLIES_ONLY);
+	}
+
 	public static boolean getTownDefaultPublic() {
 
 		return getBoolean(ConfigNodes.TOWN_DEF_PUBLIC);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPaperEvents.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPaperEvents.java
@@ -248,8 +248,15 @@ public class TownyPaperEvents implements Listener {
 
 			Town blockTown = TownyAPI.getInstance().getTown(block.getLocation());
 			Town playerTown = TownyAPI.getInstance().getTown(player);
-			if (blockTown == null || (playerTown != null && CombatUtil.isAlly(playerTown, blockTown)))
+			
+			// Beacon is in the wild.
+			if (blockTown == null)
 				return;
+			
+			if (playerTown != null && CombatUtil.isAlly(playerTown, blockTown)) {
+				if (!(playerTown.isConquered() && blockTown.hasNation() && blockTown.getNationOrNull().hasTown(playerTown) && TownySettings.beaconsExcludeConqueredTowns()))
+					return;
+			}
 
 			((Cancellable) event).setCancelled(true);
 		};


### PR DESCRIPTION
  - Requires Paper for this to work.

```
  - New Config Option: global_town_settings.beacons_for_allies_only
    - Default: false
    - When true, a beacon placed in a town will only affect the allies of the town. This includes residents, nation residents and allied nation residents.
  - New Config Option: global_town_settings.beacons.exclude_conquered_towns
    - Default: false
    - When true, conquered towns are not considered allies.
```
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

  - Closes #7532
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
