### PR TITLE
Prevent wind charge exploits on switch blocks.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/event/executors/TownyActionEventExecutor.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/event/executors/TownyActionEventExecutor.java
@@ -60,6 +60,26 @@ public class TownyActionEventExecutor {
 	 * @return true if not cancelled by the cache or the event results.
 	 */
 	private static boolean isAllowedAction(Player player, Location loc, Material mat, ActionType action, TownyActionEvent event) {
+		return isAllowedAction(player, loc, mat, action, event, false);
+	}
+
+	/**
+	 * First checks the Player's cache using the PlayerCacheUtil, and sets the
+	 * cancellation of the Action-Type Event. Then fires the ActionType-based Event,
+	 * with which Towny will decide if Event War or Flag War change anything, or any
+	 * other plugin wanting to affect the outcome of an action-based decision.
+	 * 
+	 * Displays feedback to the player when an action is cancelled.
+	 * 
+	 * @param player     - Player involved in the event.
+	 * @param loc   - Location of the event.
+	 * @param mat   - Material being involved in the event.
+	 * @param action - The ActionType of the event. ex: BUILD
+	 * @param event - One of the four ActionType-based events.
+	 * @param silent - Whether to suppress the message.
+	 * @return true if not cancelled by the cache or the event results.
+	 */
+	private static boolean isAllowedAction(Player player, Location loc, Material mat, ActionType action, TownyActionEvent event, boolean silent) {
 
 		/*
 		 * Use the PlayerCache to decide what Towny will do,
@@ -82,7 +102,7 @@ public class TownyActionEventExecutor {
 		/*
 		 * Send any feedback when the action is denied.
 		 */
-		if (event.isCancelled() && !event.isMessageSuppressed())
+		if (event.isCancelled() && !event.isMessageSuppressed() && !silent)
 			TownyMessaging.sendErrorMsg(player, event.getCancelMessage());
 
 		return !event.isCancelled();
@@ -248,8 +268,21 @@ public class TownyActionEventExecutor {
 	 * @return true if allowed.
 	 */
 	public static boolean canSwitch(Player player, Location loc, Material mat) {
+		return canSwitch(player, loc, mat, false);
+	}
+
+	/**
+	 * Can the player use switches of this material at this location?
+	 * 
+	 * @param player     - Player involved in the event.
+	 * @param loc   - Location of the event.
+	 * @param mat   - Material being involved in the event.
+	 * @param silent Whether to show an error message.
+	 * @return true if allowed.
+	 */
+	public static boolean canSwitch(Player player, Location loc, Material mat, boolean silent) {
 		TownySwitchEvent event = new TownySwitchEvent(player, loc, mat, getBlock(loc), TownyAPI.getInstance().getTownBlock(loc), false);
-		return isAllowedAction(player, loc, mat, ActionType.SWITCH, event);
+		return isAllowedAction(player, loc, mat, ActionType.SWITCH, event, silent);
 	}
 
 	/**

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/MinecraftVersion.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/MinecraftVersion.java
@@ -15,6 +15,7 @@ public class MinecraftVersion {
 	public static final Version MINECRAFT_1_20_2 = Version.fromString("1.20.2");
 	public static final Version MINECRAFT_1_20_3 = Version.fromString("1.20.3");
 	public static final Version MINECRAFT_1_20_5 = Version.fromString("1.20.5");
+	public static final Version MINECRAFT_1_21 = Version.fromString("1.21");
 	
 	public static final Version CURRENT_VERSION = Version.fromString(Bukkit.getBukkitVersion());
 	public static final Version OLDEST_VERSION_SUPPORTED = MINECRAFT_1_19_1;

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -2612,3 +2612,5 @@ msg_admin_eco_convert_conversion_progress: "Account conversion in progress, %s c
 msg_admin_eco_convert_success: "Economy conversion successful"
 
 msg_err_mode_does_not_exist: "The mode %s is not recognized."
+
+msg_err_not_allowed_to_switch: "You aren't allowed to Switch here."


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

Adds a new listener that takes care of only WindCharge entity explosions.
- Removes blocks that are switches that cannot be used by the player.

Adds a new silent option to the isAllowedAction method, which allows Towny to suppress spammy permission tests.

Stops players using switch blocks when they're activated by wind charge explosions.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

Closes #7648 
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
