### PR TITLE
Fix selection gui item ordering being wack

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -51,6 +51,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -103,8 +104,8 @@ public class TownySettings {
 	private static final SortedMap<Integer, TownLevel> configTownLevel = Collections.synchronizedSortedMap(new TreeMap<>(Collections.reverseOrder()));
 	private static final SortedMap<Integer, NationLevel> configNationLevel = Collections.synchronizedSortedMap(new TreeMap<>(Collections.reverseOrder()));
 	
-	private static final Set<Material> itemUseMaterials = new HashSet<>();
-	private static final Set<Material> switchUseMaterials = new HashSet<>();
+	private static final Set<Material> itemUseMaterials = new LinkedHashSet<>();
+	private static final Set<Material> switchUseMaterials = new LinkedHashSet<>();
 	private static final List<Class<?>> protectedMobs = new ArrayList<>();
 	
 	private static final Map<NamespacedKey, Consumer<CommentedConfiguration>> CONFIG_RELOAD_LISTENERS = new HashMap<>();

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownBlockData.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownBlockData.java
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
  import java.util.EnumSet;
- import java.util.HashSet;
+ import java.util.LinkedHashSet;
  import java.util.Set;
 
 public class TownBlockData {
@@ -18,9 +18,9 @@ public class TownBlockData {
 	private NamedTextColor colour = null;
 	private double cost = 0.0;
 	private double tax = 0.0;
-	private final Set<Material> itemUseIds = new HashSet<>(); // List of item names that will trigger an item use test.
-	private final Set<Material> switchIds = new HashSet<>(); // List of item names that will trigger a switch test.
-	private final Set<Material> allowedBlocks = new HashSet<>(); // List of item names that will always be allowed.
+	private final Set<Material> itemUseIds = new LinkedHashSet<>(); // List of item names that will trigger an item use test.
+	private final Set<Material> switchIds = new LinkedHashSet<>(); // List of item names that will trigger a switch test.
+	private final Set<Material> allowedBlocks = new LinkedHashSet<>(); // List of item names that will always be allowed.
 	
 	public String getMapKey() {
 		return mapKey;

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownBlockTypeHandler.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownBlockTypeHandler.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -154,7 +155,7 @@ public final class TownBlockTypeHandler {
 	
 	private static Set<Material> loadMaterialList(String listName, String materialList, String typeName) {
 		if (!materialList.isEmpty()) {
-			Set<Material> set = new HashSet<>();
+			Set<Material> set = new LinkedHashSet<>();
 			for (String materialName : materialList.split(",")) {
 				if (ItemLists.GROUPS.contains(materialName)) {
 					set.addAll(ItemLists.getGrouping(materialName));


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
When using /towny switches, /towny itemuse, or /towny allowedblocks the ordering of the items in them is all over the place, this PR fixes that by switching the relevant sets where the data is obtained from to ones that preserve insertion order.
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
