### PR TITLE
Don't show warmup particles for hidden/invisible players

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/TeleportWarmupParticle.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/TeleportWarmupParticle.java
@@ -3,36 +3,41 @@ package com.palmergames.bukkit.towny.object;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.palmergames.bukkit.towny.utils.MinecraftVersion;
 import org.bukkit.Location;
 import org.bukkit.Particle;
-import org.bukkit.World;
 
 import com.palmergames.bukkit.towny.Towny;
+import org.bukkit.entity.Player;
 
 public class TeleportWarmupParticle {
 
 	private static final List<RingCoord> RING_PATTERN = createRingOffsets();
 	public static final int RING_POINT_COUNT = 12;
 	public static final int RING_DELAY_TICKS = 2;
-	public final Location loc;
 
+	@Deprecated
 	public TeleportWarmupParticle(Location loc) {
-		this.loc = loc;
-		drawParticle();
+		
 	}
 
-	private void drawParticle() {
-		final World world = loc.getWorld();
-		if (world == null)
-			return;
+	public static void drawParticles(final Player player, final double yOffset) {
 		int i = 0;
 		for (RingCoord ringPosition : RING_PATTERN) {
-			Location point = loc.clone().add(ringPosition.x(), 0.0, ringPosition.z());
-			Towny.getPlugin().getScheduler().runAsyncLater(() -> {
-				try {
-					// This can potentially throw an exception if we're running this async and a player disconnects while it's sending particles.
-					world.spawnParticle(Particle.CRIT_MAGIC, point, 1, 0.0, 0.0, 0.0, 0.0);
-				} catch (Exception ignored) {}
+			Towny.getPlugin().getScheduler().runLater(player, () -> {
+				final Location point = player.getLocation().add(ringPosition.x(), yOffset, ringPosition.z());
+
+				player.spawnParticle(Particle.CRIT_MAGIC, point, 1, 0.0, 0.0, 0.0, 0.0);
+
+				// Don't show particles for other players if the player is invisible
+				if (player.isInvisible())
+					return;
+
+				if (MinecraftVersion.CURRENT_VERSION.isNewerThanOrEquals(MinecraftVersion.MINECRAFT_1_20_2)) {
+					for (final Player trackingPlayer : player.getTrackedBy()) {
+						trackingPlayer.spawnParticle(Particle.CRIT_MAGIC, point, 1, 0.0, 0.0, 0.0, 0.0);
+					}
+				}
 			}, (long) i * RING_DELAY_TICKS);
 			i++;
 		}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/TeleportWarmupTimerTask.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/TeleportWarmupTimerTask.java
@@ -91,8 +91,8 @@ public class TeleportWarmupTimerTask extends TownyTimerTask {
 			// Send a particle that drops from above the player to their feet over the course of the warmup.
 			if (TownySettings.isTeleportWarmupShowingParticleEffect()) {
 				double progress = (double) (teleportWarmupTime - seconds) / teleportWarmupTime;
-				double offset = 2.0 + (progress * -2.0);
-				new TeleportWarmupParticle(resident.getPlayer().getLocation().add(0.0, offset, 0.0));
+				double yOffset = 2.0 + (progress * -2.0);
+				TeleportWarmupParticle.drawParticles(resident.getPlayer(), yOffset);
 			}
 		}
 	}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/MinecraftVersion.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/MinecraftVersion.java
@@ -12,6 +12,7 @@ public class MinecraftVersion {
 	public static final Version MINECRAFT_1_19_1 = Version.fromString("1.19.1");
 	public static final Version MINECRAFT_1_19_3 = Version.fromString("1.19.3");
 	public static final Version MINECRAFT_1_20 = Version.fromString("1.20");
+	public static final Version MINECRAFT_1_20_2 = Version.fromString("1.20.2");
 	public static final Version MINECRAFT_1_20_3 = Version.fromString("1.20.3");
 	
 	public static final Version CURRENT_VERSION = Version.fromString(Bukkit.getBukkitVersion());


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
If a player is using an invisibility potion then only they will be able to see the particles, and players hidden using the builtin bukkit vanish api also won't have their particles shown to players who can't see them.
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
