### PR TITLE
Add build information to the version command

### DIFF
--- a/Towny/pom.xml
+++ b/Towny/pom.xml
@@ -469,6 +469,23 @@
                         </archive>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>io.github.git-commit-id</groupId>
+                    <artifactId>git-commit-id-maven-plugin</artifactId>
+                    <version>9.0.2</version>
+                    <executions>
+                        <execution>
+                            <id>get-the-git-infos</id>
+                            <goals>
+                                <goal>revision</goal>
+                            </goals>
+                            <phase>initialize</phase>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+                    </configuration>
+                </plugin>
             </plugins>
         <resources>
             <resource>

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownyCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownyCommand.java
@@ -13,10 +13,12 @@ import com.palmergames.bukkit.towny.TownyUpdateChecker;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.hooks.PluginIntegrations;
 import com.palmergames.bukkit.towny.huds.HUDManager;
+import com.palmergames.bukkit.towny.object.BuildInfo;
 import com.palmergames.bukkit.towny.object.Government;
 import com.palmergames.bukkit.towny.object.TownBlockType;
 import com.palmergames.bukkit.towny.object.TownBlockTypeHandler;
 import com.palmergames.bukkit.towny.object.Translatable;
+import com.palmergames.bukkit.towny.object.Translation;
 import com.palmergames.bukkit.towny.object.Translator;
 import com.palmergames.bukkit.towny.object.comparators.GovernmentComparators;
 import com.palmergames.bukkit.towny.object.Nation;
@@ -35,12 +37,17 @@ import com.palmergames.bukkit.util.ChatTools;
 import com.palmergames.bukkit.util.Colors;
 import com.palmergames.util.StringMgmt;
 import com.palmergames.util.TimeMgmt;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.IOException;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -48,6 +55,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 public class TownyCommand extends BaseCommand implements CommandExecutor {
@@ -267,6 +275,27 @@ public class TownyCommand extends BaseCommand implements CommandExecutor {
 						TownyMessaging.sendMsg(sender, Translatable.of("msg_latest_version", plugin.getVersion(), TownyUpdateChecker.getNewVersion()));
 					} else {
 						TownyMessaging.sendMsg(sender, Translatable.of("msg_towny_version", plugin.getVersion()));
+						
+						try {
+							final BuildInfo buildInfo = BuildInfo.retrieveBuildInfo(plugin);
+							
+							String repositoryUrl = buildInfo.repositoryUrl();
+							if (repositoryUrl.endsWith(".git")) {
+								repositoryUrl = repositoryUrl.substring(0, repositoryUrl.length() - ".git".length());
+							}
+
+							final String viewCommitUrl = repositoryUrl + "/commit/" + buildInfo.commit();
+
+							final Component buildInfoMessage = Translatable.of("default_towny_prefix").append(Translatable.of("msg_version_build_info", buildInfo.commitShort(), buildInfo.branch()))
+								.component(Translation.getLocale(sender))
+								.clickEvent(ClickEvent.openUrl(viewCommitUrl))
+								.hoverEvent(HoverEvent.showText(Component.text(buildInfo.message(), NamedTextColor.GREEN)));
+
+							Towny.getAdventure().sender(sender).sendMessage(buildInfoMessage);
+						} catch (IOException e) {
+							plugin.getLogger().log(Level.WARNING, "Could not retrieve build information", e);
+							TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_version_build_info_failed"));
+						}
 
 						if (TownyUpdateChecker.hasCheckedSuccessfully())
 							TownyMessaging.sendMsg(sender, Translatable.of("msg_up_to_date"));

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/BuildInfo.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/BuildInfo.java
@@ -1,0 +1,42 @@
+package com.palmergames.bukkit.towny.object;
+
+import com.palmergames.bukkit.towny.Towny;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Properties;
+
+/**
+ * Represents git build information for a Towny jar file.
+ * 
+ * @param commit The full SHA-1 hash of the most recent commit.
+ * @param commitShort The shortened hash of the most recent commit.
+ * @param branch The branch this jar was built from.
+ * @param repositoryUrl The url for the remote git repository.
+ * @param message The subject of the most recent commit.
+ */
+@ApiStatus.Internal
+public record BuildInfo(String commit, String commitShort, String branch, String repositoryUrl, String message) {
+	public static BuildInfo retrieveBuildInfo(Towny plugin) throws IOException {
+		try (final InputStream is = plugin.getResource("version.properties")) {
+			if (is == null) {
+				throw new IOException("Could not find version.properties in the Towny jar file.");
+			}
+
+			final Properties properties = new Properties();
+			try (final InputStreamReader reader = new InputStreamReader(is)) {
+				properties.load(reader);
+			}
+
+			return new BuildInfo(
+				properties.getProperty("commit"),
+				properties.getProperty("commit-short"),
+				properties.getProperty("branch"),
+				properties.getProperty("repository-url"),
+				properties.getProperty("commit-message")
+			);
+		}
+	}
+}

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -2651,3 +2651,6 @@ msg_err_you_cannot_add_towntrust_on_outlaw: "You cannot trust a town who has res
 msg_err_you_cannot_add_towntrust_on_enemy: "You cannot trust a town who is part of an enemy nation."
 
 status_world_jailing: "Jailing: "
+
+msg_version_build_info: "<dark_green>Build Information: <green>%s</green> on branch <green>%s<green>."
+msg_version_build_info_failed: "<red>Could not retrieve build information for this version."

--- a/Towny/src/main/resources/version.properties
+++ b/Towny/src/main/resources/version.properties
@@ -1,0 +1,5 @@
+commit=${git.commit.id}
+commit-short=${git.commit.id.abbrev}
+branch=${git.branch}
+repository-url=${git.remote.origin.url}
+commit-message=${git.commit.message.short}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Adds a [maven plugin](https://github.com/git-commit-id/git-commit-id-maven-plugin) to obtain commit info from git and exposes that in the version command as pictured below, useful for figuring out what build of towny is being ran exactly, including a clickable link.

<img width="1305" height="91" alt="image" src="https://github.com/user-attachments/assets/d779f8eb-0e11-470d-9f5f-4e66e513ae3c" />

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
