### PR TITLE
Add unformatted tags for town and nation along with any overrides

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/hooks/TownyPlaceholderExpansion.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/hooks/TownyPlaceholderExpansion.java
@@ -1,13 +1,17 @@
 package com.palmergames.bukkit.towny.hooks;
 
-import java.text.DecimalFormat;
-import java.util.List;
-import java.util.Locale;
-import java.util.UUID;
+import com.palmergames.bukkit.towny.object.TownBlock;
+import com.palmergames.bukkit.towny.object.Translation;
+import com.palmergames.bukkit.towny.object.comparators.ComparatorCaches;
+import com.palmergames.bukkit.towny.object.comparators.ComparatorType;
+import com.palmergames.bukkit.towny.object.Translatable;
+import com.palmergames.bukkit.towny.utils.CombatUtil;
 
+import com.palmergames.util.Pair;
+import com.palmergames.util.TimeMgmt;
+import net.kyori.adventure.text.Component;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
-import org.jetbrains.annotations.Nullable;
 
 import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.TownyAPI;
@@ -18,20 +22,17 @@ import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
-import com.palmergames.bukkit.towny.object.TownBlock;
-import com.palmergames.bukkit.towny.object.Translatable;
-import com.palmergames.bukkit.towny.object.Translation;
-import com.palmergames.bukkit.towny.object.comparators.ComparatorCaches;
-import com.palmergames.bukkit.towny.object.comparators.ComparatorType;
-import com.palmergames.bukkit.towny.utils.CombatUtil;
-import com.palmergames.util.Pair;
 import com.palmergames.util.StringMgmt;
-import com.palmergames.util.TimeMgmt;
 
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import me.clip.placeholderapi.expansion.Relational;
-import net.kyori.adventure.text.Component;
 import net.md_5.bungee.api.ChatColor;
+import org.jetbrains.annotations.Nullable;
+
+import java.text.DecimalFormat;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
 
 /**
  * This class will be registered through the register-method in the plugins
@@ -44,7 +45,7 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 	final String res = TownySettings.getPAPIFormattingResident() + Translation.of("res_sing");
 	final String mayor = TownySettings.getPAPIFormattingMayor() + Translation.of("mayor_sing");
 	final String king = TownySettings.getPAPIFormattingKing() + Translation.of("king_sing");
-
+	
 	private final Towny plugin;
 
 	/**
@@ -83,7 +84,7 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 	/**
 	 * The name of the person who created this expansion should go here. <br>
 	 * For convienience do we return the author from the plugin.yml
-	 *
+	 * 
 	 * @return The name of the author as a String.
 	 */
 	@Override
@@ -116,7 +117,7 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 	public String getVersion() {
 		return plugin.getDescription().getVersion();
 	}
