### PR TITLE
Fix adventure relocation not excluding things from paper-api. 

### DIFF
--- a/.github/workflows/deploy_prerelease.yml
+++ b/.github/workflows/deploy_prerelease.yml
@@ -24,7 +24,7 @@ jobs:
       - name: compile towny with maven
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn -B clean package -DskipTests=true
+        run: mvn -B clean package -DskipTests=false
       - name: setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,7 @@
 name: Run Tests
 on:
-    workflow_dispatch:
-#    push:
-#        branches-ignore: [l10n_master]
+    push:
+        branches-ignore: [l10n_master]
 jobs:
     test:
         runs-on: ubuntu-latest

--- a/Towny/pom.xml
+++ b/Towny/pom.xml
@@ -81,13 +81,13 @@
     </repositories>
 
     <dependencies>
-        <!-- Here to satisfy MockBukkit testing.
+        <!-- Here to satisfy MockBukkit testing. -->
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
             <version>1.21.1-R0.1-SNAPSHOT</version>
             <scope>test</scope>
-        </dependency> -->
+        </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
@@ -374,12 +374,40 @@
                                 <shadedPattern>com.palmergames.compress</shadedPattern>
                             </relocation>
                             <relocation>
-                                <pattern>net.kyori.adventure</pattern>
+                                <pattern>net.kyori.adventure-platform-bukkit</pattern>
                                 <shadedPattern>com.palmergames.adventure</shadedPattern>
                             </relocation>
                             <relocation>
-                                <pattern>net.kyori.examination</pattern>
-                                <shadedPattern>com.palmergames.examination</shadedPattern>
+                                <pattern>net.kyori.adventure-platform-api</pattern>
+                                <shadedPattern>com.palmergames.adventure</shadedPattern>
+                            </relocation>
+                            <relocation>
+                                <pattern>net.kyori.adventure-text-serializer-bungeecord</pattern>
+                                <shadedPattern>com.palmergames.adventure</shadedPattern>
+                            </relocation>
+                            <relocation>
+                                <pattern>net.kyori.adventure-nbt</pattern>
+                                <shadedPattern>com.palmergames.adventure</shadedPattern>
+                            </relocation>
+                            <relocation>
+                                <pattern>net.kyori.adventure-text-serializer-gson-legacy-impl</pattern>
+                                <shadedPattern>com.palmergames.adventure</shadedPattern>
+                            </relocation>
+                            <relocation>
+                                <pattern>net.kyori.adventure-platform-facet</pattern>
+                                <shadedPattern>com.palmergames.adventure</shadedPattern>
+                            </relocation>
+                            <relocation>
+                                <pattern>net.kyori.adventure-platform-viaversion</pattern>
+                                <shadedPattern>com.palmergames.adventure</shadedPattern>
+                            </relocation>
+                            <relocation>
+                                <pattern>net.kyori.adventure-text-serializer-plain</pattern>
+                                <shadedPattern>com.palmergames.adventure</shadedPattern>
+                            </relocation>
+                            <relocation>
+                                <pattern>net.kyori.adventure-text-minimessage</pattern>
+                                <shadedPattern>com.palmergames.adventure</shadedPattern>
                             </relocation>
                             <relocation>
                                 <pattern>org.bstats</pattern>

--- a/Towny/pom.xml
+++ b/Towny/pom.xml
@@ -87,6 +87,22 @@
             <artifactId>paper-api</artifactId>
             <version>1.21.1-R0.1-SNAPSHOT</version>
             <scope>test</scope>
+            <exclusions>
+              <exclusion>
+                <groupId>net.kyori</groupId>
+                <artifactId>adventure-api</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>net.kyori</groupId>
+                <artifactId>adventure-text-serializer-gson</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>net.kyori</groupId>
+                <artifactId>
+                  adventure-text-serializer-legacy
+                </artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>
@@ -374,39 +390,7 @@
                                 <shadedPattern>com.palmergames.compress</shadedPattern>
                             </relocation>
                             <relocation>
-                                <pattern>net.kyori.adventure-platform-bukkit</pattern>
-                                <shadedPattern>com.palmergames.adventure</shadedPattern>
-                            </relocation>
-                            <relocation>
-                                <pattern>net.kyori.adventure-platform-api</pattern>
-                                <shadedPattern>com.palmergames.adventure</shadedPattern>
-                            </relocation>
-                            <relocation>
-                                <pattern>net.kyori.adventure-text-serializer-bungeecord</pattern>
-                                <shadedPattern>com.palmergames.adventure</shadedPattern>
-                            </relocation>
-                            <relocation>
-                                <pattern>net.kyori.adventure-nbt</pattern>
-                                <shadedPattern>com.palmergames.adventure</shadedPattern>
-                            </relocation>
-                            <relocation>
-                                <pattern>net.kyori.adventure-text-serializer-gson-legacy-impl</pattern>
-                                <shadedPattern>com.palmergames.adventure</shadedPattern>
-                            </relocation>
-                            <relocation>
-                                <pattern>net.kyori.adventure-platform-facet</pattern>
-                                <shadedPattern>com.palmergames.adventure</shadedPattern>
-                            </relocation>
-                            <relocation>
-                                <pattern>net.kyori.adventure-platform-viaversion</pattern>
-                                <shadedPattern>com.palmergames.adventure</shadedPattern>
-                            </relocation>
-                            <relocation>
-                                <pattern>net.kyori.adventure-text-serializer-plain</pattern>
-                                <shadedPattern>com.palmergames.adventure</shadedPattern>
-                            </relocation>
-                            <relocation>
-                                <pattern>net.kyori.adventure-text-minimessage</pattern>
+                                <pattern>net.kyori.adventure</pattern>
                                 <shadedPattern>com.palmergames.adventure</shadedPattern>
                             </relocation>
                             <relocation>


### PR DESCRIPTION
Allows paper-api to be included in the pom.xml (so our testing will run via MockBukkit) and still be able to deliver messages in game.

<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
