### PR TITLE
Remove world references stored inside WorldCoord

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/WorldCoord.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/WorldCoord.java
@@ -19,8 +19,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
 
-import java.lang.ref.Reference;
-import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -34,16 +32,10 @@ import java.util.concurrent.CompletableFuture;
 public class WorldCoord extends Coord {
 
 	private final String worldName;
-	private UUID worldUUID;
-	private Reference<World> worldRef = new WeakReference<>(null);
 
 	public WorldCoord(String worldName, int x, int z) {
 		super(x, z);
 		this.worldName = worldName;
-		
-		World world = Bukkit.getServer().getWorld(worldName);
-		if (world != null)
-			this.worldUUID = world.getUID();
 	}
 
 	public WorldCoord(String worldName, Coord coord) {
@@ -53,7 +45,6 @@ public class WorldCoord extends Coord {
 	public WorldCoord(String worldName, UUID worldUUID, int x, int z) {
 		super(x, z);
 		this.worldName = worldName;
-		this.worldUUID = worldUUID;
 	}
 
 	public WorldCoord(String worldName, UUID worldUUID, Coord coord) {
@@ -63,7 +54,6 @@ public class WorldCoord extends Coord {
 	public WorldCoord(@NotNull World world, int x, int z) {
 		super(x, z);
 		this.worldName = world.getName();
-		this.worldUUID = world.getUID();
 	}
 
 	public WorldCoord(@NotNull World world, Coord coord) {
@@ -73,8 +63,6 @@ public class WorldCoord extends Coord {
 	public WorldCoord(WorldCoord worldCoord) {
 		super(worldCoord);
 		this.worldName = worldCoord.getWorldName();
-		this.worldUUID = worldCoord.worldUUID;
-		this.worldRef = new WeakReference<>(worldCoord.worldRef.get());
 	}
 
 	public String getWorldName() {
@@ -106,7 +94,7 @@ public class WorldCoord extends Coord {
 	}
 
 	public WorldCoord add(int xOffset, int zOffset) {
-		return new WorldCoord(getWorldName(), worldUUID, getX() + xOffset, getZ() + zOffset);
+		return new WorldCoord(getWorldName(), getX() + xOffset, getZ() + zOffset);
 	}
 
 	@Override
@@ -147,16 +135,7 @@ public class WorldCoord extends Coord {
 	 */
 	@Nullable
 	public World getBukkitWorld() {
-		World world = worldRef.get();
-		if (world == null) {
-			world = Bukkit.getServer().getWorld(this.worldName);
-			worldRef = new WeakReference<>(world);
-			
-			if (this.worldUUID == null && world != null)
-				this.worldUUID = world.getUID();
-		}
-		
-		return world;
+		return Bukkit.getServer().getWorld(this.worldName);
 	}
 
 	/**


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
The getBukkitWorld method on WorldCoord isn't called very often, and even when it is, it's at worst just a simple map lookup. Removing the field lets us be a bit nicer to the gc, since WorldCoord is more often used as a throwaway object to look up towns with.

worldUUID is also just completely unused, the constructor parameter is untouched in case it's ever useful in the future.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
