### PR TITLE
Fix the townyperms group command not working with capitalized groups

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -759,7 +759,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 			HelpMenu.TA_TOWNYPERMS.send(sender);
 			return;
 		}
-		if (!TownyPerms.getGroupList().contains(args[0].toLowerCase(Locale.ROOT)))
+		if (!TownyPerms.getGroupList().contains(args[0]))
 			throw new TownyException(Translatable.of("msg_err_group_not_found", args[0]));
 
 		String group = args[0];

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/TownyPerms.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/TownyPerms.java
@@ -849,7 +849,8 @@ public class TownyPerms {
 	}
 	
 	public static List<String> getPermsOfGroup(String group) {
-		return mapHasGroup(group) ? (groupPermsMap.get(group) != null ? groupPermsMap.get(group): new ArrayList<String>()): new ArrayList<String>(); 
+		final List<String> perms = groupPermsMap.get(group);
+		return perms != null ? perms : new ArrayList<>();
 	}
 	
 	private static void buildGroupPermsMap() {


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
The current /ta townyperms group command assumes that groups are always lowercase, causing it to show an error message for otherwise valid groups containing capital letters.

The change in TownyPerms isn't part of the fix, it just looks better.
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
