### PR TITLE
Add experimental option to consider conquered towns as not allies.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -989,6 +989,13 @@ public enum ConfigNodes {
 			"-1",
 			"",
 			"# The maximum amount of allies that a nation can have, set to -1 to have no limit."),
+	GNATION_SETTINGS_ARE_CONQUERED_TOWNS_CONSIDERED_ALLIES(
+			"global_nation_settings.are_conquered_towns_considered_allies",
+			"true",
+			"",
+			"# While true, conquered towns will be considered a member of good standing in the nation.",
+			"# When set to false CombatUtil#isAlly() tests will treat conquered towns and their nations as not allied.",
+			"# Setting this to false could result in strange unforseen behaviour."),
 	GNATION_SETTINGS_PROXIMITY_ROOT(
 			"global_nation_settings.proximity", "", ""),
 	GNATION_SETTINGS_NATION_PROXIMITY_TO_CAPITAL(

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -3611,6 +3611,10 @@ public class TownySettings {
 		return getInt(ConfigNodes.GNATION_SETTINGS_MAX_ALLIES);
 	}
 	
+	public static boolean areConqueredTownsConsideredAllied() {
+		return getBoolean(ConfigNodes.GNATION_SETTINGS_ARE_CONQUERED_TOWNS_CONSIDERED_ALLIES);
+	}
+	
 	public static String getBankHistoryBookFormat() {
 		return getString(ConfigNodes.BANKHISTORY_BOOK);
 	}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/CombatUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/CombatUtil.java
@@ -478,8 +478,10 @@ public class CombatUtil {
 			return true;
 		if (isSameNation(a, b) && TownySettings.areConqueredTownsConsideredAllied())
 			return true;
-		if (isSameNation(a, b) && !TownySettings.areConqueredTownsConsideredAllied() && ((a.isConquered() && !b.isConquered()) || (!a.isConquered() && b.isConquered())))
+		if (isSameNation(a, b) && !TownySettings.areConqueredTownsConsideredAllied() && ((a.isConquered() && !b.isConquered()) || (!a.isConquered() && b.isConquered()))) {
+			TownyMessaging.sendDebugMsg(String.format("The isAlly test between %s and %s was overridden because one of the two towns is conquered by the other.", a.getName(), b.getName()));
 			return false;
+		}
 		if (a.hasNation() && b.hasNation() && a.getNationOrNull().hasAlly(b.getNationOrNull()))
 			return true;
 		return false;

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/CombatUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/CombatUtil.java
@@ -476,8 +476,10 @@ public class CombatUtil {
 			return true;
 		if (a.hasAlly(b))
 			return true;
-		if (isSameNation(a, b))
+		if (isSameNation(a, b) && TownySettings.areConqueredTownsConsideredAllied())
 			return true;
+		if (isSameNation(a, b) && !TownySettings.areConqueredTownsConsideredAllied() && ((a.isConquered() && !b.isConquered()) || (!a.isConquered() && b.isConquered())))
+			return false;
 		if (a.hasNation() && b.hasNation() && a.getNationOrNull().hasAlly(b.getNationOrNull()))
 			return true;
 		return false;


### PR DESCRIPTION

<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This would cause the common CombatUtil.isAlly(Town, Town) method call to return differently when a town which is conquered and a non-conquered town of the same nation are tested.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->

```
New Config Option:
global_nation_settings.are_conquered_towns_considered_allies
  - Default: true
  - While true, conquered towns will be considered a member of good standing in the nation.
  - When set to false CombatUtil#isAlly() tests will treat conquered towns and their nations as not allied.
  - Setting this to false could result in strange unforseen behaviour.
```

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
