### PR TITLE
Fix/plotpreclaim cancel message

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/event/plot/changeowner/PlotPreClaimEvent.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/event/plot/changeowner/PlotPreClaimEvent.java
@@ -2,6 +2,7 @@ package com.palmergames.bukkit.towny.event.plot.changeowner;
 
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.TownBlock;
+import com.palmergames.bukkit.towny.object.Translation;
 import org.bukkit.event.Cancellable;
 
 public class PlotPreClaimEvent extends PlotChangeOwnerEvent implements Cancellable {
@@ -10,6 +11,7 @@ public class PlotPreClaimEvent extends PlotChangeOwnerEvent implements Cancellab
 	
 	public PlotPreClaimEvent(Resident oldResident, Resident newResident, TownBlock townBlock) {
 		super(oldResident, newResident, townBlock);
+		cancelMessage = Translation.of("msg_err_plot_preclaim_disable", townBlock.toString());
 	}
 
 	@Override

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/event/plot/changeowner/PlotPreUnclaimEvent.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/event/plot/changeowner/PlotPreUnclaimEvent.java
@@ -2,6 +2,7 @@ package com.palmergames.bukkit.towny.event.plot.changeowner;
 
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.TownBlock;
+import com.palmergames.bukkit.towny.object.Translation;
 import org.bukkit.event.Cancellable;
 
 public class PlotPreUnclaimEvent extends PlotChangeOwnerEvent implements Cancellable {
@@ -10,6 +11,7 @@ public class PlotPreUnclaimEvent extends PlotChangeOwnerEvent implements Cancell
 	
 	public PlotPreUnclaimEvent(Resident oldResident, Resident newResident, TownBlock townBlock) {
 		super(oldResident, newResident, townBlock);
+		cancelMessage = Translation.of("msg_err_plot_preunclaim_disable", townBlock.toString());
 	}
 
 	@Override

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -759,6 +759,8 @@ msg_err_input_too_long: '&cInput is too long.'
 msg_err_invalid_choice: '&cInvalid choice'
 msg_err_invalid_sub: '&cInvalid sub command.'
 msg_err_command_disable: '&cYou don''t have enough permissions for that command.'
+msg_err_plot_preclaim_disable: "&cYou cannot claim the plot %s right now."
+msg_err_plot_preunclaim_disable: "&cResident cannot unclaim the plot %s right now."
 msg_err_you_dont_have_permission_to_use_colours: "You do not have permission to use colour codes in titles and surnames."
 msg_err_universe_limit: '&cThe universe cannot hold any more towns.'
 msg_err_too_many_npc: '&cToo many npc''s registered.'

--- a/Towny/src/main/resources/lang/ru-RU.yml
+++ b/Towny/src/main/resources/lang/ru-RU.yml
@@ -663,6 +663,8 @@ msg_err_input_too_long: '&cСлишком длинно.'
 msg_err_invalid_choice: '&cНеверный выбор'
 msg_err_invalid_sub: '&cНеверная подкоманда.'
 msg_err_command_disable: '&cУ вас недостаточно прав для этой команды.'
+msg_err_plot_preclaim_disable: "&cВы не можете сейчас занять участок %s."
+msg_err_plot_preunclaim_disable: "&cРезидент не может сейчас освободить участок %s."
 msg_err_you_dont_have_permission_to_use_colours: "У вас нет прав для использования цветовых кодов в 'title' и 'surname'."
 msg_err_universe_limit: '&cМаксимальный предел городов достигнут.'
 msg_err_too_many_npc: '&cСлишком много NPC зарегистрировано.'


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This PR fixes a long-standing issue with `PlotPreClaimEvent` and `PlotPreUnclaimEvent`.  

Previously:  
- If these events were cancelled, no further action occurred, but the player received *Successfully claimed*.  
- This often confused players, since the plot was not actually claimed/unclaimed and no reason was shown.  

Now:  
- Both events are initialized with default cancel messages (`msg_err_plot_preclaim_disable`, `msg_err_plot_preunclaim_disable`).  
- When cancellation occurs without a custom message, the player will see a translated default message.  
- As a result, players always receive clear feedback when a claim/unclaim attempt is blocked.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
https://github.com/TownyAdvanced/Towny/issues/7868

____
- [X] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