-
+	
 	@Override
 	public String onPlaceholderRequest(Player player, Player player2, String identifier) {
 		return ChatColor.translateAlternateColorCodes('&', getRelationalPlaceholder(player, player2, identifier));
@@ -130,8 +131,8 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 		Resident res2 = TownyUniverse.getInstance().getResident(player2.getUniqueId());
 		if (res == null || res2 == null)
 			return TownySettings.getPAPIRelationNone();
-
-		if (!res2.hasTown())
+		
+		if (!res2.hasTown()) 
 			return TownySettings.getPAPIRelationNoTown();
 		else if (CombatUtil.isSameTown(res, res2))
 			return TownySettings.getPAPIRelationSameTown();
@@ -165,19 +166,19 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 		if (player == null && !identifier.startsWith("top_")) {
 			return "";
 		}
-
+		
 		if (identifier.startsWith("top_"))
 			return getLeaderBoardPlaceholder(identifier);
-
+		
 		/*
 		 * This is a location-based placeholder request, use the onPlaceholderRequest to fulfill it.
 		 * %townyadvanced_player_status% is a special case and should probably be renamed to %townyadvanced_resident_status%.
 		 */
 		if (player.isOnline() && (identifier.startsWith("player_") && !identifier.equals("player_status")))
 			return onPlaceholderRequest((Player) player, identifier);
-
+		
 		Resident resident = TownyUniverse.getInstance().getResident(player.getUniqueId());
-
+		
 		if (resident == null)
 			return "";
 
@@ -521,12 +522,12 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 		case "daily_town_overclaimed_per_plot_upkeep_penalty": // %townyadvanced_daily_town_overclaimed_per_plot_upkeep_penalty%
 			return getMoney(TownySettings.getUpkeepPenalty());
 		case "daily_town_upkeep_reduction_from_town_level": // %townyadvanced_daily_town_upkeep_reduction_from_town_level%
-			cost = resident.hasTown()
+			cost = resident.hasTown() 
 				? resident.getTownOrNull().getTownLevel().upkeepModifier()
 				: 1.0;
 			return cost == 1.0 ? "0" : String.valueOf(dFormat.format((1.0 - cost) * 100));
 		case "daily_town_upkeep_reduction_from_nation_level": // %townyadvanced_daily_town_upkeep_reduction_from_nation_level%
-			cost = resident.hasNation()
+			cost = resident.hasNation() 
 				? resident.getNationOrNull().getNationLevel().nationTownUpkeepModifier()
 				: 1.0;
 			return cost == 1.0 ? "0" : String.valueOf(dFormat.format((1.0 - cost) * 100));
@@ -538,7 +539,7 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 		case "daily_nation_per_town_upkeep": // %townyadvanced_daily_nation_per_town_upkeep%
 			return String.valueOf(TownySettings.getNationUpkeep());
 		case "daily_nation_upkeep_reduction_from_nation_level": // %townyadvanced_daily_nation_upkeep_reduction_from_nation_level%
-			cost = resident.hasNation()
+			cost = resident.hasNation() 
 				? resident.getNationOrNull().getNationLevel().upkeepModifier()
 				: 1.0;
 			return cost == 1.0 ? "0" : String.valueOf(dFormat.format((1.0 - cost) * 100));
@@ -615,7 +616,7 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 				if (!hex.isEmpty())
 					hex = "#"+hex;
 			}
-			return hex;
+			return hex;				
 		case "nation_map_color_hex": // %townyadvanced_nation_map_color_hex%
 			if (resident.hasNation()){
 				hex = resident.getNationOrNull().getMapColorHexCode();
@@ -629,21 +630,21 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 				if (!hex.isEmpty())
 					hex = "<#"+hex+">";
 			}
-			return hex;
+			return hex;				
 		case "nation_map_color_minimessage_hex": // %townyadvanced_nation_map_color_minimessage_hex%
 			if (resident.hasNation()){
 				hex = resident.getNationOrNull().getMapColorHexCode();
 				if (!hex.isEmpty())
 					hex = "<#"+hex+">";
 			}
-			return hex;
+			return hex;	
 		case "town_ranks": // %townyadvanced_town_ranks%
 			if (resident.isMayor())
 				rank = Translation.of("mayor_sing");
 			else if (!resident.getTownRanks().isEmpty())
 				rank = StringMgmt.capitalize(StringMgmt.join(resident.getTownRanks(), ", "));
 			return rank;
-
+			
 		case "nation_ranks": // %townyadvanced_nation_ranks%
 			if (resident.isKing())
 				rank = Translation.of("king_sing");
@@ -672,9 +673,9 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 			return resident.hasNation() ? TownySettings.getNationPostfix(resident.getNationOrNull()) : "";
 		case "player_jailed": // %townyadvanced_player_jailed%
 			return String.valueOf(resident.isJailed());
-		case "is_nation_peaceful": // %townyadvanced_is_nation_peaceful%
+		case "is_nation_peaceful": // %townyadvanced_is_nation_peaceful%	
 			return resident.hasNation() ? (resident.getNationOrNull().isNeutral() ? Translation.of("status_town_title_peaceful"): "") : "";
-		case "is_town_peaceful": // %townyadvanced_is_town_peaceful%
+		case "is_town_peaceful": // %townyadvanced_is_town_peaceful%	
 			return resident.hasTown() ? (resident.getTownOrNull().isNeutral() ? Translation.of("status_town_title_peaceful"): "") : "";
 		case "is_town_public": // %townyadvanced_is_town_public%
 			return resident.hasTown() ? (resident.getTownOrNull().isPublic() ? Translation.of("status_public") : "") : "";
