### PR TITLE
Shut down tasks/timers before datasource

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/Towny.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/Towny.java
@@ -412,6 +412,13 @@ public class Towny extends JavaPlugin {
 	public void onDisable() {
 
 		Bukkit.getLogger().info("==============================================================");
+
+		// Turn off timers.		
+		toggleTimersOff();
+
+		TownyRegenAPI.cancelProtectionRegenTasks();
+		ChunkNotificationUtil.cancelChunkNotificationTasks();
+
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
 		if (townyUniverse.getDataSource() != null && !isError(TownyInitException.TownyError.DATABASE)) {
 			townyUniverse.getDataSource().saveQueues();
@@ -421,12 +428,6 @@ public class Towny extends JavaPlugin {
 			plugin.getLogger().info("Finishing File IO Tasks...");
 			townyUniverse.getDataSource().finishTasks();
 		}
-
-		// Turn off timers.		
-		toggleTimersOff();
-
-		TownyRegenAPI.cancelProtectionRegenTasks();
-		ChunkNotificationUtil.cancelChunkNotificationTasks();
 
 		playerCache.clear();
 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Fixes an issue I encountered where if finishTasks takes a long time to shut down, tasks in the background continue running. This causes a bunch of error spam due to new tasks being attempted to be scheduled while the plugin is already considered disabled.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
