### PR TITLE
Check the chunk is still wilderness after confirmation in /town new

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -2646,8 +2646,10 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		final String finalName = name;
 		Confirmation.runOnAccept(() -> {
 			try {
-				if (!TownyAPI.getInstance().isWilderness(spawnLocation))
-					throw new TownyException(Translatable.of("msg_already_claimed_1", key));
+				if (!TownyAPI.getInstance().isWilderness(spawnLocation)) {
+					resident.getAccount().deposit(cost, "New town creation cancelled");
+					throw new TownyException(Translatable.of("msg_already_claimed_1", key));	
+				}
 				// Make town.
 				newTown(world, finalName, resident, key, spawnLocation, player, cost);
 				TownyMessaging.sendGlobalMessage(Translatable.of("msg_new_town", player.getName(), StringMgmt.remUnderscore(finalName)));


### PR DESCRIPTION
#### Description: 
Currently, if two players type /t new in the same plot the wilderness check on TownCommand#L2605 passes and no error is thrown

When using confirmations, the chunk is not re-checked for whether it's still wilderness or if it was claimed by the time the player confirms. This allows both players to create their town in the same chunk
____

____
- [ ] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
