### PR TITLE
Add setting manual NationLevels onto Nations.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -411,7 +411,8 @@ public class TownySettings {
 	}
 
 	public static NationLevel getNationLevel(Nation nation) {
-		return getNationLevel(nation.getLevelNumber());
+		int numResidents = getResidentCountForNationLevel(nation.getLevelNumber());
+		return getNationLevel(numResidents);
 	}
 
 	public static NationLevel getNationLevelWithModifier(int modifier) {
@@ -433,6 +434,21 @@ public class TownySettings {
 			if (threshold >= level)
 				return level;
 		return 0;
+	}
+
+	/**
+	 * Gets the number of residents required to look up the NationLevel in the SortedMap.
+	 * @param level The number used to get the key from the keySet array. 
+	 * @return the number of residents which will get us the correct TownLevel in the NationLevel SortedMap.
+	 */
+	public static int getResidentCountForNationLevel(int level) {
+		Integer[] keys = configNationLevel.keySet().toArray(new Integer[] {});
+		// keys is always ordered from biggest to lowest (despite what the javadocs say
+		// about being sorted in Ascending order, this is not the case for a SortedMap.)
+		// We have to get it from lowest to largest.
+		Arrays.sort(keys);
+		level = Math.min(level, keys.length);
+		return keys[level];
 	}
 
 	public static int getNationLevelMax() {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/SQLSchema.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/SQLSchema.java
@@ -321,6 +321,7 @@ public class SQLSchema {
 		columns.add(new ColumnData("conqueredTax", "float NOT NULL"));
 		columns.add(new ColumnData("sanctionedTowns", "mediumtext DEFAULT NULL"));
 		columns.add(new ColumnData("hasActiveWar", "bool NOT NULL DEFAULT '0'"));
+		columns.add(new ColumnData("manualNationLevel", "BIGINT DEFAULT '-1'"));
 		return columns;
 	}
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -1297,6 +1297,10 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 				if (line != null)
 					nation.setActiveWar(Boolean.parseBoolean(line));
 
+				line = keys.get("manualNationLevel");
+				if (line != null)
+					nation.setManualNationLevel(Integer.parseInt(line));
+
 			} catch (Exception e) {
 				plugin.getLogger().log(Level.WARNING, Translation.of("flatfile_err_reading_nation_file_at_line", nation.getName(), line, nation.getName()), e);
 				return false;
@@ -2365,6 +2369,8 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 		list.add("sanctionedTowns=" + StringMgmt.join(nation.getSanctionedTownsForSaving(), "#"));
 		// Active War
 		list.add("hasActiveWar=" + nation.hasActiveWar());
+
+		list.add("manualNationLevel=" + nation.getManualNationLevel());
 		/*
 		 *  Make sure we only save in async
 		 */

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -1385,6 +1385,9 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			if (line != null && !line.isEmpty())
 				nation.setActiveWar(rs.getBoolean("hasActiveWar"));
 
+
+			nation.setManualNationLevel(rs.getInt("manualNationLevel"));
+			
 			return true;
 		} catch (SQLException e) {
 			TownyMessaging.sendErrorMsg("SQL: Load Nation " + name + " SQL Error - " + e.getMessage());
@@ -2497,6 +2500,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			nat_hm.put("maxPercentTaxAmount", nation.getMaxPercentTaxAmount());
 			nat_hm.put("spawnCost", nation.getSpawnCost());
 			nat_hm.put("neutral", nation.isNeutral());
+			nat_hm.put("manualNationLevel", nation.getManualNationLevel());
 			
 			final Position spawnPos = nation.spawnPosition();
 			nat_hm.put("nationSpawn", spawnPos != null ? String.join("#", spawnPos.serialize()) : "");

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Nation.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Nation.java
@@ -49,6 +49,7 @@ public class Nation extends Government {
 	private boolean isTaxPercentage = TownySettings.getNationDefaultTaxPercentage();
 	private double maxPercentTaxAmount = TownySettings.getMaxNationTaxPercentAmount();
 	private double conqueredTax = TownySettings.getDefaultNationConqueredTaxAmount();
+	private int manualNationLevel = -1;
 
 	@ApiStatus.Internal
 	public Nation(String name, UUID uuid) {
@@ -649,7 +650,10 @@ public class Nation extends Government {
 	 */
 	public int getLevelNumber() {
 		int modifier = TownySettings.isNationLevelDeterminedByTownCount() ? getNumTowns() : getNumResidents();
-		int nationLevelNumber = TownySettings.getNationLevelFromGivenInt(modifier);
+		int nationLevelNumber = getManualNationLevel() > -1
+			? Math.min(getManualNationLevel(), TownySettings.getNationLevelMax())
+			: TownySettings.getNationLevelFromGivenInt(modifier);
+		
 		NationCalculateNationLevelNumberEvent ncnle = new NationCalculateNationLevelNumberEvent(this, nationLevelNumber);
 		BukkitTools.fireEvent(ncnle);
 		return ncnle.getNationLevelNumber();
@@ -713,4 +717,11 @@ public class Nation extends Government {
 	}
 
 
+	public int getManualNationLevel() {
+		return manualNationLevel;
+	}
+
+	public void setManualNationLevel(int manualNationLevel) {
+		this.manualNationLevel = manualNationLevel;
+	}
 }

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
@@ -380,6 +380,7 @@ public enum PermissionNodes {
 		TOWNY_COMMAND_TOWNYADMIN_NATION_BANKHISTORY("towny.command.townyadmin.nation.bankhistory"),
 		TOWNY_COMMAND_TOWNYADMIN_NATION_ENEMY("towny.command.townyadmin.nation.enemy"),
 		TOWNY_COMMAND_TOWNYADMIN_NATION_ALLY("towny.command.townyadmin.nation.ally"),
+		TOWNY_COMMAND_TOWNYADMIN_NATION_SETNATIONLEVEL("towny.command.townyadmin.nation.setnationlevel"),
 	
 	TOWNY_COMMAND_TOWNYADMIN_TOGGLE("towny.command.townyadmin.toggle.*"),
 		TOWNY_COMMAND_TOWNYADMIN_TOGGLE_DEVMODE("towny.command.townyadmin.toggle.devmode"),

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -2690,3 +2690,6 @@ msg_err_must_specify_days_to_be_conquered: "You must specify a number of days to
 msg_conquered_status_granted: "You have set %s to have the conquered status for %s days."
 msg_conquered_status_granted_unlimited: "You have set %s to have the conquered status for an indefinite amount of days."
 msg_err_must_specify_on_or_off: "You must specify on or off."
+    
+msg_nation_level_overridden_with: 'The nation %s has had their nationlevel set to %s.'
+msg_nation_level_unset: 'The nation %s has had their manually-set nationlevel unset. Current nationlevel is %s.'

--- a/Towny/src/main/resources/plugin.yml
+++ b/Towny/src/main/resources/plugin.yml
@@ -827,6 +827,7 @@ permissions:
             towny.command.townyadmin.nation.toggle: true
             towny.command.townyadmin.nation.transfer: true
             towny.command.townyadmin.nation.withdraw: true
+            towny.command.townyadmin.nation.setnationlevel: true
 
     towny.command.townyadmin.nation.set.*:
         description: User can access the admin nation set commands.


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This PR adds the option to manually override the nation's level

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
/townyadmin nation setnationlevel
towny.command.townyadmin.nation.setnationlevel

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
