### PR TITLE
Suppress outlaw warning for spectators

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/ResidentUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/ResidentUtil.java
@@ -21,6 +21,7 @@ import com.palmergames.bukkit.towny.tasks.CooldownTimerTask;
 import com.palmergames.bukkit.towny.tasks.CooldownTimerTask.CooldownType;
 
 import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
@@ -304,8 +305,11 @@ public class ResidentUtil {
 		
 		boolean hasBypassNode = outlaw.hasPermissionNode(PermissionNodes.TOWNY_ADMIN_OUTLAW_TELEPORT_BYPASS.getNode()) && !outlaw.hasMode("adminbypass");
 		
+		final Player outlawPlayer = outlaw.getPlayer();
+		final boolean isSpectator = outlawPlayer != null && outlawPlayer.getGameMode() == GameMode.SPECTATOR;
+
 		// Admins are omitted so towns won't be informed an admin might be spying on them.
-		if (TownySettings.doTownsGetWarnedOnOutlaw() && !hasBypassNode && !CooldownTimerTask.hasCooldown(outlaw.getName(), CooldownType.OUTLAW_WARNING)) {
+		if (!isSpectator && TownySettings.doTownsGetWarnedOnOutlaw() && !hasBypassNode && !CooldownTimerTask.hasCooldown(outlaw.getName(), CooldownType.OUTLAW_WARNING)) {
 			if (TownySettings.getOutlawWarningMessageCooldown() > 0)
 				CooldownTimerTask.addCooldownTimer(outlaw.getName(), CooldownType.OUTLAW_WARNING);
 			TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_outlaw_town_notify", outlaw.getFormattedName()));


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Makes the warning sent when an outlaw enters a town not show up if the outlawed player is in spectator mode.

Closes #7918
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
