### PR TITLE
Add a new resident district mode and aligned tab completion for /plot district with help and codebase 

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/PlotCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/PlotCommand.java
@@ -132,6 +132,8 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 	
 	private static final List<String> districtTabCompletes = Arrays.asList(
 		"add",
+		"new",
+		"create",
 		"delete",
 		"remove",
 		"rename"

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
@@ -85,6 +85,8 @@ public class TownyCustomListener implements Listener {
 					TownCommand.parseTownUnclaimCommand(player, new String[] {});
 				if (resident.hasMode("plotgroup") && resident.hasPlotGroupName()) 
 					Towny.getPlugin().getScheduler().runLater(player, () -> Bukkit.dispatchCommand(player, "plot group add " + resident.getPlotGroupName()), 1L);
+				if (resident.hasMode("district") && resident.hasDistrictName())
+					Towny.getPlugin().getScheduler().runLater(player, () -> Bukkit.dispatchCommand(player, "plot district add " + resident.getDistrictName()), 1L);
 			} catch (TownyException e) {
 				TownyMessaging.sendErrorMsg(player, e.getMessage(player));
 			}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/resident/mode/ResidentModeHandler.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/resident/mode/ResidentModeHandler.java
@@ -45,6 +45,7 @@ public class ResidentModeHandler {
 		addMode(new GenericResidentMode("infotool", PermissionNodes.TOWNY_COMMAND_RESIDENT_TOGGLE_INFOTOOL.getNode()));
 		addMode(new GenericResidentMode("map", PermissionNodes.TOWNY_COMMAND_RESIDENT_TOGGLE_MAP.getNode()));
 		addMode(new GenericResidentMode("plotgroup", PermissionNodes.TOWNY_COMMAND_RESIDENT_TOGGLE_PLOTGROUP.getNode()));
+		addMode(new GenericResidentMode("district", PermissionNodes.TOWNY_COMMAND_RESIDENT_TOGGLE_DISTRICT.getNode()));
 		addMode(new GenericResidentMode("townborder", PermissionNodes.TOWNY_COMMAND_RESIDENT_TOGGLE_TOWNBORDER.getNode()));
 		addMode(new GenericResidentMode("spy", PermissionNodes.TOWNY_CHAT_SPY.getNode()));
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
@@ -282,6 +282,7 @@ public enum PermissionNodes {
 		TOWNY_COMMAND_RESIDENT_TOGGLE_INFOTOOL("towny.command.resident.toggle.infotool"),
 		TOWNY_COMMAND_RESIDENT_TOGGLE_MAP("towny.command.resident.toggle.map"),
 		TOWNY_COMMAND_RESIDENT_TOGGLE_PLOTGROUP("towny.command.resident.toggle.plotgroup"),
+		TOWNY_COMMAND_RESIDENT_TOGGLE_DISTRICT("towny.command.resident.toggle.district"),
 		TOWNY_COMMAND_RESIDENT_TOGGLE_TOWNBORDER("towny.command.resident.toggle.townborder"),
 		// Border Modes
 		TOWNY_COMMAND_RESIDENT_TOGGLE_CONSTANTPLOTBORDER("towny.command.resident.toggle.constantplotborder"),

--- a/Towny/src/main/resources/plugin.yml
+++ b/Towny/src/main/resources/plugin.yml
@@ -671,6 +671,7 @@ permissions:
             towny.command.resident.toggle.infotool: true
             towny.command.resident.toggle.map: true
             towny.command.resident.toggle.plotgroup: true
+            towny.command.resident.toggle.district: true
             towny.command.resident.toggle.constantplotborder: true
             towny.command.resident.toggle.plotborder: true
             towny.command.resident.toggle.townborder: true


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Allows residents to set /res toggle district, which will add any plots that they walk into to a district, as long as the resident has a district name set in memory. This is set when a resident runs /plot district add NAME.

There is now tab completion for "new" and "create" as arguments for /plot district, aligning it with the help for /plot district and the actual codebase.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
Adds `/res toggle district` and the permission `towny.command.resident.toggle.district` for it.

Adds tab completion for "new" and "create" for /plot district.
____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
