### PR TITLE
Fix SQL loading of forSale, forSalePrice, and forSaleTime

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -999,19 +999,9 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			town.setAllowedToWar(rs.getBoolean("allowedToWar"));
 			town.setJoinedNationAt(rs.getLong("joinedNationAt"));
 			town.setMovedHomeBlockAt(rs.getLong("movedHomeBlockAt"));
-			
-			line = rs.getString("forSale");
-			if (line != null)
-				town.setForSale(Boolean.getBoolean(line));
-			
-			line = rs.getString("forSalePrice");
-			if (line != null)
-				town.setForSalePrice(Double.parseDouble(line));
-
-			line = rs.getString("forSaleTime");
-			if (line != null)
-				town.setForSaleTime(Long.parseLong(line));
-
+			town.setForSale(rs.getBoolean("forSale"));
+			town.setForSalePrice(rs.getDouble("forSalePrice"));
+			town.setForSaleTime(rs.getLong("forSaleTime"));
 			town.setPurchasedBlocks(rs.getInt("purchased"));
 			town.setNationZoneOverride(rs.getInt("nationZoneOverride"));
 			town.setNationZoneEnabled(rs.getBoolean("nationZoneEnabled"));


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
When using MySQL, the `forSale`, `forSalePrice`, and `forSaleTime` fields are loaded incorrectly, making them not persist in-game between server restarts, even though the values are saved to the database. This fix updates the SQL loading to read these fields using their correct data types.
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
