### PR TITLE
Fix issue where /n set title sends a redundant error

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -2060,10 +2060,8 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 	}
 
 	private static void nationSetSurname(CommandSender sender, Nation nation, Resident resident, String[] split, boolean admin) throws TownyException {
-		// Give the resident a title
-		if (split.length < 2)
-			TownyMessaging.sendErrorMsg(sender, "Eg: /nation set surname bilbo the dwarf ");
-		else
+		// Give the resident a surname
+		if (split.length > 1)
 			resident = getResidentOrThrow(split[1]);
 
 		if (!nation.hasResident(resident)) {
@@ -2089,15 +2087,11 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 			if (admin)
 				TownyMessaging.sendMsg(sender, Translatable.of("msg_clear_title_surname", "Surname", resident.getName()));
 		}
-
-
 	}
 
 	private static void nationSetTitle(CommandSender sender, Nation nation, Resident resident, String[] split, boolean admin) throws TownyException {
 		// Give the resident a title
-		if (split.length < 2)
-			TownyMessaging.sendErrorMsg(sender, "Eg: /nation set title bilbo Jester ");
-		else
+		if (split.length > 1)
 			resident = getResidentOrThrow(split[1]);
 		
 		if (!nation.hasResident(resident)) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -2339,16 +2339,14 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 	private void adminSetSurname(CommandSender sender, String[] split) throws TownyException {
 		checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_SET_SURNAME.getNode());
 		
-		Resident resident = null;
 		// Give the resident a surname
 		if (split.length < 2) {
-			TownyMessaging.sendErrorMsg(sender, "Eg: /townyadmin set surname bilbo Jester");
-			return;
-		} else
-			resident = getResidentOrThrow(split[1]);
+			throw new TownyException("Eg: /townyadmin set surname bilbo Jester");
+		}
+		Resident resident = getResidentOrThrow(split[1]);
 
 		String surname = NameValidation.checkAndFilterTitlesSurnameOrThrow(StringMgmt.remArgs(split, 2));
-		resident.setSurname(surname + " ");
+		resident.setSurname(surname);
 		resident.save();
 
 		if (resident.hasSurname()) {
@@ -2363,16 +2361,14 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 	private void adminSetTitle(CommandSender sender, String[] split) throws TownyException {
 		checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_SET_TITLE.getNode());
 		
-		Resident resident = null;
 		// Give the resident a title
 		if (split.length < 2) {
-			TownyMessaging.sendErrorMsg(sender, "Eg: /townyadmin set title bilbo Jester");
-			return;
-		} else
-			resident = getResidentOrThrow(split[1]);
+			throw new TownyException("Eg: /townyadmin set title bilbo Jester");
+		}
+		Resident resident = getResidentOrThrow(split[1]);
 
 		String title = NameValidation.checkAndFilterTitlesSurnameOrThrow(StringMgmt.remArgs(split, 2));
-		resident.setTitle(title + " ");
+		resident.setTitle(title);
 		resident.save();
 
 		if (resident.hasTitle()) {


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Using `/n set title` would send an error message with the correct usage, but still work, as the resident object was passed down and is the nation leader by default

This PR removes the error message, and also cleans up some other error messages

____
- [ x ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
