### PR TITLE
Use Java 21 on Jitpack

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -2,9 +2,9 @@ before_install:
     # Make sure SDKMAN is addressable and up-to-date.
     - source "$HOME/.sdkman/bin/sdkman-init.sh"
     - sdk update
-    # Use Eclipse Temurin 17 builds
-    - sdk install java 17.0.0-tem
-    - sdk use java 17.0.0-tem
+    # Use Eclipse Temurin 21 builds
+    - sdk install java 21-tem
+    - sdk use java 21-tem
     # Use a modern Maven binary
     - sdk install maven 3.8.3
     - sdk use maven 3.8.3


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Updated the Java version used by JitPack from 17 to 21. The reason for this is:
1) This fixes compilation on JitPack. The build fails while trying to compile `towny-paper-provider` due to `class file has wrong version 65.0, should be 61.0`. JitPack shows that the status is `ok`, but it only actually publishes artifacts for `towny-folia-provider`, `towny-base-providers`, and `towny-parent`. Crucially, no artifact for the `towny` module is published, as you can see in the [logs for 0.101.1.1](https://jitpack.io/com/github/TownyAdvanced/Towny/0.101.1.1/build.log).
2) This brings it in line with the version used by the Actions workflow to compile the project.


____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
