### PR TITLE
Add prior location to SuccessfulTownyTeleportEvent

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/event/teleport/SuccessfulTownyTeleportEvent.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/event/teleport/SuccessfulTownyTeleportEvent.java
@@ -19,13 +19,15 @@ public class SuccessfulTownyTeleportEvent extends Event {
 	private static final HandlerList handlers = new HandlerList();
 	private final Resident resident;
 	private final Location teleportLocation;
+	private final Location priorLocation;
 	private final double teleportCost;
 
-	public SuccessfulTownyTeleportEvent(Resident resident, Location loc, double cost) {
+	public SuccessfulTownyTeleportEvent(Resident resident, Location loc, double cost, Location priorLocation) {
 		super(!Bukkit.isPrimaryThread());
 		this.resident = resident;
 		this.teleportLocation = loc;
 		this.teleportCost = cost;
+		this.priorLocation = priorLocation;
 	}
 
 	@NotNull
@@ -45,6 +47,11 @@ public class SuccessfulTownyTeleportEvent extends Event {
 	public Location getTeleportLocation() {
 		return teleportLocation;
 	}
+	
+	/**
+	 * @return The location the player was at prior to being teleported.
+	 */
+	public Location getPriorLocation() { return priorLocation; }
 
 	/**
 	 * @return The price that the player paid to teleport.

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/TeleportWarmupTimerTask.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/TeleportWarmupTimerTask.java
@@ -69,9 +69,10 @@ public class TeleportWarmupTimerTask extends TownyTimerTask {
 				// Teleporting a player can cause the chunk to unload too fast, abandoning pets.
 				SpawnUtil.addAndRemoveChunkTicket(WorldCoord.parseWorldCoord(player.getLocation()));
 
+				final Location prior = player.getLocation();
 				player.teleportAsync(request.destinationLocation(), TeleportCause.COMMAND).thenAccept(successfulTeleport -> {
 					if (successfulTeleport)
-						BukkitTools.fireEvent(new SuccessfulTownyTeleportEvent(resident, request.destinationLocation(), request.teleportCost()));
+						BukkitTools.fireEvent(new SuccessfulTownyTeleportEvent(resident, request.destinationLocation(), request.teleportCost(), prior));
 				});
 
 				if (request.cooldown() > 0)

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/SpawnUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/SpawnUtil.java
@@ -800,9 +800,10 @@ public class SpawnUtil {
 			// Teleporting a player can cause the chunk to unload too fast, abandoning pets.
 			addAndRemoveChunkTicket(WorldCoord.parseWorldCoord(player.getLocation()));
 
+			final Location prior = player.getLocation();
 			player.teleportAsync(spawnLoc, TeleportCause.COMMAND).thenAccept(successfulTeleport -> {
 				if (successfulTeleport)
-					BukkitTools.fireEvent(new SuccessfulTownyTeleportEvent(resident, spawnLoc, cost));
+					BukkitTools.fireEvent(new SuccessfulTownyTeleportEvent(resident, spawnLoc, cost, prior));
 			});
 
 			if (cooldown > 0 && !hasPerm(player, PermissionNodes.TOWNY_SPAWN_ADMIN_NOCOOLDOWN))


### PR DESCRIPTION
#### Description: 
Hi, I'm working on a /back command for my server and noticed this API event doesn't give me the location prior to when someone was teleported which is a must for a /back command. Hence why I am opening this PR to add it.

____
#### New Nodes/Commands/ConfigOptions: 
N/A


____
#### Relevant Towny Issue ticket:
N/A


____
- [ ] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
