### PR TITLE
Reduce SQL queries by adding SQL table versioning

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/SQLSchema.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/SQLSchema.java
@@ -230,7 +230,6 @@ public class SQLSchema {
 		columns.add("`homeblock` mediumtext NOT NULL");
 		columns.add("`spawn` mediumtext NOT NULL");
 		columns.add("`outpostSpawns` mediumtext DEFAULT NULL");
-		columns.add("`jailSpawns` mediumtext DEFAULT NULL");
 		columns.add("`outlaws` mediumtext DEFAULT NULL");
 		columns.add("`uuid` VARCHAR(36) DEFAULT NULL");
 		columns.add("`registered` BIGINT DEFAULT NULL");

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/SQLSchema.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/SQLSchema.java
@@ -399,10 +399,8 @@ public class SQLSchema {
 		String update;
 
 		try (Statement s = cntx.createStatement()) {
-			DatabaseMetaData md = cntx.getMetaData();
-			ResultSet rs = md.getColumns(null, null, table, column);
-			if (!rs.next())
-				return;
+			// No need to check if the column exists, just try to drop it.
+			// If it doesn't exist, we get error 1091, which we ignore.
 
 			update = "ALTER TABLE `" + SQLDB_NAME + "`.`" + table + "` DROP COLUMN `" + column + "`";
 
@@ -411,7 +409,7 @@ public class SQLSchema {
 			TownyMessaging.sendDebugMsg("Table " + table + " has dropped the " + column + " column.");
 
 		} catch (SQLException ee) {
-			if (ee.getErrorCode() != MYSQL_DUPLICATE_COLUMN_ERR)
+			if (ee.getErrorCode() != MYSQL_DUPLICATE_COLUMN_ERR && ee.getErrorCode() != 1091)
 				TownyMessaging.sendErrorMsg("Error updating table " + table + ":" + ee.getMessage());
 		}
 	}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -412,25 +412,28 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 	}
 	
 	public enum TownyDBTableType {
-		JAIL("JAILS", "SELECT uuid FROM ", "uuid"),
-		PLOTGROUP("PLOTGROUPS", "SELECT groupID FROM ", "groupID"),
-		DISTRICT("DISTRICTS", "SELECT uuid FROM ", "uuid"),
-		RESIDENT("RESIDENTS", "SELECT name FROM ", "name"),
-		HIBERNATED_RESIDENT("HIBERNATEDRESIDENTS", "", "uuid"),
-		TOWN("TOWNS", "SELECT name FROM ", "name"),
-		NATION("NATIONS", "SELECT name FROM ", "name"),
-		WORLD("WORLDS", "SELECT name FROM ", "name"),
-		TOWNBLOCK("TOWNBLOCKS", "SELECT world,x,z FROM ", "name"),
-		COOLDOWN("COOLDOWNS", "SELECT * FROM ", "key");
+		JAIL("JAILS", 1, "SELECT uuid FROM ", "uuid"),
+		PLOTGROUP("PLOTGROUPS", 1, "SELECT groupID FROM ", "groupID"),
+		DISTRICT("DISTRICTS", 1, "SELECT uuid FROM ", "uuid"),
+		RESIDENT("RESIDENTS", 1, "SELECT name FROM ", "name"),
+		HIBERNATED_RESIDENT("HIBERNATEDRESIDENTS", 1, "", "uuid"),
+		TOWN("TOWNS", 1, "SELECT name FROM ", "name"),
+		NATION("NATIONS", 1, "SELECT name FROM ", "name"),
+		WORLD("WORLDS", 1, "SELECT name FROM ", "name"),
+		TOWNBLOCK("TOWNBLOCKS", 1, "SELECT world,x,z FROM ", "name"),
+		COOLDOWN("COOLDOWNS", 1, "SELECT * FROM ", "key"),
+		VERSIONING("VERSIONING", 1, "SELECT * FROM ", "name");
 		
 		private final String tableName;
+		private final int latestVersion;
 		@SuppressWarnings("unused")
 		private String queryString;
 		@SuppressWarnings("unused")
 		private String primaryKey;
 
-		TownyDBTableType(String tableName, String queryString, String primaryKey) {
+		TownyDBTableType(String tableName, int latestVersion, String queryString, String primaryKey) {
 			this.tableName = tableName;
+			this.latestVersion = latestVersion;
 			this.queryString = queryString;
 			this.primaryKey = primaryKey;
 		}
@@ -438,6 +441,8 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 		public String tableName() {
 			return tableName;
 		}
+
+		public int latestVersion() { return latestVersion; }
 		
 		public String primaryKey() {
 			return primaryKey;

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -1083,29 +1083,35 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 				}
 			}
 			// Load legacy jail spawns into new Jail objects.
-			line = rs.getString("jailSpawns");
-			if (line != null) {
-				String[] jails = line.split(";");
-				for (String spawn : jails) {
-					search = (line.contains("#")) ? "#" : ",";
-					tokens = spawn.split(search);
-					if (tokens.length >= 4)
-						try {
-							Position pos = Position.deserialize(tokens);
-
-							TownBlock tb = universe.getTownBlock(pos.worldCoord());
-							if (tb == null)
-								continue;
-							
-							Jail jail = new Jail(UUID.randomUUID(), town, tb, Collections.singleton(pos));
-							universe.registerJail(jail);
-							town.addJail(jail);
-							tb.setJail(jail);
-							jail.save();
-						} catch (IllegalArgumentException e) {
-							plugin.getLogger().warning("Failed to load a legacy jail spawn location for town " + town.getName() + ": " + e.getMessage());
-						}
+			try {
+				line = rs.getString("jailSpawns");
+				if (line != null) {
+					String[] jails = line.split(";");
+					for (String spawn : jails) {
+						search = (line.contains("#")) ? "#" : ",";
+						tokens = spawn.split(search);
+						if (tokens.length >= 4)
+							try {
+								Position pos = Position.deserialize(tokens);
+	
+								TownBlock tb = universe.getTownBlock(pos.worldCoord());
+								if (tb == null)
+									continue;
+								
+								Jail jail = new Jail(UUID.randomUUID(), town, tb, Collections.singleton(pos));
+								universe.registerJail(jail);
+								town.addJail(jail);
+								tb.setJail(jail);
+								jail.save();
+							} catch (IllegalArgumentException e) {
+								plugin.getLogger().warning("Failed to load a legacy jail spawn location for town " + town.getName() + ": " + e.getMessage());
+							}
+					}
 				}
+			} catch (SQLException e) {
+				// Ignore error if the column doesn't exist.
+				if (!e.getMessage().equals("Column 'jailSpawns' not found."))
+					throw e;
 			}
 			line = rs.getString("outlaws");
 			if (line != null) {


### PR DESCRIPTION
#### Description: 
An SQL query is ran for every initTable + updateTable column which comes out to 173 queries ran on every startup & reload, these queries are ran on the main thread which isn't good when reloading (wish I had the time to make the reload async) or when your MySQL database setup is less than ideal (remote, underpowered/high usage/slow).

This PR stops the "CREATE TABLE" & "ALTER TABLE" queries from running after the DB has been created and up-to-date, if the DB table version isn't up-to-date then any new alter table queries are ran.

Tested this with remote DB, before was 52780ms (caused the server to crash when using the reload command) and after is 4877ms (server no longer crashes on reload just lags the server a little bit).
Tested this with local DB, before was 717ms and after is 307ms.

_Another way one could go about this, instead of implementing per-table versions you could just run the create table & alter table queries (initTable/updateTable) when the plugin version changes (based on version.last_run_version) or it's the first time using database mysql type. But I don't think the SQL schema changes as much as the plugin updates, eliminating any unnecessary SQL queries._

____
#### New Nodes/Commands/ConfigOptions: 
N/A


____
#### Relevant Towny Issue ticket:
Fix #7959 

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
