### PR TITLE
Add info/meta node for overriding teleport warmup.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
@@ -542,6 +542,7 @@ public enum PermissionNodes {
 	TOWNY_DEFAULT_MODES("towny_default_modes"),
 	TOWNY_MAX_PLOTS("towny_maxplots"),
 	TOWNY_EXTRA_PLOTS("towny_extraplots"),
+	TOWNY_TELEPORT_WARMUP_SECONDS("towny_teleport_warmup_seconds"),
 	TOWNY_MAX_OUTPOSTS("towny_maxoutposts");
 
 	private String value;

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/SpawnUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/SpawnUtil.java
@@ -798,7 +798,10 @@ public class SpawnUtil {
 		boolean isUsingAdminBypass = resident.hasMode("adminbypass");
 		if (TownyTimerHandler.isTeleportWarmupRunning() && (!hasPerm(player, PermissionNodes.TOWNY_SPAWN_ADMIN_NOWARMUP) || isUsingAdminBypass)) {
 			// Use teleport warmup
-			TownyMessaging.sendMsg(player, Translatable.of("msg_town_spawn_warmup", TownySettings.getTeleportWarmupTime()));
+			int warmupTime = TownyUniverse.getInstance().getPermissionSource().getGroupPermissionIntNode(player.getName(), PermissionNodes.TOWNY_TELEPORT_WARMUP_SECONDS.getNode());
+			if (warmupTime == -1)
+				warmupTime = TownySettings.getTeleportWarmupTime();
+			TownyMessaging.sendMsg(player, Translatable.of("msg_town_spawn_warmup", warmupTime));
 			TeleportWarmupTimerTask.requestTeleport(resident, spawnLoc, cooldown, refundAccount, cost);
 		} else {
 			// Don't use teleport warmup


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->

```
  - New Permission Node: towny_teleport_warmup_seconds.N
    - An info/option node (see
https://github.com/TownyAdvanced/Towny/wiki/Towny-Permission-Nodes#infooptionmeta-nodes)
that overrides a player's warmup time.
    - Replace N with the seconds to use for a warmup time.
    - When not set, the standard warmup time from the Towny config.yml
is used.
```
____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #7950.


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
