### PR TITLE
Re-add switch tests on left click for specified switch items.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -328,9 +328,7 @@ public class TownyPlayerListener implements Listener {
 			return;
 		
 		Action action = event.getAction();
-		if(action != Action.RIGHT_CLICK_BLOCK && action != Action.RIGHT_CLICK_AIR && action != Action.PHYSICAL) {
-			if (action != Action.LEFT_CLICK_BLOCK || !event.hasItem() ||
-				!event.hasBlock() || !TownySettings.isSwitchMaterial(event.getItem().getType(), event.getClickedBlock().getLocation()))
+		if(actionIsNotRightClickOrPhysical(action) && actionIsNotLeftClickThatCountsAsSwitch(event, action)) {
 			return;
 		}
 		
@@ -488,6 +486,29 @@ public class TownyPlayerListener implements Listener {
 					!TownyActionEventExecutor.canDestroy(player, clickedBlock.getLocation(), clickedMat))
 				event.setCancelled(true);
 		}
+	}
+
+	/**
+	 * Is the action one that involves left-clicking on a Switch block? This is
+	 * useful for protecting (usually) modded blocks that can be used via left
+	 * clicks.
+	 * 
+	 * @param event  PlayerInteractEvent causing a switch test.
+	 * @param action Action that has to be LEFT_CLICK_BLOCK for this to count.
+	 * @return true if the player is left clicking a block that is technically a
+	 *         switch_id in Towny.
+	 */
+	private boolean actionIsNotLeftClickThatCountsAsSwitch(PlayerInteractEvent event, Action action) {
+		return action != Action.LEFT_CLICK_BLOCK || !event.hasBlock() || !TownySettings.isSwitchMaterial(event.getClickedBlock().getType(), event.getClickedBlock().getLocation());
+	}
+
+	/**
+	 * Is the action something we don't want to worry about when we're dealing with something like honey comb and a sign, or candles and cake when testing PlayerInteractEvents.
+	 * @param action Action that player is making for this to matter.
+	 * @return true if the action is a right click or physical Action.
+	 */
+	private boolean actionIsNotRightClickOrPhysical(Action action) {
+		return action != Action.RIGHT_CLICK_BLOCK && action != Action.RIGHT_CLICK_AIR && action != Action.PHYSICAL;
 	}
 
 	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -328,8 +328,11 @@ public class TownyPlayerListener implements Listener {
 			return;
 		
 		Action action = event.getAction();
-		if(action != Action.RIGHT_CLICK_BLOCK && action != Action.RIGHT_CLICK_AIR && action != Action.PHYSICAL)
+		if(action != Action.RIGHT_CLICK_BLOCK && action != Action.RIGHT_CLICK_AIR && action != Action.PHYSICAL) {
+			if (action != Action.LEFT_CLICK_BLOCK || !event.hasItem() ||
+				!event.hasBlock() || !TownySettings.isSwitchMaterial(event.getItem().getType(), event.getClickedBlock().getLocation()))
 			return;
+		}
 		
 		Player player = event.getPlayer();
 		Block clickedBlock = event.getClickedBlock();


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

A while back we completely dropped protecting a bunch of interactions from listening to left clicks.

This was good because we don't test left clicks for things we treat special, like unwaxing a sign with an axe, or putting a candle on a cake. 

We did lose the ability to protect a block that is considered a switch_id to be protected from left clicks. Some mods allow blocks to be interacted with via right and left clicks, this makes it possible to protect those blocks again via adding them to the switch ids.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
