### PR TITLE
Improve method for preventing saturation loss in towns

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -71,6 +71,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
+import org.bukkit.event.entity.EntityExhaustionEvent;
 import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerArmorStandManipulateEvent;
@@ -925,6 +926,21 @@ public class TownyPlayerListener implements Listener {
 			}
 		}	
 	}
+	
+	@EventHandler
+	public void onEntityExhaustion(EntityExhaustionEvent event) {
+		// Stop player exhaustion if criteria is met to prevent saturation loss
+		Player player = (Player) event.getEntity();
+		Town playersTown = TownyAPI.getInstance().getTown(player);
+		TownBlock tbAtPlayer = TownyAPI.getInstance().getTownBlock(player);
+		if (tbAtPlayer == null)
+			return;
+		Town townAtPlayer = tbAtPlayer.getTownOrNull();
+		if (!TownySettings.preventSaturationLoss() && townAtPlayer != null && !townAtPlayer.hasActiveWar() && CombatUtil.isAlly(townAtPlayer, playersTown) && !tbAtPlayer.getType().equals(TownBlockType.ARENA)) {
+			return;
+		}
+		event.setCancelled(true);
+	} 
 
 	/*
 	* PlayerMoveEvent that can fire the PlayerChangePlotEvent

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/HealthRegenTimerTask.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/HealthRegenTimerTask.java
@@ -78,10 +78,6 @@ public class HealthRegenTimerTask extends TownyTimerTask {
 	}
 
 	private void evaluateHealth(Player player) {
-		// When enabled, keep saturation above zero while in town, preventing food level loss.
-		if (TownySettings.preventSaturationLoss() && player.getSaturation() != 1F)
-			player.setSaturation(1F);
-
 		// Heal 1 HP while in town.
 		final double currentHP = player.getHealth();
 		final double futureHP = currentHP + 1;


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This PR improves the way Towny handles preventing saturation loss in towns. Previously, when you entered your town, you would have your saturation set to 1, and when you left, it would still be at 1, regardless of your saturation level before you  entered your town. This PR cancels the event for changing exhaustion while you are in your town, so your saturation level is not able to decrease, due to your exhaustion not increasing. This means that while you are in, and when you leave your town, your saturation level will remain the same as when you entered your town.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
