### PR TITLE
Allow the TownPreUnclaimEvent to no longer be fired when a town is being deleted, allowing Districts to get properly deleted when their town will no longer exist.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyDataSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyDataSource.java
@@ -5,6 +5,7 @@ import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.event.DeleteTownEvent;
+import com.palmergames.bukkit.towny.event.town.TownPreUnclaimEvent.Cause;
 import com.palmergames.bukkit.towny.event.DeleteNationEvent;
 import com.palmergames.bukkit.towny.exceptions.AlreadyRegisteredException;
 import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
@@ -333,6 +334,8 @@ public abstract class TownyDataSource {
 	abstract public void removeResident(Resident resident);
 
 	abstract public void removeTownBlock(TownBlock townBlock);
+
+	abstract public void removeTownBlock(TownBlock townBlock, Cause cause);
 
 	abstract public void removeTownBlocks(Town town);
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
@@ -345,7 +345,7 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 	}
 
 	@Override
-	public void removeTownBlock(TownBlock townBlock, TownPreUnclaimEvent.Cause cause ) {
+	public void removeTownBlock(TownBlock townBlock, TownPreUnclaimEvent.Cause cause) {
 		Town town = townBlock.getTownOrNull();
 		if (town == null)
 			// Log as error because TownBlocks *must* have a town.

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
@@ -341,17 +341,24 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 
 	@Override
 	public void removeTownBlock(TownBlock townBlock) {
+		removeTownBlock(townBlock, TownPreUnclaimEvent.Cause.UNKNOWN);
+	}
+
+	@Override
+	public void removeTownBlock(TownBlock townBlock, TownPreUnclaimEvent.Cause cause ) {
 		Town town = townBlock.getTownOrNull();
 		if (town == null)
 			// Log as error because TownBlocks *must* have a town.
 			plugin.getLogger().severe(String.format("The TownBlock at (%s, %d, %d) is not registered to a town.", townBlock.getWorld().getName(), townBlock.getX(), townBlock.getZ()));
 
-		TownPreUnclaimEvent event = new TownPreUnclaimEvent(town, townBlock);
-		if (BukkitTools.isEventCancelled(event)) {
-			// Log as Warn because the event has been processed
-			if (!event.getCancelMessage().isEmpty())
-				plugin.getLogger().warning(event.getCancelMessage());
-			return;
+		if (!cause.ignoresPreEvent()) {
+			TownPreUnclaimEvent event = new TownPreUnclaimEvent(town, townBlock, cause);
+			if (BukkitTools.isEventCancelled(event)) {
+				// Log as Warn because the event has been processed
+				if (!event.getCancelMessage().isEmpty())
+					plugin.getLogger().warning(event.getCancelMessage());
+				return;
+			}
 		}
 		
 		if (townBlock.isJail() && townBlock.getJail() != null)
@@ -381,7 +388,7 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 	public void removeTownBlocks(Town town) {
 
 		for (TownBlock townBlock : new ArrayList<>(town.getTownBlocks()))
-			removeTownBlock(townBlock);
+			removeTownBlock(townBlock, TownPreUnclaimEvent.Cause.DELETE);
 	}
 
 	@Override

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/event/town/TownPreUnclaimEvent.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/event/town/TownPreUnclaimEvent.java
@@ -70,20 +70,26 @@ public class TownPreUnclaimEvent extends CancellableTownyEvent {
 	}
 
 	public enum Cause {
+		/**
+		 * The townblock is being unclaimed for an unknown reason.
+		 */
 		UNKNOWN,
 		/**
-		 * The townblock is being unclaimed for an unknown reason
+		 * The townblock is being unclaimed because of a command.
 		 */
 		COMMAND,
 		/**
+		 * The townblock is being unclaimed because of a command run by an admin.
+		 */
+		ADMIN_COMMAND,
+		/**
 		 * The townblock's town is being deleted.
-		 * @see #isUpkeep() 
 		 */
 		DELETE;
 
 		@ApiStatus.Internal
 		public boolean ignoresPreEvent() {
-			return this == DELETE;
+			return this == DELETE || this == ADMIN_COMMAND;
 		}
 	}
 }

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/event/town/TownPreUnclaimEvent.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/event/town/TownPreUnclaimEvent.java
@@ -80,15 +80,7 @@ public class TownPreUnclaimEvent extends CancellableTownyEvent {
 		 * @see #isUpkeep() 
 		 */
 		DELETE;
-		
-		public boolean isCommand() {
-			return this == COMMAND;
-		}
 
-		public boolean isDeleted() {
-			return this == DELETE;
-		}
-		
 		@ApiStatus.Internal
 		public boolean ignoresPreEvent() {
 			return this == DELETE;

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/event/town/TownPreUnclaimEvent.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/event/town/TownPreUnclaimEvent.java
@@ -5,6 +5,7 @@ import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.Translation;
 import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -13,6 +14,7 @@ public class TownPreUnclaimEvent extends CancellableTownyEvent {
 
     private final TownBlock townBlock;
     private final Town town;
+    private final Cause cause;
 
     /**
      * Event thrown prior to a {@link TownBlock} being unclaimed by a {@link Town}.
@@ -23,9 +25,10 @@ public class TownPreUnclaimEvent extends CancellableTownyEvent {
      * @param town The Town unclaiming the TownBlock.
      * @param townBlock The TownBlock that will be unclaimed.
      */
-    public TownPreUnclaimEvent(Town town, TownBlock townBlock) {
+    public TownPreUnclaimEvent(Town town, TownBlock townBlock, Cause cause) {
         this.town = town;
         this.townBlock = townBlock;
+        this.cause = cause;
 
         // Don't even bother with things if town is null.
         if (this.town == null){
@@ -60,5 +63,35 @@ public class TownPreUnclaimEvent extends CancellableTownyEvent {
 	@Override
 	public HandlerList getHandlers() {
 		return HANDLER_LIST;
+	}
+
+	public Cause getCause() {
+		return cause;
+	}
+
+	public enum Cause {
+		UNKNOWN,
+		/**
+		 * The townblock is being unclaimed for an unknown reason
+		 */
+		COMMAND,
+		/**
+		 * The townblock's town is being deleted.
+		 * @see #isUpkeep() 
+		 */
+		DELETE;
+		
+		public boolean isCommand() {
+			return this == COMMAND;
+		}
+
+		public boolean isDeleted() {
+			return this == DELETE;
+		}
+		
+		@ApiStatus.Internal
+		public boolean ignoresPreEvent() {
+			return this == DELETE;
+		}
 	}
 }

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
@@ -236,9 +236,8 @@ public class TownyCustomListener implements Listener {
 	 */
 	@EventHandler(ignoreCancelled = true)
 	public void onTownUnclaimDistrict(TownPreUnclaimEvent event) {
-
 		TownBlock townBlock = event.getTownBlock();
-		if (!townBlock.hasDistrict() || event.getCause().isDeleted())
+		if (!townBlock.hasDistrict() || event.getCause().ignoresPreEvent())
 			return;
 
 		try {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
@@ -237,7 +237,7 @@ public class TownyCustomListener implements Listener {
 	@EventHandler(ignoreCancelled = true)
 	public void onTownUnclaimDistrict(TownPreUnclaimEvent event) {
 		TownBlock townBlock = event.getTownBlock();
-		if (!townBlock.hasDistrict() || event.getCause().ignoresPreEvent())
+		if (!townBlock.hasDistrict())
 			return;
 
 		try {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyCustomListener.java
@@ -236,8 +236,9 @@ public class TownyCustomListener implements Listener {
 	 */
 	@EventHandler(ignoreCancelled = true)
 	public void onTownUnclaimDistrict(TownPreUnclaimEvent event) {
+
 		TownBlock townBlock = event.getTownBlock();
-		if (!townBlock.hasDistrict())
+		if (!townBlock.hasDistrict() || event.getCause().isDeleted())
 			return;
 
 		try {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/TownClaim.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/TownClaim.java
@@ -304,7 +304,8 @@ public class TownClaim implements Runnable {
 	 * @param townBlock TownBlock to remove from the database.
 	 */
 	private void unclaimTownBlock(TownBlock townBlock) {
-		plugin.getScheduler().runLater(() -> TownyUniverse.getInstance().getDataSource().removeTownBlock(townBlock, TownPreUnclaimEvent.Cause.COMMAND), 1);
+		TownPreUnclaimEvent.Cause cause = forced ? TownPreUnclaimEvent.Cause.ADMIN_COMMAND : TownPreUnclaimEvent.Cause.COMMAND;
+		plugin.getScheduler().runLater(() -> TownyUniverse.getInstance().getDataSource().removeTownBlock(townBlock, cause), 1);
 	}
 
 	private void refundForUnclaim(double unclaimRefund, int numUnclaimed) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/TownClaim.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/TownClaim.java
@@ -7,6 +7,7 @@ import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.confirmations.Confirmation;
 import com.palmergames.bukkit.towny.event.TownClaimEvent;
+import com.palmergames.bukkit.towny.event.town.TownPreUnclaimEvent;
 import com.palmergames.bukkit.towny.event.town.TownUnclaimEvent;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Town;
@@ -303,7 +304,7 @@ public class TownClaim implements Runnable {
 	 * @param townBlock TownBlock to remove from the database.
 	 */
 	private void unclaimTownBlock(TownBlock townBlock) {
-		plugin.getScheduler().runLater(() -> TownyUniverse.getInstance().getDataSource().removeTownBlock(townBlock), 1);
+		plugin.getScheduler().runLater(() -> TownyUniverse.getInstance().getDataSource().removeTownBlock(townBlock, TownPreUnclaimEvent.Cause.COMMAND), 1);
 	}
 
 	private void refundForUnclaim(double unclaimRefund, int numUnclaimed) {


### PR DESCRIPTION


<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Somewhat experimental way to solve the relevant issue.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->



Closes #7889.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
