### PR TITLE
Revert change to potion protection handling

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
@@ -310,8 +310,11 @@ public class TownyEntityListener implements Listener {
 		if (!hasDetrimentalEffects(potion.getEffects()))
 			return;
 		
-		if (discardSplashPotion(potion))
-			event.setCancelled(true);
+		for (final LivingEntity defender : event.getAffectedEntities()) {
+			if (CombatUtil.preventDamageCall(potion, defender, DamageCause.MAGIC)) {
+				event.setIntensity(defender, -1.0);
+			}
+		}
 	}
 
 	/**
@@ -1005,31 +1008,6 @@ public class TownyEntityListener implements Listener {
 				final WorldCoord current = WorldCoord.parseWorldCoord(effectCloud.getWorld().getName(), x, z);
 				final TownBlock townBlock = current.getTownBlockOrNull();
 				
-				if (townyWorld != null && CombatUtil.preventPvP(townyWorld, townBlock))
-					return true;
-				
-				lastChecked = current;
-			}
-		}
-		
-		return false;
-	}
-
-	@ApiStatus.Internal
-	private static boolean discardSplashPotion(ThrownPotion potion) {
-		final TownyWorld townyWorld = TownyAPI.getInstance().getTownyWorld(potion.getWorld());
-		final Location loc = potion.getLocation();
-		int radius = 4;
-		WorldCoord lastChecked = null;
-
-		for (int x = loc.getBlockX() - radius; x < loc.getBlockX() + radius; x++ ) {
-			for (int z = loc.getBlockZ() - radius; z < loc.getBlockZ() + radius; z++ ) {
-				if (lastChecked != null && lastChecked.getX() == Coord.toCell(x) && lastChecked.getZ() == Coord.toCell(z))
-					continue;
-
-				final WorldCoord current = WorldCoord.parseWorldCoord(potion.getWorld().getName(), x, z);
-				final TownBlock townBlock = current.getTownBlockOrNull();
-
 				if (townyWorld != null && CombatUtil.preventPvP(townyWorld, townBlock))
 					return true;
 				


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Reverts a change to splash potions that caused them to be completely discarded near non pvp zones, rather than simply not applying effects to protected entities.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
