### PR TITLE
Fix the per_outpost_cost causing very large amount of upkeep on per_plot_upkeep-using servers.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -2899,8 +2899,9 @@ public enum ConfigNodes {
 			"economy.daily_taxes.per_outpost_cost",
 			"0.0",
 			"",
-			"# An optional price that a town must pay for each outpost they own. This number is added to the town upkeep",
-			"# before any other upkeep modifiers are applied to the Town's upkeep costs."),
+			"# An optional price that a town must pay for each outpost they own.",
+			"# This number is added to the town upkeep before other upkeep modifiers are applied to the Town's upkeep costs.",
+			"# Note: when town_plotbased_upkeep is true, this cost is added after all other upkeep modifiers are applied."),
 	ECO_TAXES_ALLOW_PLOT_PAYMENTS(
 			"economy.daily_taxes.use_plot_payments",
 			"false",

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -2247,12 +2247,15 @@ public class TownySettings {
 
 		// outposts can have an added cost to the town's upkeep.
 		double outpostCost = getPerOutpostUpkeepCost() * town.getMaxOutpostSpawn();
-		double baseUpkeep = getTownUpkeep() + outpostCost;
+		// outposts having a cost will mess up the per-plot-upkeep feature, so add that on later.
+		double baseUpkeep = getTownUpkeep() + (isUpkeepByPlot() ? 0 : outpostCost);
 		// Amount is calculated using the above multipliers.
 		double amount = ((baseUpkeep * townMultiplier) * townLevelPlotModifier) * nationMultiplier;
 
 		// When per-plot-upkeep is in use, there can be min/max amounts.
 		if (isUpkeepByPlot()) {
+			// Tack on the outpost cost here when isUpkeepByPlot is used.
+			amount += outpostCost;
 			if (TownySettings.getPlotBasedUpkeepMinimumAmount() > 0.0)
 				amount = Math.max(amount, TownySettings.getPlotBasedUpkeepMinimumAmount());
 			if (TownySettings.getPlotBasedUpkeepMaximumAmount() > 0.0) 


### PR DESCRIPTION


<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

Moves the per-outpost-cost from the front to the back when per-plot-upkeep is enabled.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
