### PR TITLE
Add option to make a town's town_level determined by their townblock count, instead of resident count.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -703,6 +703,12 @@ public enum ConfigNodes {
 			"# Requires max_residents_capital_override to be above 0.",
 			"# Uses the greater of max_residents_capital_override and max_residents_per_town."
 	),
+	GTOWN_SETTINGS_TOWN_LEVEL_IS_DETERMINED_BY_TOWNBLOCK_COUNT(
+			"global_town_settings.town_level_is_determined_by_townblock_count_instead_of_resident_count",
+			"false",
+			"",
+			"# When set to true, the town's TownLevel is determined by the number of townblocks the town owns, instead of the number of residents.",
+			"# This setting will have no effect when town_block_ratio is set to 0."),
 	GTOWN_SETTINGS_DISPLAY_TOWNBOARD_ONLOGIN(
 			"global_town_settings.display_board_onlogin",
 			"true",

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -400,6 +400,10 @@ public class TownySettings {
 		return configTownLevel.size();
 	}
 
+	public static boolean isTownLevelDeterminedByTownBlockCount() {
+		return getTownBlockRatio() != 0 && getBoolean(ConfigNodes.GTOWN_SETTINGS_TOWN_LEVEL_IS_DETERMINED_BY_TOWNBLOCK_COUNT);
+	}
+
 	public static NationLevel getNationLevel(int levelNumber) {
 		return configNationLevel.get(levelNumber);
 	}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Town.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Town.java
@@ -1916,9 +1916,10 @@ public class Town extends Government implements TownBlockOwner {
 	 * @return Current TownLevel number.
 	 */
 	public int getLevelNumber() {
+		int modifier = TownySettings.isTownLevelDeterminedByTownBlockCount() ? getNumTownBlocks() : getNumResidents();
 		int townLevelNumber = getManualTownLevel() > -1
 				? Math.min(getManualTownLevel(), TownySettings.getTownLevelMax())
-				: TownySettings.getTownLevelWhichIsNotManuallySet(getNumResidents(), this);
+				: TownySettings.getTownLevelWhichIsNotManuallySet(modifier, this);
 
 		TownCalculateTownLevelNumberEvent tctle = new TownCalculateTownLevelNumberEvent(this, townLevelNumber);
 		BukkitTools.fireEvent(tctle);


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

Adds a setting in the config to make a town's town_level's index based off of the town's townblock count instead of the resident count.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
```
  - New Config Option: global_town_settings.town_level_is_determined_by_townblock_count_instead_of_resident_count
    - Default: false
    - When set to true, the town's TownLevel is determined by the number of townblocks the town owns, instead of the number of residents.
    - This setting will have no effect when town_block_ratio is set to 0.
```
____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->



Closes #7947
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
