### PR TITLE
Add the ability to make town and nation ranks require a town or nation level.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -2030,7 +2030,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 
 		if (resident.hasTown()) {
 			list.add("town=" + resident.getTownOrNull().getName());
-			list.add("town-ranks=" + StringMgmt.join(resident.getTownRanks(), ","));
+			list.add("town-ranks=" + StringMgmt.join(resident.getTownRanksForSaving(), ","));
 			list.add("nation-ranks=" + StringMgmt.join(resident.getNationRanks(), ","));
 		}
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -2312,7 +2312,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			if (!TownySettings.getDefaultResidentAbout().equals(resident.getAbout()))
 				res_hm.put("about", resident.getAbout());
 			res_hm.put("town", resident.hasTown() ? resident.getTown().getName() : "");
-			res_hm.put("town-ranks", resident.hasTown() ? StringMgmt.join(resident.getTownRanks(), "#") : "");
+			res_hm.put("town-ranks", resident.hasTown() ? StringMgmt.join(resident.getTownRanksForSaving(), "#") : "");
 			res_hm.put("nation-ranks", resident.hasTown() ? StringMgmt.join(resident.getNationRanks(), "#") : "");
 			res_hm.put("friends", StringMgmt.join(resident.getFriends(), "#"));
 			res_hm.put("protectionStatus", resident.getPermissions().toString().replaceAll(",", "#"));

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Resident.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Resident.java
@@ -593,9 +593,26 @@ public class Resident extends TownyObject implements InviteReceiver, EconomyHand
 	}
 
 	public List<String> getTownRanks() {
+		if (!townRanks.isEmpty() && hasTown()) {
+			ArrayList<String> out = new ArrayList<>();
+			for (String rank : new ArrayList<>(townRanks)) {
+				int requiredTownLevelForRank = TownyPerms.getRankTownLevelReq(rank);
+				if (requiredTownLevelForRank == 0 || getTownOrNull().getLevelNumber() >= requiredTownLevelForRank)
+					out.add(rank);
+			}
+			// Return out modified list of ranks, so that the player will not lose ranks
+			// they've been assigned when their town goes down in a level temporarily. This
+			// ensures they save and load their proper list of ranks.
+			return Collections.unmodifiableList(out);
+		}
 		return Collections.unmodifiableList(townRanks);
 	}
-	
+
+	@ApiStatus.Internal
+	public List<String> getTownRanksForSaving() {
+		return Collections.unmodifiableList(townRanks);
+	}
+
 	public boolean removeTownRank(String rank) {
 
 		if (hasTownRank(rank)) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/TownyPerms.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/TownyPerms.java
@@ -58,6 +58,7 @@ public class TownyPerms {
 	private static final HashMap<UUID, String> residentPrefixMap = new HashMap<>();
 	private static final String RANKPRIORITY_PREFIX = "towny.rankpriority.";
 	private static final String RANKPREFIX_PREFIX = "towny.rankprefix.";
+	private static final String RANKREQUIREMENT_PREFIX = "towny.town_level_requirement.";
 	
 	public static void initialize(Towny plugin) {
 		TownyPerms.plugin = plugin;
@@ -416,7 +417,7 @@ public class TownyPerms {
 	 */
 	public static List<String> getTownRankPermissions(String rank) {
 
-		return getList("towns.ranks." + rank);//.toLowerCase());
+		return getList("towns.ranks." + rank);
 	}
 
 	/*
@@ -510,6 +511,7 @@ public class TownyPerms {
 	/*
 	 * Resident Primary Rank / Rank Prefix 
 	 */
+
 	public static String getResidentPrimaryRankPrefix(Resident resident) {
 		return residentPrefixMap.getOrDefault(resident.getUUID(), setResidentPrimaryRankPrefix(resident));
 	}
@@ -563,7 +565,7 @@ public class TownyPerms {
 		int topValue = 0;
 		for (String node : nodes) {
 			if (node.startsWith(RANKPRIORITY_PREFIX)) {
-				int priorityValue = getNodePriority(node);
+				int priorityValue = getNodePriority(node, RANKPRIORITY_PREFIX.length());
 				if (topValue >= priorityValue)
 					continue;
 				topValue = priorityValue;
@@ -572,13 +574,25 @@ public class TownyPerms {
 		return topValue;
 	}
 
-	private static int getNodePriority(String node) {
+	private static int getNodePriority(String node, int length) {
 		try {
-			return Integer.parseInt(node.substring(RANKPRIORITY_PREFIX.length()));
+			return Integer.parseInt(node.substring(length));
 		} catch (NumberFormatException ignored) {
 			return 0;
 		}
 	}
+
+	/*
+	 * TownLevel Rank Requirements 
+	 */
+
+	public static int getRankTownLevelReq(String rank) {
+		for (String node : getTownRankPermissions(rank))
+			if (node.startsWith(RANKREQUIREMENT_PREFIX))
+				return getNodePriority(node, RANKREQUIREMENT_PREFIX.length());
+		return 0;
+	}
+
 	/*
 	 * Permission utility functions taken from GroupManager (which I wrote anyway).
 	 */
@@ -772,6 +786,18 @@ public class TownyPerms {
 				"#    - towny.rankpriority.100                                                               #",
 				"#    - towny.rankprefix.&a<&2Sheriff&a>                                                     #",
 				"#                                                                                           #",
+				"# The towns.ranks and nations.ranks sections support requiring their town or nation to have #",
+				"# a minimum town_level or nation_level. This means that you can lock ranks behind a town or #",
+				"# nation's population. By adding a permission node to a rank you will set this requirement: #",
+				"# You can read about town_levels and nation_levels here: https://tinyurl.com/3e9ahk2m       #",
+				"# Ex:                                                                                       #",
+				"#    - towny.town_level_requirement.4                                                       #",
+				"# Adding this to a town rank will require the Town to have a town_level of 4 or more to be  #",
+				"# able to assign that rank to their residents. If the town lost population the residents    #",
+				"# with arank beyond their town's town_level will have that rank removed from them. When     #",
+				"# their town regains enough population, that rank will automatically be re-assigned to the  #",
+				"# resident.                                                                                 #",
+				"#                                                                                           #",
 				"#############################################################################################",
 				"",
 				"",
@@ -812,5 +838,4 @@ public class TownyPerms {
 	public static CommentedConfiguration getTownyPermsFile() {
 		return perms;
 	}
-	
 }


### PR DESCRIPTION
Start of making ranks able to be assigned only to towns with a high enough rank.

DONE:
- Town rank town_level requirement node made, perms limited. 

TODO:
- [ ] Do the same for a nation_level requirement.
- [ ] Make tab completer and rank assigning commands aware of rank requirements.
- [ ] Make events that throw when a town and nation change town_level and nation_level, then make permissions re-assign when it happens.

<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #7681 
Closes #7541

____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
