### PR TITLE
Fix /ta nation NAME set capital command not making sure the town in question is part of a nation or in the nation at all.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -2240,11 +2240,12 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 	private static void changeNationOwnership(CommandSender sender, final Nation nation, Town newCapital, boolean admin) throws TownyException {
 
 		Nation newCapitalNation = newCapital.getNationOrNull();
-		if (newCapitalNation == null)
+		if (newCapitalNation == null) {
 			if (admin)
 				newCapital.setNation(nation);
 			else 
 				throw new TownyException(Translatable.of("msg_err_not_same_nation", nation));
+		}
 
 		if (!nation.equals(newCapitalNation))
 			throw new TownyException(Translatable.of("msg_err_not_same_nation", nation));


### PR DESCRIPTION


<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
