### PR TITLE
Fix formatting for listing resident modes

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/resident/mode/ResidentModeHandler.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/resident/mode/ResidentModeHandler.java
@@ -144,7 +144,7 @@ public class ResidentModeHandler {
 			}
 	
 		if (notify && !getModes(resident).isEmpty())
-			TownyMessaging.sendMsg(resident, Translatable.of("msg_modes_set").append(StringMgmt.join(getResidentModesNames(resident), ",")));
+			TownyMessaging.sendMsg(resident, Translatable.of("msg_modes_set").append(StringMgmt.join(getResidentModesNames(resident), ", ")));
 	}
 
 	/**
@@ -201,7 +201,7 @@ public class ResidentModeHandler {
 		mode.toggle(resident);
 
 		if (notify)
-			TownyMessaging.sendMsg(resident, Translatable.of("msg_modes_set").append(StringMgmt.join(getResidentModesNames(resident), ",")));
+			TownyMessaging.sendMsg(resident, Translatable.of("msg_modes_set").append(StringMgmt.join(getResidentModesNames(resident), ", ")));
 	}
 
 	/**


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This PR fixes the resident mode names shown to the player in a list to now be separated by a comma and a space, instead of just a comma.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
