### PR TITLE
Fix Town#getLevelNumber returning funny numbers on Towns with manually set TownLevel.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -320,7 +320,11 @@ public class TownySettings {
 	}
 
 	public static TownLevel getTownLevel(Town town) {
-		return getTownLevel(town.getLevelNumber());
+		// In order to look up the town level we always have to reference a number of
+		// residents (the key by which TownLevels are mapped,) even when dealing with
+		// manually-set TownLevels.
+		int numResidents = town.getManualTownLevel() == -1 ? town.getLevelNumber() : getTownLevelWhichIsManuallySet(town.getManualTownLevel());
+		return getTownLevel(numResidents);
 	}
 
 	public static TownLevel getTownLevelWithModifier(int modifier, Town town) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Town.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Town.java
@@ -1880,6 +1880,7 @@ public class Town extends Government implements TownBlockOwner {
 	public TownLevel getTownLevel() {
 		return TownySettings.getTownLevel(this);
 	}
+
 	/**
 	 * Get the Town's current TownLevel number, based on its population.
 	 * <p>
@@ -1899,7 +1900,7 @@ public class Town extends Government implements TownBlockOwner {
 	 */
 	public int getLevelNumber() {
 		int townLevelNumber = getManualTownLevel() > -1
-				? TownySettings.getTownLevelWhichIsManuallySet(getManualTownLevel())
+				? Math.min(getManualTownLevel(), TownySettings.getTownLevelMax())
 				: TownySettings.getTownLevelFromGivenInt(getNumResidents(), this);
 
 		TownCalculateTownLevelNumberEvent tctle = new TownCalculateTownLevelNumberEvent(this, townLevelNumber);


### PR DESCRIPTION


<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

I found that using getLevelNumber would return the number of residents from the town level that corresponds to the number of the town_level when town_level is set manually on a town.

ie: setting a manual level of 4 would result in getLevelNumber returning a 6, which is the numResidents value of the 4th town_level.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
