### PR TITLE
Format resident last online with relative time

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -18,6 +18,7 @@ import com.palmergames.bukkit.towny.object.TownBlockTypeCache;
 import com.palmergames.bukkit.towny.object.TownBlockTypeHandler;
 import com.palmergames.bukkit.towny.object.TownyObject;
 import com.palmergames.bukkit.towny.object.TownyWorld;
+import com.palmergames.bukkit.towny.object.Translatable;
 import com.palmergames.bukkit.towny.object.Translation;
 import com.palmergames.bukkit.towny.object.Translator;
 import com.palmergames.bukkit.towny.object.metadata.CustomDataField;
@@ -35,6 +36,7 @@ import com.palmergames.bukkit.util.ChatTools;
 import com.palmergames.bukkit.util.Colors;
 import com.palmergames.util.StringMgmt;
 
+import com.palmergames.util.TimeTools;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.event.ClickEvent;
@@ -150,9 +152,11 @@ public class TownyFormatter {
 
 		StatusScreen screen = new StatusScreen(sender);
 		final Translator translator = Translator.locale(sender);
+		
+		final boolean onlineAndVisible = playerIsOnlineAndVisible(resident.getName(), sender);
 
 		// ___[ King Harlus ]___
-		screen.addComponentOf("title", ChatTools.formatTitle(resident.getFormattedName() + (playerIsOnlineAndVisible(resident.getName(), sender) ? translator.of("online2") : "")));
+		screen.addComponentOf("title", ChatTools.formatTitle(resident.getFormattedName() + (onlineAndVisible ? translator.of("online2") : "")));
 
 		// About: Just a humble farmer
 		if (!resident.getAbout().isEmpty())
@@ -163,7 +167,7 @@ public class TownyFormatter {
 		// Registered: Sept 3 2009 | Last Online: March 7 2009
 		screen.addComponentOf("registered", getResidentRegisteredLine(resident, translator));
 		if (!resident.isNPC())
-			screen.addComponentOf("lastonline", getResidentLastOnline(resident, translator));
+			screen.addComponentOf("lastonline", getResidentLastOnline(resident, onlineAndVisible, translator));
 		
 		// Town: Camelot
 		String townLine = colourKeyValue(translator.of("status_town"), (!resident.hasTown() ? translator.of("status_no_town") : resident.getTownOrNull().getFormattedName() + formatPopulationBrackets(resident.getTownOrNull().getResidents().size()) ));
@@ -614,10 +618,18 @@ public class TownyFormatter {
 		return String.format(keyValueFormat, Translation.of("status_format_key_value_key"), key, Translation.of("status_format_key_value_value"), value); 
 	}
 	
+	public static Component colourKeyValue(Component key, Component value) {
+		return Translatable.of("status_format_key_value_key").append(key).append(" ").append(Translatable.of("status_format_key_value_value").append(value)).component();
+	}
+
 	public static String colourKey(String key) {
 		return String.format(keyFormat, Translation.of("status_format_key_value_key"), key); 
 	}
 	
+	public static String colourValue(String value) {
+		return Translation.of("status_format_key_value_value") + value;
+	}
+
 	public static String colourKeyImportant(String key) {
 		return String.format(keyFormat, Translation.of("status_format_key_important"), key);
 	}
@@ -651,11 +663,16 @@ public class TownyFormatter {
 	/**
 	 * Gets the last online line for the Resident StatusScreen.
 	 * @param resident Resident who's status we are getting.
+	 * @param onlineAndVisible Whether the resident is currently visible as being online.  
 	 * @param translator Translator used for lang choice.
-	 * @return String with last online times formatted for use in the StatusScreen. 
+	 * @return Component with last online times formatted for use in the StatusScreen. 
 	 */
-	private static String getResidentLastOnline(Resident resident, Translator translator) {
-		return (sameYear(resident) ? colourKeyValue(translator.of("status_lastonline"), lastOnlineFormat.format(resident.getLastOnline())) : colourKeyValue(translator.of("status_lastonline"), lastOnlineFormatIncludeYear.format(resident.getLastOnline())));
+	private static Component getResidentLastOnline(Resident resident, boolean onlineAndVisible, Translator translator) {
+		final String hoverText = colourValue(sameYear(resident) ? lastOnlineFormat.format(resident.getLastOnline()) : lastOnlineFormatIncludeYear.format(resident.getLastOnline()));
+
+		return colourKeyValue(translator.component(onlineAndVisible ? "status_onlinesince" : "status_lastonline"), TimeTools.formatRelativeTime(resident.getLastOnline()).component(translator.locale())
+			.hoverEvent(HoverEvent.showText(TownyComponents.miniMessage(hoverText)))
+			.clickEvent(ClickEvent.openUrl("https://time.is/" + resident.getLastOnline())));
 	}
 	
 	private static String getResidentJoinedTownDate(Resident resident, Translator translator) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Translator.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Translator.java
@@ -38,4 +38,8 @@ public class Translator {
 	public Component component(String key, Object... args) {
 		return Translatable.of(key, args).locale(this.locale).component();
 	}
+	
+	public Locale locale() {
+		return this.locale;
+	}
 }

--- a/Towny/src/main/java/com/palmergames/util/TimeTools.java
+++ b/Towny/src/main/java/com/palmergames/util/TimeTools.java
@@ -1,7 +1,9 @@
 package com.palmergames.util;
 
 import com.palmergames.bukkit.towny.TownySettings;
+import com.palmergames.bukkit.towny.object.Translatable;
 
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 /**
@@ -9,10 +11,11 @@ import java.util.regex.Pattern;
  */
 public class TimeTools {
 
-	private static final long MILLIS_PER_SECOND = 1000L;
-	private static final long MILLIS_PER_MINUTE = MILLIS_PER_SECOND * 60L;
-	private static final long MILLIS_PER_HOUR = MILLIS_PER_MINUTE * 60L;
-	private static final long MILLIS_PER_DAY = MILLIS_PER_HOUR * 24L;
+	private static final long MILLIS_PER_SECOND = TimeUnit.SECONDS.toMillis(1);
+	private static final long MILLIS_PER_MINUTE = TimeUnit.MINUTES.toMillis(1);
+	private static final long MILLIS_PER_HOUR = TimeUnit.HOURS.toMillis(1);
+	private static final long MILLIS_PER_DAY = TimeUnit.DAYS.toMillis(1);
+	private static final long MILLIS_PER_YEAR = TimeUnit.DAYS.toMillis(365);
 
 	/**
 	 * This will parse a time string such as 2d30m to an equivalent amount of
@@ -113,5 +116,34 @@ public class TimeTools {
 
 	public static long getTimeInMillisXDaysAgo(int days) {
 		return System.currentTimeMillis() - (MILLIS_PER_DAY * days); 
+	}
+	
+	public static Translatable formatRelativeTime(final long unixMs) {
+		final long now = System.currentTimeMillis();
+
+		if (unixMs > now)
+			return Translatable.of("time-future");
+
+		final long diff = now - unixMs;
+
+		if (diff < MILLIS_PER_SECOND) {
+			return Translatable.of("time-just-now");
+		} else if (diff < 2 * MILLIS_PER_MINUTE) {
+			return Translatable.of("time-a-minute-ago");
+		} else if (diff < 60 * MILLIS_PER_MINUTE) {
+			return Translatable.of("time-x-minutes-ago", diff / MILLIS_PER_MINUTE);
+		} else if (diff < 2 * MILLIS_PER_HOUR) {
+			return Translatable.of("time-an-hour-ago");
+		} else if (diff < 24 * MILLIS_PER_HOUR) {
+			return Translatable.of("time-x-hours-ago", diff / MILLIS_PER_HOUR);
+		} else if (diff < 48 * MILLIS_PER_HOUR) {
+			return Translatable.of("time-yesterday");
+		} else if (diff < MILLIS_PER_YEAR) {
+			return Translatable.of("time-x-days-ago", diff / MILLIS_PER_DAY);
+		} else if (diff < 2 * MILLIS_PER_YEAR) {
+			return Translatable.of("time-a-year-ago");
+		} else {
+			return Translatable.of("time-x-years-ago", diff / MILLIS_PER_YEAR);
+		}
 	}
 }

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -2656,3 +2656,17 @@ status_world_jailing: "Jailing: "
 
 msg_version_build_info: "<dark_green>Build Information: <green>%s</green> on branch <green>%s<green>."
 msg_version_build_info_failed: "<red>Could not retrieve build information for this version."
+
+time-future: "in the future"
+time-just-now: "just now"
+time-a-minute-ago: "a minute ago"
+time-x-minutes-ago: "%d minutes ago"
+time-an-hour-ago: "an hour ago"
+time-x-hours-ago: "%d hours ago"
+time-yesterday: "yesterday"
+time-x-days-ago: "%d days ago"
+time-a-year-ago: "a year ago"
+time-x-years-ago: "%d years ago"
+
+# Shown instead of status_lastonline if the player is currently online
+status_onlinesince: "Online Since:"


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Rather than showing the full time on the resident status screen and having players deal with timezones, we can show the relative time.

<img width="1141" height="55" alt="image" src="https://github.com/user-attachments/assets/59e4c2f0-f302-4a0b-9582-0f51a4503b6f" />

thoughts:
- Should we still show the absolute time if someone has been offline for a longer period of time (> 1 year)?
- Should we show the server's UTC offset in the hover text? it can already be calculated manually by comparing the current time to the displayed time after logging in.

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
