### PR TITLE
Stop using Properties to load object files, preserve raw metadata for #7925

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/metadata/DataFieldIO.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/metadata/DataFieldIO.java
@@ -79,7 +79,7 @@ public class DataFieldIO {
 				continue;
 			
 			JsonArray cdfArray = element.getAsJsonArray();
-			if (cdfArray.size() < 2)
+			if (cdfArray.size() < 3)
 				continue;
 			
 			RawDataField rdf = deserializeCDFToRaw(cdfArray);


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
- Adjust DataFieldIO because we always read array.get(2), so the guard must be < 3

For FileMgmt:
- Replaced Properties.load(...) in FileMgmt.loadFileIntoHashMap with a
  simple manual parser:
  * skip blank lines and comments (#…)
  * split on the first '=' (optionally ':' if present)
  * trim the key, but **preserve the value verbatim**
- Values are no longer unescaped; backslashes and quotes are preserved
  exactly as written.
- Behavior for normal scalar values (numbers, booleans, strings without
  escape sequences) is unchanged.
- Still uses UTF-8 for reading.

____
#### New Nodes/Commands/ConfigOptions: 
None


____
#### Relevant Towny Issue ticket:
#7925


____
- [X] I have tested this pull request for defects on a server. 
- It seems to load metadata properly.

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
