### PR TITLE
Toggle Jailing in world | Issue #7817

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -484,6 +484,12 @@ public enum ConfigNodes {
 			"# This list is useful if you have a death chest plugin which could put a player's inventory inside chest",
 			"# that is inside of a regenerating creeper explosion pit. For Example: By putting CHEST here you can ",
 			"# prevent the chest from being overwritten by the dirt block that used to be there."),
+	NWS_PLOT_MANAGEMENT_JAILING_ENABLE(
+		"new_world_settings.plot_management.jailing_enabled",
+		"true",
+		"",
+		"# This section is applied to new worlds as default settings when new worlds are detected.",
+		"# Whether to allow players in this world to be jailed or not"),
 
 	GTOWN_SETTINGS(
 			"global_town_settings",

--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -341,6 +341,12 @@ public enum ConfigNodes {
 			"true",
 			"",
 			"# Do new worlds disable creatures trampling crops, by default?"),
+	NWS_JAILING_ENABLE(
+			"new_world_settings.jailing_enabled",
+			"true",
+			"",
+			"# This section is applied to new worlds as default settings when new worlds are detected.",
+			"# Whether to allow players in this world to be jailed or not"),
 	NWS_PLOT_MANAGEMENT_HEADER(
 			"new_world_settings.plot_management",
 			"",
@@ -484,13 +490,7 @@ public enum ConfigNodes {
 			"# This list is useful if you have a death chest plugin which could put a player's inventory inside chest",
 			"# that is inside of a regenerating creeper explosion pit. For Example: By putting CHEST here you can ",
 			"# prevent the chest from being overwritten by the dirt block that used to be there."),
-	NWS_PLOT_MANAGEMENT_JAILING_ENABLE(
-		"new_world_settings.plot_management.jailing_enabled",
-		"true",
-		"",
-		"# This section is applied to new worlds as default settings when new worlds are detected.",
-		"# Whether to allow players in this world to be jailed or not"),
-
+	
 	GTOWN_SETTINGS(
 			"global_town_settings",
 			"",

--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -490,6 +490,7 @@ public enum ConfigNodes {
 			"# This list is useful if you have a death chest plugin which could put a player's inventory inside chest",
 			"# that is inside of a regenerating creeper explosion pit. For Example: By putting CHEST here you can ",
 			"# prevent the chest from being overwritten by the dirt block that used to be there."),
+
 	GTOWN_SETTINGS(
 			"global_town_settings",
 			"",

--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -490,7 +490,6 @@ public enum ConfigNodes {
 			"# This list is useful if you have a death chest plugin which could put a player's inventory inside chest",
 			"# that is inside of a regenerating creeper explosion pit. For Example: By putting CHEST here you can ",
 			"# prevent the chest from being overwritten by the dirt block that used to be there."),
-	
 	GTOWN_SETTINGS(
 			"global_town_settings",
 			"",

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -578,8 +578,9 @@ public class TownyFormatter {
 				    colourKeyValue(translator.of("status_world_wildernessmobs"), (world.hasWildernessMobs() ? translator.of("status_on") : translator.of("status_off"))));
 			// ForceTownMobs: ON
 			screen.addComponentOf("townmobs", colourKeyValue(translator.of("status_world_forcetownmobs"), (world.isForceTownMobs() ? translator.of("status_forced") : translator.of("status_adjustable"))));
-			// Unclaim Revert: ON
-			screen.addComponentOf("unclaim_revert", colourKeyValue("\n" + translator.of("status_world_unclaimrevert"), (world.isUsingPlotManagementRevert() ? translator.of("status_on_good") : translator.of("status_off_bad")))); 
+			// Unclaim Revert: ON | Jailing: ON
+			screen.addComponentOf("unclaim_revert", colourKeyValue("\n" + translator.of("status_world_unclaimrevert"), (world.isUsingPlotManagementRevert() ? translator.of("status_on_good") : translator.of("status_off_bad"))) + translator.of("status_splitter") + 
+					colourKeyValue(translator.of("status_world_jailing"), (world.isJailingEnabled() ? translator.of("status_on_good") : translator.of("status_off_bad"))));
 			// Entity Explosion Revert: ON | Block Explosion Revert: ON
 			screen.addComponentOf("explosion_reverts", colourKeyValue(translator.of("status_world_explrevert_entity"), (world.isUsingPlotManagementWildEntityRevert() ? translator.of("status_on_good") : translator.of("status_off_bad"))) + translator.of("status_splitter") +
 					colourKeyValue(translator.of("status_world_explrevert_block"), (world.isUsingPlotManagementWildBlockRevert() ? translator.of("status_on_good") : translator.of("status_off_bad"))));

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -3932,8 +3932,8 @@ public class TownySettings {
 		return getDouble(ConfigNodes.GTOWN_SETTINGS_MAX_BUYTOWN_PRICE);
 	}
 
-	public static boolean isJailingEnabled() {
-		return getBoolean(ConfigNodes.NWS_PLOT_MANAGEMENT_JAILING_ENABLE);
+	public static boolean isWorldJailingEnabled() {
+		return getBoolean(ConfigNodes.NWS_JAILING_ENABLE);
 	}
 }
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -3931,5 +3931,9 @@ public class TownySettings {
 	public static double maxBuyTownPrice() {
 		return getDouble(ConfigNodes.GTOWN_SETTINGS_MAX_BUYTOWN_PRICE);
 	}
+
+	public static boolean isJailingEnabled() {
+		return getBoolean(ConfigNodes.NWS_PLOT_MANAGEMENT_JAILING_ENABLE);
+	}
 }
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/HelpMenu.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/HelpMenu.java
@@ -506,7 +506,8 @@ public enum HelpMenu {
 				.add("revertunclaim", Translatable.of("world_toggle_help_8"))
 				.add("revertentityexpl/revertblockexpl", Translatable.of("world_toggle_help_9"))
 				.add("plotcleardelete", Translatable.of("world_toggle_help_10"))
-				.add("unclaimblockdelete", Translatable.of("world_toggle_help_11"));
+				.add("unclaimblockdelete", Translatable.of("world_toggle_help_11"))
+				.add("jailing", Translatable.of("world_toggle_help_12"));
 		}
 	},
 
@@ -525,7 +526,8 @@ public enum HelpMenu {
 				.add("revertunclaim", Translatable.of("world_toggle_help_8"))
 				.add("revertentityexpl/revertblockexpl", Translatable.of("world_toggle_help_9"))
 				.add("plotcleardelete", Translatable.of("world_toggle_help_10"))
-				.add("unclaimblockdelete", Translatable.of("world_toggle_help_11"));
+				.add("unclaimblockdelete", Translatable.of("world_toggle_help_11"))
+				.add("jailing", Translatable.of("world_toggle_help_12"));
 		}
 	},
 	

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -1711,7 +1711,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 
 		// Is this resident in a jailable world?
 		TownyWorld world = TownyAPI.getInstance().getTownyWorld(jailedResident.getPlayer().getWorld());
-		if (!world.isJailingEnabled())
+		if (world != null && !world.isJailingEnabled())
 			throw new TownyException(Translatable.of("msg_err_x_in_unjailable_world", jailedResident));
 
 		// Check if Town has reached max potential jailed and react according to maxJailedNewJailBehavior in config

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -1606,11 +1606,6 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		// Can the Town jail this resident?
 		testTownCanJailResidentOrThrow(town, initialJailFee, jailedResident);
 
-		// Is this resident in a jailable world?
-		TownyWorld world = TownyAPI.getInstance().getTownyWorld(jailedResident.getPlayer().getWorld());
-		if (!world.isJailingEnabled())
-			throw new TownyException(Translatable.of("msg_err_x_in_unjailable_world", jailedResident));
-
 		// Jail the resident, when enabled it will apply the bail.
 		JailUtil.jailResidentWithBail(jailedResident, jail, cell, hours, bail, JailReason.MAYOR, sender);
 
@@ -1713,6 +1708,11 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		// Make sure the town can afford to jail. 
 		if (initialJailFee > 0 && !town.getAccount().canPayFromHoldings(initialJailFee))
 			throw new TownyException(Translatable.of("msg_not_enough_money_in_bank_to_jail_x_fee_is_x", jailedResident, initialJailFee));
+
+		// Is this resident in a jailable world?
+		TownyWorld world = TownyAPI.getInstance().getTownyWorld(jailedResident.getPlayer().getWorld());
+		if (!world.isJailingEnabled())
+			throw new TownyException(Translatable.of("msg_err_x_in_unjailable_world", jailedResident));
 
 		// Check if Town has reached max potential jailed and react according to maxJailedNewJailBehavior in config
 		if (TownySettings.getMaxJailedPlayerCount() > 0 && town.getJailedPlayerCount() >= TownySettings.getMaxJailedPlayerCount()) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -1606,6 +1606,11 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		// Can the Town jail this resident?
 		testTownCanJailResidentOrThrow(town, initialJailFee, jailedResident);
 
+		// Is this resident in a jailable world?
+		TownyWorld world = TownyAPI.getInstance().getTownyWorld(jailedResident.getPlayer().getWorld());
+		if (!world.isJailingEnabled())
+			throw new TownyException(Translatable.of("msg_err_x_in_unjailable_world", jailedResident));
+
 		// Jail the resident, when enabled it will apply the bail.
 		JailUtil.jailResidentWithBail(jailedResident, jail, cell, hours, bail, JailReason.MAYOR, sender);
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownyWorldCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownyWorldCommand.java
@@ -64,7 +64,8 @@ public class TownyWorldCommand extends BaseCommand implements CommandExecutor {
 		"unclaimblockdelete",
 		"unclaimentitydelete",
 		"plotcleardelete",
-		"wildernessuse"
+		"wildernessuse",
+		"jailing"
 	);
 	
 	private static final List<String> townySetTabCompletes = Arrays.asList(
@@ -237,6 +238,7 @@ public class TownyWorldCommand extends BaseCommand implements CommandExecutor {
 		case "unclaimblockdelete" -> toggleUnclaimBlockDelete(sender, world, choice);
 		case "unclaimentitydelete" -> toggleUnclaimEntityDelete(sender, world, choice);
 		case "wildernessuse" -> toggleWildernessUse(sender, world, split);
+		case "jailing" -> toggleJailing(sender, world, choice);
 		default -> {
 			if (TownyCommandAddonAPI.hasCommand(CommandType.TOWNYWORLD_TOGGLE, split[0])) {
 				TownyCommandAddonAPI.getAddonCommand(CommandType.TOWNYWORLD_TOGGLE, split[0]).execute(sender, "townyworld", split);
@@ -385,6 +387,12 @@ public class TownyWorldCommand extends BaseCommand implements CommandExecutor {
 		world.setUnclaimedZoneSwitch(toggle);
 		
 		TownyMessaging.sendMsg(sender, Translatable.of("msg_wilderness_use_set_to", toggle, world.getName()));
+	}
+
+	private void toggleJailing(CommandSender sender, TownyWorld world, Optional<Boolean> choice) throws NoPermissionException {
+		checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYWORLD_TOGGLE_JAILING.getNode());
+		world.setJailing(choice.orElse(!world.isJailingEnabled()));
+		TownyMessaging.sendMsg(sender, Translatable.of("msg_changed_world_setting", "Jailing", world.getName(), formatBool(world.isJailingEnabled())));
 	}
 
 	public void worldSet(CommandSender sender, TownyWorld world, String[] split) throws NoPermissionException {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownyWorldCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownyWorldCommand.java
@@ -391,7 +391,7 @@ public class TownyWorldCommand extends BaseCommand implements CommandExecutor {
 
 	private void toggleJailing(CommandSender sender, TownyWorld world, Optional<Boolean> choice) throws NoPermissionException {
 		checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYWORLD_TOGGLE_JAILING.getNode());
-		world.setJailing(choice.orElse(!world.isJailingEnabled()));
+		world.setJailingEnabled(choice.orElse(!world.isJailingEnabled()));
 		TownyMessaging.sendMsg(sender, Translatable.of("msg_changed_world_setting", "Jailing", world.getName(), formatBool(world.isJailingEnabled())));
 	}
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/SQLSchema.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/SQLSchema.java
@@ -326,7 +326,7 @@ public class SQLSchema {
 		columns.add("`usingTowny` bool NOT NULL DEFAULT '0'");
 		columns.add("`warAllowed` bool NOT NULL DEFAULT '0'");
 		columns.add("`metadata` text DEFAULT NULL");
-		columns.add("`jailing` bool NOT NULL DEFAULT '0'");
+		columns.add("`jailing` bool NOT NULL DEFAULT '1'");
 		return columns;
 	}
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/SQLSchema.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/SQLSchema.java
@@ -326,6 +326,7 @@ public class SQLSchema {
 		columns.add("`usingTowny` bool NOT NULL DEFAULT '0'");
 		columns.add("`warAllowed` bool NOT NULL DEFAULT '0'");
 		columns.add("`metadata` text DEFAULT NULL");
+		columns.add("`jailing` bool NOT NULL DEFAULT '0'");
 		return columns;
 	}
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -2446,8 +2446,6 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 		list.add("usingPlotManagementWildRegenDelay=" + world.getPlotManagementWildRevertDelay());
 
 		
-
-		
 		// Using Towny
 		list.add("");
 		list.add("# This setting is used to enable or disable Towny in this world.");

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -1604,6 +1604,13 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 					} catch (Exception ignored) {
 					}
 
+				line = keys.get("jailing");
+				if (line != null)
+					try {
+						world.setJailing(Boolean.parseBoolean(line));
+					} catch (Exception ignored) {
+					}
+
 				line = keys.get("metadata");
 				if (line != null && !line.isEmpty())
 					MetadataLoader.getInstance().deserializeMetadata(world, line.trim());
@@ -2439,6 +2446,8 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 		list.add("usingPlotManagementWildRegenDelay=" + world.getPlotManagementWildRevertDelay());
 
 		
+
+		
 		// Using Towny
 		list.add("");
 		list.add("# This setting is used to enable or disable Towny in this world.");
@@ -2450,6 +2459,9 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 		list.add("# This setting is used to enable or disable Event war in this world.");
 		list.add("warAllowed=" + world.isWarAllowed());
 
+		// jailing
+		list.add("jailing=" + world.isJailingEnabled());		
+		
 		// Metadata
 		list.add("");
 		list.add("metadata=" + serializeMetadata(world));

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -1607,7 +1607,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 				line = keys.get("jailing");
 				if (line != null)
 					try {
-						world.setJailing(Boolean.parseBoolean(line));
+						world.setJailingEnabled(Boolean.parseBoolean(line));
 					} catch (Exception ignored) {
 					}
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -1790,7 +1790,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 
 			result = rs.getBoolean("jailing");
 			try {
-				world.setJailing(result);
+				world.setJailingEnabled(result);
 			} catch (Exception ignored) {
 			}
 			

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -1788,6 +1788,12 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			} catch (Exception ignored) {
 			}
 
+			result = rs.getBoolean("jailing");
+			try {
+				world.setJailing(result);
+			} catch (Exception ignored) {
+			}
+			
 			try {
 				line = rs.getString("metadata");
 				if (line != null && !line.isEmpty()) {
@@ -2640,6 +2646,8 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 
 			// War allowed in this world.
 			nat_hm.put("warAllowed", world.isWarAllowed());
+
+			nat_hm.put("jailing", world.isJailingEnabled());
 
 			if (world.hasMeta())
 				nat_hm.put("metadata", serializeMetadata(world));

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownyWorld.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownyWorld.java
@@ -399,7 +399,7 @@ public class TownyWorld extends TownyObject {
 		wildRevertMaterialsToNotOverwrite = null;
 		// Entities protected from explosions
 		entityExplosionProtection = null;
-		setJailing(TownySettings.isWorldJailingEnabled());
+		setJailingEnabled(TownySettings.isWorldJailingEnabled());
 	}
 
 	public void setUsingPlotManagementDelete(boolean using) {
@@ -1038,7 +1038,7 @@ public class TownyWorld extends TownyObject {
 		return isFriendlyFire;
 	}
 
-	public void setJailing(boolean parseBoolean) {
+	public void setJailingEnabled(boolean parseBoolean) {
 		isJailing = parseBoolean;
 		
 	}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownyWorld.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownyWorld.java
@@ -1040,7 +1040,6 @@ public class TownyWorld extends TownyObject {
 
 	public void setJailingEnabled(boolean parseBoolean) {
 		isJailing = parseBoolean;
-		
 	}
 	
 	public boolean isJailingEnabled( ) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownyWorld.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownyWorld.java
@@ -77,6 +77,8 @@ public class TownyWorld extends TownyObject {
 	private boolean isExplosion = TownySettings.isExplosions();
 	private boolean isForceExpl = TownySettings.isForcingExplosions();
 	private boolean isEndermanProtect = TownySettings.getEndermanProtect();
+	private boolean isJailing = TownySettings.isJailingEnabled();
+
 	
 	private boolean isDisableCreatureTrample = TownySettings.isCreatureTramplingCropsDisabled();
 	
@@ -397,6 +399,7 @@ public class TownyWorld extends TownyObject {
 		wildRevertMaterialsToNotOverwrite = null;
 		// Entities protected from explosions
 		entityExplosionProtection = null;
+		setJailing(TownySettings.isJailingEnabled());
 	}
 
 	public void setUsingPlotManagementDelete(boolean using) {
@@ -1033,6 +1036,15 @@ public class TownyWorld extends TownyObject {
 	
 	public boolean isFriendlyFireEnabled( ) {
 		return isFriendlyFire;
+	}
+
+	public void setJailing(boolean parseBoolean) {
+		isJailing = parseBoolean;
+		
+	}
+	
+	public boolean isJailingEnabled( ) {
+		return isJailing;
 	}
 
 	@Override

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownyWorld.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownyWorld.java
@@ -77,7 +77,7 @@ public class TownyWorld extends TownyObject {
 	private boolean isExplosion = TownySettings.isExplosions();
 	private boolean isForceExpl = TownySettings.isForcingExplosions();
 	private boolean isEndermanProtect = TownySettings.getEndermanProtect();
-	private boolean isJailing = TownySettings.isJailingEnabled();
+	private boolean isJailing = TownySettings.isWorldJailingEnabled();
 
 	
 	private boolean isDisableCreatureTrample = TownySettings.isCreatureTramplingCropsDisabled();
@@ -399,7 +399,7 @@ public class TownyWorld extends TownyObject {
 		wildRevertMaterialsToNotOverwrite = null;
 		// Entities protected from explosions
 		entityExplosionProtection = null;
-		setJailing(TownySettings.isJailingEnabled());
+		setJailing(TownySettings.isWorldJailingEnabled());
 	}
 
 	public void setUsingPlotManagementDelete(boolean using) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
@@ -448,6 +448,7 @@ public enum PermissionNodes {
 		TOWNY_COMMAND_TOWNYWORLD_TOGGLE_UNCLAIMBLOCKDELETE("towny.command.townyworld.toggle.unclaimblockdelete"),
 		TOWNY_COMMAND_TOWNYWORLD_TOGGLE_UNCLAIMENTITYDELETE("towny.command.townyworld.toggle.unclaimentitydelete"),
 		TOWNY_COMMAND_TOWNYWORLD_TOGGLE_WILDERNESSUSE("towny.command.townyworld.toggle.wildernessuse"),
+		TOWNY_COMMAND_TOWNYWORLD_TOGGLE_JAILING("towny.command.townyworld.toggle.jailing"),
 
 	/*
 	 * Towns Spawning Nodes.

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -2639,3 +2639,6 @@ msg_err_you_cannot_add_trust_on_enemy: "You cannot trust a player who is part of
 msg_err_you_cannot_add_towntrust_on_outlaw: "You cannot trust a town who has residents which are outlawed by your town."
 
 msg_err_you_cannot_add_towntrust_on_enemy: "You cannot trust a town who is part of an enemy nation."
+
+# added in 0.157
+status_world_jailing: "Jailing"

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -2640,5 +2640,4 @@ msg_err_you_cannot_add_towntrust_on_outlaw: "You cannot trust a town who has res
 
 msg_err_you_cannot_add_towntrust_on_enemy: "You cannot trust a town who is part of an enemy nation."
 
-# added in 0.157
-status_world_jailing: "Jailing:"
+status_world_jailing: "Jailing: "

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -302,6 +302,7 @@ world_toggle_help_8: "Toggle on/off the revert-on-unclaim feature in this world.
 world_toggle_help_9: "Toggle on/off the explosions-are-reverted features in this world."
 world_toggle_help_10: "Toggle on/off the plot-clear-deletes-blocks command in this world."
 world_toggle_help_11: "Toggle on/off the plot-unclaiming-deletes-blocks feature in this world."
+world_toggle_help_12: "Toggle on/off if being jailed is enabled in this world."
 
 
 townyadmin_help_1: 'Unclaim this town block'

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -2241,6 +2241,7 @@ msg_you_were_released_as_town_ran_out_of_upkeep_funds: 'You have been released a
 msg_x_has_been_released_ran_out_of_upkeep_funds: '%s has been released due to a lack of funds in the Town bank.'
 msg_x_has_been_withdrawn_for_upkeep_of_prisoner_x: '%s withdrawn from Town bank to pay for upkeep for prisoner %s.'
 msg_x_has_been_withdrawn_for_jailing_of_prisoner_x: '%s withdrawn from Town bank to pay for jailing of %s.'
+msg_err_x_in_unjailable_world: '%s is in a world that they cannot be jailed from.'
 
 #Message shown in the confirmation for /ta resetbanks {amount}.
 confirmation_are_you_sure_you_want_to_reset_all_banks: 'Are you sure you want to reset all town and nation banks to %s?'

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -2641,4 +2641,4 @@ msg_err_you_cannot_add_towntrust_on_outlaw: "You cannot trust a town who has res
 msg_err_you_cannot_add_towntrust_on_enemy: "You cannot trust a town who is part of an enemy nation."
 
 # added in 0.157
-status_world_jailing: "Jailing"
+status_world_jailing: "Jailing:"

--- a/Towny/src/main/resources/plugin.yml
+++ b/Towny/src/main/resources/plugin.yml
@@ -900,6 +900,7 @@ permissions:
             towny.command.townyworld.toggle.forcefire: true
             towny.command.townyworld.toggle.forcepvp: true
             towny.command.townyworld.toggle.friendlyfire: true
+            towny.command.townyworld.toggle.jailing: true
             towny.command.townyworld.toggle.plotcleardelete: true
             towny.command.townyworld.toggle.pvp: true
             towny.command.townyworld.toggle.revertunclaim: true
@@ -914,7 +915,6 @@ permissions:
             towny.command.townyworld.toggle.wildernessmobs: true
             towny.command.townyworld.toggle.wildernessuse: true
             towny.command.townyworld.toggle.worldmobs: true
-            towny.command.townyworld.toggle.jailing: true
 
     towny.receives-plot-notifications:
         description: User is able to be shown the notifications that appear when crossing plot boundaries and entering/exiting towns.

--- a/Towny/src/main/resources/plugin.yml
+++ b/Towny/src/main/resources/plugin.yml
@@ -914,6 +914,7 @@ permissions:
             towny.command.townyworld.toggle.wildernessmobs: true
             towny.command.townyworld.toggle.wildernessuse: true
             towny.command.townyworld.toggle.worldmobs: true
+            towny.command.townyworld.toggle.jailing: true
 
     towny.receives-plot-notifications:
         description: User is able to be shown the notifications that appear when crossing plot boundaries and entering/exiting towns.


### PR DESCRIPTION
#### Description: 
Allow server admins to toggle whether or not a user is able to be jailed while in x world
____
#### New Nodes/Commands/ConfigOptions: 
/tw toggle jailing
towny.command.townyworld.toggle.jailing
new_world_settings.plot_management.jailing_enabled

____
#### Relevant Towny Issue ticket:
Closes https://github.com/TownyAdvanced/Towny/issues/7817

____
- [x ] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
