### PR TITLE
Fix IndexOutOfBounds exception in /t join

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -3068,10 +3068,12 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		Resident resident = getResidentOrThrow(player);
 		if (resident.hasTown())
 			throw new TownyException(Translatable.of("msg_err_already_res2", "You"));
-
+		if (args.length < 1)
+			throw new TownyException(Translatable.of("msg_usage", "/t join [name]"));
+		
 		Town town = getTownOrThrow(args[0]);
 
-		// Check if town is town is free to join.
+		// Check if town is free to join.
 		if (!town.isOpen())
 			throw new TownyException(Translatable.of("msg_err_not_open", town.getFormattedName()));
 


### PR DESCRIPTION
#### Description: 
Send a "Usage: " error message instead of an IndexOutOfBounds exception when `/t join` is used with no town argument

<img width="362" height="89" alt="image" src="https://github.com/user-attachments/assets/000ca214-40ab-4d3e-baa4-d8ac5789b98d" />


- [ x ] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
