### PR TITLE
Correctly remove bad outpost spawns in getOutpostNames

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Town.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Town.java
@@ -56,6 +56,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -1054,12 +1055,15 @@ public class Town extends Government implements TownBlockOwner {
 	public List<String> getOutpostNames() {
 		List<String> outpostNames = new ArrayList<>();
 		int i = 0;
-		for (Location loc : getAllOutpostSpawns()) {
+		
+		final Iterator<Position> outpostSpawnIterator = this.outpostSpawns.iterator();
+		while (outpostSpawnIterator.hasNext()) {
 			i++;
-			TownBlock tboutpost = TownyAPI.getInstance().getTownBlock(loc);
+			final Position pos = outpostSpawnIterator.next();
+			TownBlock tboutpost = TownyAPI.getInstance().getTownBlock(pos.worldCoord());
 
 			if (tboutpost == null) {
-				removeOutpostSpawn(loc);
+				outpostSpawnIterator.remove();
 				save();
 				continue;
 			}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Directly converts the outpost spawn position to a worldcoord rather than doing position -> location -> worldcoord to prevent an exception if the position doesn't have a valid bukkit world when removing it.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
