### PR TITLE
Ignore colors in length validation, strip unwanted minimessage tags

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/util/NameValidation.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/NameValidation.java
@@ -8,6 +8,7 @@ import com.palmergames.bukkit.towny.object.Government;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.Translatable;
+import com.palmergames.bukkit.towny.utils.TownyComponents;
 import com.palmergames.util.StringMgmt;
 
 import java.util.Arrays;
@@ -186,10 +187,12 @@ public class NameValidation {
 
 		testForConfigBlacklistedName(title);
 
-		if (title.length() > TownySettings.getMaxTitleLength())
+		int textLength = TownyComponents.USER_SAFE.stripTags(Colors.translateLegacyCharacters(title)).length();
+
+		if (textLength > TownySettings.getMaxTitleLength())
 			throw new InvalidNameException(Translatable.of("msg_err_name_validation_title_too_long", title));
 
-		return title;
+		return TownyComponents.USER_SAFE.stripTags(title);
 	}
 
 	/**


### PR DESCRIPTION
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Clean remake of https://github.com/TownyAdvanced/Towny/pull/8092
When validating title/surname length, ignore color tags

____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
