### PR TITLE
Potentially fix unloading worlds not being respected by Towny

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyUniverse.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyUniverse.java
@@ -769,6 +769,11 @@ public class TownyUniverse {
 		worlds.putIfAbsent(world.getName().toLowerCase(Locale.ROOT), world);
 	}
 
+	public void unregisterTownyWorld(@NotNull TownyWorld world) {
+		Preconditions.checkNotNull(world, "World cannot be null!");
+		worldUUIDMap.remove(world.getUUID(), world);
+		worlds.remove(world.getName());
+	}
 	public Map<UUID, TownyWorld> getWorldIDMap() {
 		return worldUUIDMap;
 	}
@@ -1141,4 +1146,5 @@ public class TownyUniverse {
 	public Map<String,String> getReplacementNameMap() {
 		return replacementNamesMap;
 	}
+
 }

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyWorldListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyWorldListener.java
@@ -25,6 +25,7 @@ import org.bukkit.event.world.PortalCreateEvent;
 import org.bukkit.event.world.StructureGrowEvent;
 import org.bukkit.event.world.WorldInitEvent;
 import org.bukkit.event.world.WorldLoadEvent;
+import org.bukkit.event.world.WorldUnloadEvent;
 
 public class TownyWorldListener implements Listener {
 	
@@ -39,6 +40,16 @@ public class TownyWorldListener implements Listener {
 	public void onWorldLoad(WorldLoadEvent event) {
 
 		newWorld(event.getWorld());
+	}
+
+	@EventHandler(priority = EventPriority.MONITOR)
+	public void onWorldUnload(WorldUnloadEvent event) {
+		if (event.isCancelled())
+			return;
+		TownyWorld world = TownyUniverse.getInstance().getWorld(event.getWorld().getName());
+		if (world == null)
+			return;
+		TownyUniverse.getInstance().unregisterTownyWorld(world);
 	}
 
 	@EventHandler(priority = EventPriority.NORMAL)


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

A newer dungeon plugin is using the WorldUnloadEvent which we aren't paying any attention to, there was potentially a memory leak with plugins holding onto World references. This branch sought to debug whether this change in towny would lessen the issue on the system in question.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
