### PR TITLE
Fix itemuse list not being used against projectiles which are fired into the air.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/EntityTypeUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/EntityTypeUtil.java
@@ -55,6 +55,8 @@ public class EntityTypeUtil {
 		register(map, "cow", "cow_spawn_egg");
 		register(map, "goat", "goat_spawn_egg");
 		register(map, "mooshroom", "mooshroom_spawn_egg");
+		register(map, "ender_pearl", "ender_pearl");
+		register(map, "wind_charge", "wind_charge");
 		
 		TownyMessaging.sendDebugMsg("[EntityTypeUtil] Attempted: " + attempted + " | Registered: " + map.size());
 


### PR DESCRIPTION




<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Ender pearls and wind charges do not fire PlayerInteractEvents when they are fired into the air, allowing players to get around using item use items which are EPs and wind charges in places they are not allowed to item_use.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
