### PR TITLE
Exclude minimessage colors/tags when validating title & surname length

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/util/NameValidation.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/NameValidation.java
@@ -190,7 +190,7 @@ public class NameValidation {
 	 * Check and perform regex on Titles and Surnames given to residents.
 	 * 
 	 * @param words an Array of strings that make up the title or surname.
-	 * @param countColors whether to count minimessage tags in the string length
+	 * @param countColors whether to count color tags in the string length
 	 * @return String of the valid name result.
 	 * @throws InvalidNameException if the title or surname is invalid.
 	 */	
@@ -199,7 +199,7 @@ public class NameValidation {
 
 		testForConfigBlacklistedName(title);
 		
-		int textLength = countColors ? title.length() : TownyComponents.plain(TownyComponents.miniMessage(title)).length();
+		int textLength = countColors ? title.length() : Colors.strip(title).length();
 
 		if (textLength > TownySettings.getMaxTitleLength())
 			throw new InvalidNameException(Translatable.of("msg_err_name_validation_title_too_long", title));


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Resident titles & surnames support minimessage when displayed in `/resident` status screens. The configured max length is easily reached when using tags such as <rainbow> or multiple colors (<blue>King<red>)

____
- [ x ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