@@ -689,13 +690,13 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 			return Translatable.of("msg_time_until_a_new_day").append(TimeMgmt.formatCountdownTime(TimeMgmt.townyTime(true), locale)).translate(locale);
 		}
 		case "time_until_new_day_hours_formatted": // %townyadvanced_time_until_new_day_hours_formatted%
-			return TimeMgmt.formatCountdownTimeHours(TimeMgmt.townyTime(true), player.getPlayer());
+			return TimeMgmt.formatCountdownTimeHours(TimeMgmt.townyTime(true), player.getPlayer()); 
 		case "time_until_new_day_minutes_formatted": // %townyadvanced_time_until_new_day_minutes_formatted%
 			return TimeMgmt.formatCountdownTimeMinutes(TimeMgmt.townyTime(true), player.getPlayer());
 		case "time_until_new_day_seconds_formatted": // %townyadvanced_time_until_new_day_seconds_formatted%
 			return TimeMgmt.formatCountdownTimeSeconds(TimeMgmt.townyTime(true), player.getPlayer());
 		case "time_until_new_day_hours_raw": // %townyadvanced_time_until_new_day_hours_raw%
-			return TimeMgmt.countdownTimeHoursRaw(TimeMgmt.townyTime(true));
+			return TimeMgmt.countdownTimeHoursRaw(TimeMgmt.townyTime(true)); 
 		case "time_until_new_day_minutes_raw": // %townyadvanced_time_until_new_day_minutes_raw%
 			return TimeMgmt.countdownTimeMinutesRaw(TimeMgmt.townyTime(true));
 		case "time_until_new_day_seconds_raw": // %townyadvanced_time_until_new_day_seconds_raw%
@@ -705,7 +706,7 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 		case "number_of_neutral_towns_in_server": // %townyadvanced_number_of_neutral_towns_in_server%
 			return String.valueOf(TownyUniverse.getInstance().getTowns().stream().filter(Town::isNeutral).count());
 		case "nation_or_town_name":	// %townyadvanced_nation_or_town_name%
-			return !resident.hasTown()
+			return !resident.hasTown() 
 				? ""
 				: resident.hasNation()
 					? String.format(TownySettings.getPAPIFormattingNation(), StringMgmt.remUnderscore(resident.getNationOrNull().getName()))
@@ -807,7 +808,7 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 			case "player_location_plotgroup_name": // %townyadvanced_player_location_plotgroup_name%
 				return townblock != null ? (townblock.hasPlotObjectGroup() ? townblock.getPlotObjectGroup().getName() : "") : "";
 			case "player_location_plot_owner_name": // %townyadvanced_player_location_plot_owner_name%
-				return (townblock != null && townblock.hasResident()) ? townblock.getResidentOrNull().getName() : "";
+				return (townblock != null && townblock.hasResident()) ? townblock.getResidentOrNull().getName() : ""; 
 			case "player_location_town_prefix": // %townyadvanced_player_location_town_prefix%
 				return townblock != null ? townblock.getTownOrNull().getPrefix(): "";
 			case "player_location_town_postfix": // %townyadvanced_player_location_town_postfix%
@@ -836,7 +837,7 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 						.filter(t -> t.getHomeblockWorld().equals(townblock.getWorld()))
 						.count());
 			case "player_location_town_forsale_cost": // %townyadvanced_player_location_town_forsale_cost%
-				return townblock == null ? "" :
+				return townblock == null ? "" : 
 					townblock.getTownOrNull().isForSale()
 						? getMoney(townblock.getTownOrNull().getForSalePrice())
 						: Translation.of("msg_not_for_sale");


### PR DESCRIPTION
#### Description: 
The PR adds the following placeholders:
- `town_tag_unformatted`
- `town_tag_override_unformatted`
- `nation_tag_unformatted`
- `nation_tag_override_unformatted`

This PR also has the unintended side effect of trimming whitespace and reordering imports within the file, which can be undone upon request.
____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
