### PR TITLE
Cancel block events on low priority, and never 'uncancel'

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
@@ -51,7 +51,7 @@ public class TownyBlockListener implements Listener {
 		plugin = instance;
 	}
 
-	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void onBlockBreak(BlockBreakEvent event) {
 
 		if (plugin.isError()) {
@@ -64,10 +64,13 @@ public class TownyBlockListener implements Listener {
 			return;
 
 		//Cancel based on whether this is allowed using the PlayerCache and then a cancellable event.
-		event.setCancelled(!TownyActionEventExecutor.canDestroy(event.getPlayer(), block.getLocation(), block.getType()));
+		if (TownyActionEventExecutor.canDestroy(event.getPlayer(), block.getLocation(), block.getType()))
+			return;
+
+		event.setCancelled(true);
 	}
 
-	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void onBlockPlace(BlockPlaceEvent event) {
 
 		if (plugin.isError()) {
@@ -150,7 +153,7 @@ public class TownyBlockListener implements Listener {
 	}
 
 	// prevent blocks igniting if within a protected town area when fire spread is set to off.
-	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void onBlockBurn(BlockBurnEvent event) {
 
 		if (plugin.isError()) {
@@ -161,10 +164,13 @@ public class TownyBlockListener implements Listener {
 		if (!TownyAPI.getInstance().isTownyWorld(event.getBlock().getWorld()))
 			return;
 
-		event.setCancelled(!TownyActionEventExecutor.canBurn(event.getBlock()));
+		if (TownyActionEventExecutor.canBurn(event.getBlock()))
+			return;
+
+		event.setCancelled(true);
 	}
 
-	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void onBlockIgnite(BlockIgniteEvent event) {
 
 		if (plugin.isError()) {
@@ -175,10 +181,13 @@ public class TownyBlockListener implements Listener {
 		if (!TownyAPI.getInstance().isTownyWorld(event.getBlock().getWorld()))
 			return;
 
-		event.setCancelled(!TownyActionEventExecutor.canBurn(event.getBlock()));
+		if (TownyActionEventExecutor.canBurn(event.getBlock()))
+			return;
+
+		event.setCancelled(true);
 	}
 
-	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void onBlockPistonRetract(BlockPistonRetractEvent event) {
 
 		if (plugin.isError()) {
@@ -197,13 +206,15 @@ public class TownyBlockListener implements Listener {
 		if (!blocks.isEmpty()) {
 			//check each block to see if it's going to pass a plot boundary
 			for (Block block : blocks) {
-				if (!canBlockMove(block, block.getRelative(event.getDirection()), false))
+				if (!canBlockMove(block, block.getRelative(event.getDirection()), false)) {
 					event.setCancelled(true);
+					break;
+				}
 			}
 		}
 	}
 
-	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void onBlockPistonExtend(BlockPistonExtendEvent event) {
 
 		if (plugin.isError()) {
@@ -225,8 +236,10 @@ public class TownyBlockListener implements Listener {
 		if (!blocks.isEmpty()) {
 			//check each block to see if it's going to pass a plot boundary
 			for (Block block : blocks) {
-				if (!canBlockMove(block, block.getRelative(event.getDirection()), allowWild))
+				if (!canBlockMove(block, block.getRelative(event.getDirection()), allowWild)) {
 					event.setCancelled(true);
+					break;
+				}
 			}
 		}
 	}
@@ -263,7 +276,7 @@ public class TownyBlockListener implements Listener {
 		return currentTownBlock.getTownOrNull() == destinationTownBlock.getTownOrNull() && !currentTownBlock.hasResident() && !destinationTownBlock.hasResident();
 	}
 	
-	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void onCreateExplosion(BlockExplodeEvent event) {
 		if (plugin.isError()) {
 			event.setCancelled(true);
@@ -322,14 +335,17 @@ public class TownyBlockListener implements Listener {
 		// Snowmen making snow will also throw this event. 
 		if (event.getEntity() instanceof Player player) {
 			//Cancel based on whether this is allowed using the PlayerCache and then a cancellable event.
-			event.setCancelled(!TownyActionEventExecutor.canBuild(player, event.getBlock().getLocation(), event.getBlock().getType()));
+			if (TownyActionEventExecutor.canBuild(player, event.getBlock().getLocation(), event.getBlock().getType()))
+				return;
+
+			event.setCancelled(true);
 		}
 	}
 	
 	/*
 	* Prevents water or lava from going into other people's plots.
 	*/
-	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void onBlockFromToEvent(BlockFromToEvent event) {
 		if (plugin.isError()) {
 			event.setCancelled(true);
@@ -350,7 +366,7 @@ public class TownyBlockListener implements Listener {
 			event.setCancelled(true);
 	}
 
-	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void onBlockDispense(BlockDispenseEvent event) {
 		if (plugin.isError()) {
 			event.setCancelled(true);
@@ -378,7 +394,7 @@ public class TownyBlockListener implements Listener {
 	/*
 	 * Used to prevent bonemeal and moss growing into areas it shouldn't.
 	 */
-	@EventHandler(ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void onBlockFertilize(BlockFertilizeEvent event) {
 		if (plugin.isError()) {
 			event.setCancelled(true);
@@ -390,13 +406,13 @@ public class TownyBlockListener implements Listener {
 		
 		List<BlockState> allowed = BorderUtil.allowedBlocks(event.getBlocks(), event.getBlock(), event.getPlayer());
 		event.getBlocks().clear();
-        event.getBlocks().addAll(allowed);
+		event.getBlocks().addAll(allowed);
 	}
 
 	/*
 	 * Used to prevent Sculk Spread.
 	 */
-	@EventHandler(ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void onSculkSpread(BlockSpreadEvent event) {
 		String sourceName = event.getSource().getType().getKey().getKey();
 		if (!sourceName.startsWith("sculk"))
@@ -410,14 +426,18 @@ public class TownyBlockListener implements Listener {
 		if (!TownyAPI.getInstance().isTownyWorld(event.getBlock().getWorld()))
 			return;
 
-		if (sourceName.equalsIgnoreCase("sculk_catalyst")) {
-			// Check if the sculk is passing across a border with differing owners, allowing
-			// sculk to spread from a town into the wilderness.
-			event.setCancelled(!canBlockMove(event.getSource(), event.getBlock(), true));
-		}
+		if (!sourceName.equalsIgnoreCase("sculk_catalyst"))
+			return;
+
+		// Check if the sculk is passing across a border with differing owners, allowing
+		// sculk to spread from a town into the wilderness.
+		if (canBlockMove(event.getSource(), event.getBlock(), true))
+			return;
+
+		event.setCancelled(true);
 	}
 	
-	@EventHandler(ignoreCancelled = true, priority = EventPriority.LOW)
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void onCauldronLevelChange(CauldronLevelChangeEvent event) {
 		if (!(event.getEntity() instanceof Player player))
 			return;


### PR DESCRIPTION
#### Description: 
Towny has a responsibility to cancel block breaks, placements, explosions, and more, to prevent players from griefing blocks in towns to which they do not belong. It does this successfully, but unconventionally compared to other world protection plugins like WorldEdit or GriefPrevention. Generally speaking, these protection plugins are intended to be run very early so that downstream listeners can ignore any cancelled events calls. Towny does the opposite. It listens like a downstream plugin and changes the cancellation state of an event later in the listener pipeline, causing plugins listening on the default event priority to mistakenly enable griefing.

Additionally, the fact that Towny has the ability to _uncancel_ events is separately problematic. While `Cancellable#setCancelled(condition)` may seem like harmless shorthand, it has the consequence of potentially invoking `Cancellable#setCancelled(false)`, which will negate _other_ protections from other plugins. This should be avoided at all costs, and has been remedied in this pull request.

This pull request was drafted after a user from VeinMiner noticed that they were able to vein mine outside of a town's borders, causing neighbouring blocks inside the town's borders to drop items, but blocks to not be destroyed, allowing for item duplication. The reason for this is because VeinMiner listens on the default event priority (which I think is also a mistake, it can safely listen on the `MONITOR` priority, but that's besides the point). VeinMiner does its vein mining, then Towny handles its block protection.

____
#### New Nodes/Commands/ConfigOptions: 
N/A


____
#### Relevant Towny Issue ticket:
N/A


____
- [ ] I have tested this pull request for defects on a server. 

I have not tested this on a server, however I am confident that the changes made are trivial enough to not need a thorough test. This is a compatibility change so that other plugins may better support Towny. Testing this thoroughly would be extremely difficult.

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
