### PR TITLE
Fix splash potion not applying to mobs

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
@@ -311,14 +311,13 @@ public class TownyEntityListener implements Listener {
 		if (!TownyAPI.getInstance().isTownyWorld(event.getEntity().getWorld()))
 			return;
 		
-		if (!hasDetrimentalEffects(event.getPotion().getEffects()))
+		ThrownPotion potion = event.getPotion();
+		
+		if (!hasDetrimentalEffects(potion.getEffects()))
 			return;
 		
-		for (LivingEntity defender : event.getAffectedEntities()) {
-			if (CombatUtil.preventDamageCall(event.getPotion(), defender, DamageCause.MAGIC)) {
-				event.setIntensity(defender, -1.0);
-			}
-		}
+		if (discardSplashPotion(potion))
+			event.setCancelled(true);
 	}
 
 	/**
@@ -1009,6 +1008,31 @@ public class TownyEntityListener implements Listener {
 				final WorldCoord current = WorldCoord.parseWorldCoord(effectCloud.getWorld().getName(), x, z);
 				final TownBlock townBlock = current.getTownBlockOrNull();
 				
+				if (townyWorld != null && CombatUtil.preventPvP(townyWorld, townBlock))
+					return true;
+				
+				lastChecked = current;
+			}
+		}
+		
+		return false;
+	}
+
+	@ApiStatus.Internal
+	private static boolean discardSplashPotion(ThrownPotion potion) {
+		final TownyWorld townyWorld = TownyAPI.getInstance().getTownyWorld(potion.getWorld());
+		final Location loc = potion.getLocation();
+		int radius = 4;
+		WorldCoord lastChecked = null;
+
+		for (int x = loc.getBlockX() - radius; x < loc.getBlockX() + radius; x++ ) {
+			for (int z = loc.getBlockZ() - radius; z < loc.getBlockZ() + radius; z++ ) {
+				if (lastChecked != null && lastChecked.getX() == Coord.toCell(x) && lastChecked.getZ() == Coord.toCell(z))
+					continue;
+
+				final WorldCoord current = WorldCoord.parseWorldCoord(potion.getWorld().getName(), x, z);
+				final TownBlock townBlock = current.getTownBlockOrNull();
+
 				if (townyWorld != null && CombatUtil.preventPvP(townyWorld, townBlock))
 					return true;
 				


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

Fix potion effects not applying to mobs even with PVP on. 

This pull request's fix is based on how lingering splash potions are handled (which work correctly), however, it has a hardcoded value for the distance from the potion that is tested for due to ThrownPotion not having a method to get the radius of the potion's effects.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

#7838
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
