### PR TITLE
Config option for non-public towns to show map link  #7872

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1621,6 +1621,13 @@ public enum ConfigNodes {
 		"# If enabled, the world name placeholder will be replaced with the world key instead of the Bukkit name.",
 		"# This should be enabled if you use SquareMap."
 	),
+
+	PLUGIN_WEB_MAP_SHOW_LINK_FOR_NONPUBLIC_TOWNS(
+		"plugin.interfacing.web_map.non_public_towns_show_map_link",
+		"false",
+		"",
+		"# If enabled, non-public towns will show a link to their map location in the town status screen."
+	),
 	
 	PLUGIN_WEB_MAP_URL(
 			"plugin.interfacing.web_map.url",

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -311,7 +311,7 @@ public class TownyFormatter {
 		else
 			screen.addComponentOf("townblocks", colourKeyValue(translator.of("status_town_size"), translator.of("status_fractions", town.getTownBlocks().size(), town.getMaxTownBlocksAsAString())));
 
-		if (town.isPublic()) {
+		if (town.isPublic() || TownySettings.isWebMapLinkShownForNonPublicTowns()) {
 			Component homeComponent = TownyComponents.miniMessage(translator.of("status_home_element", TownySettings.getTownDisplaysXYZ()
 						? (town.hasSpawn() ? BukkitTools.convertCoordtoXYZ(town.getSpawnOrNull()) : translator.of("status_no_town"))
 						: (town.hasHomeBlock() ? town.getHomeBlockOrNull().getCoord().toString() : translator.of("status_no_town"))

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -3747,7 +3747,11 @@ public class TownySettings {
 	public static boolean isUsingWebMapStatusScreens() {
 		return getBoolean(ConfigNodes.PLUGIN_WEB_MAP_USING_STATUSSCREEN);
 	}
-	
+
+	public static boolean isWebMapLinkShownForNonPublicTowns() {
+		return getBoolean(ConfigNodes.PLUGIN_WEB_MAP_SHOW_LINK_FOR_NONPUBLIC_TOWNS);
+	}
+
 	public static boolean isUsingWorldKeyForWorldName() {
 		return getBoolean(ConfigNodes.PLUGIN_WEB_MAP_WORLD_NAME_USES_KEY);
 	}


### PR DESCRIPTION
#### Description: 
This PR adds a new config option `non_public_towns_show_map_link` under the web map integration section. When enabled, it allows non-public towns to display a clickable map link in the town status screens, making it easier for players and admins to locate towns on the web map, even if the towns are private.

____
#### New Nodes/Commands/ConfigOptions: 
- plugin.interfacing.web_map.non_public_towns_show_map_link
 - boolean
 - default: false
 - description: If enabled, non-public towns will show a link to their map location in the town status screen.

____
#### Relevant Towny Issue ticket:
Closes #7872 


____
- [X] I have tested this pull request for defects on a server. 
![image](https://github.com/user-attachments/assets/6e28c0be-4425-4c9a-bc70-42679f20853c)
![image](https://github.com/user-attachments/assets/7ec578d2-a26b-476c-8506-8a1f66d2c923)


By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
