### PR TITLE
Future proof minecraft version parsing

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/MinecraftVersion.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/MinecraftVersion.java
@@ -21,6 +21,6 @@ public class MinecraftVersion {
 	public static final Version MINECRAFT_1_21_5 = Version.fromString("1.21.5");
 	public static final Version MINECRAFT_1_21_9 = Version.fromString("1.21.9");
 	
-	public static final Version CURRENT_VERSION = Version.fromString(Bukkit.getBukkitVersion());
+	public static final Version CURRENT_VERSION = Version.fromString(Bukkit.getMinecraftVersion());
 	public static final Version OLDEST_VERSION_SUPPORTED = MINECRAFT_1_19_1;
 }


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
The MinecraftVersion class currently parses the minecraft version from the bukkit version ("1.21.10-R0.1-SNAPSHOT"), which works fine and will likely continue working fine. Regardless, this PR changes it to directly get the minecraft version ("1.21.10") so that this will always continue working normally.

The code as it already is will also work fine for the future version format changes mojang is planning on doing next year.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
