### PR TITLE
Add /ta resident set for lastonline/registered with timestamp validation

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/HelpMenu.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/HelpMenu.java
@@ -255,6 +255,7 @@ public enum HelpMenu {
 			return new MenuBuilder("townyadmin resident")
 				.add("[resident]", Translatable.of("res_3"))
 				.add("[resident] about clear", Translatable.of("ta_resident_help_4"))
+				.add("[resident] set [lastonline/registered] [timestamp]", Translatable.of("ta_resident_help_5"))
 				.add("[resident] rename [newname]", Translatable.of("ta_resident_help_0"))
 				.add("[resident] friend... [add|remove] [resident]", Translatable.of("ta_resident_help_1"))
 				.add("[resident] friend... [list|clear]", Translatable.of("ta_resident_help_2"))

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -228,11 +228,18 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 	);
 	
 	private static final List<String> adminResidentTabCompletes = Arrays.asList(
+		"about",
 		"rename",
 		"friend",
 		"meta",
 		"unjail",
-		"delete"
+		"delete",
+		"set"
+	);
+
+	private static final List<String> adminResidentSetTabCompletes = Arrays.asList(
+		"lastonline",
+		"registered"
 	);
 	
 	private static final List<String> adminResidentFriendTabCompletes = Arrays.asList(
@@ -429,6 +436,8 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 					case 4:
 						if (args[2].equalsIgnoreCase("about"))
 							return Collections.singletonList("clear");
+						if (args[2].equalsIgnoreCase("set"))
+							return NameUtil.filterByStart(adminResidentSetTabCompletes, args[3]);
 						if (args[2].equalsIgnoreCase("friend"))
 							return NameUtil.filterByStart(adminResidentFriendTabCompletes, args[3]);
 						if (args[2].equalsIgnoreCase("meta"))
@@ -1235,8 +1244,43 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 		case "unjail" -> residentUnjail(sender, resident);
 		case "delete" -> residentDelete(sender, resident);
 		case "about" -> residentAbout(sender, split, resident); 
+		case "set" -> residentSet(sender, split, resident);
 		default -> throw new TownyException(Translatable.of("msg_err_invalid_property", split[1]));
 		}
+	}
+
+	private void residentSet(CommandSender sender, String[] split, Resident resident) throws TownyException {
+		checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_RESIDENT_SET.getNode());
+		if (split.length != 4)
+			throw new TownyException("Eg: /townyadmin resident [resident] set [lastonline/registered] [timestamp]");
+
+		long timestamp = parseVerifiedResidentTimestamp(split[3]);
+		switch (split[2].toLowerCase(Locale.ROOT)) {
+		case "lastonline" -> {
+			resident.setLastOnline(timestamp);
+			TownyMessaging.sendMsg(sender, Translatable.of("msg_resident_lastonline_set", resident.getName(), TownyFormatter.registeredFormat.format(resident.getLastOnline())));
+		}
+		case "registered" -> {
+			resident.setRegistered(timestamp);
+			TownyMessaging.sendMsg(sender, Translatable.of("msg_resident_registered_set", resident.getName(), TownyFormatter.registeredFormat.format(resident.getRegistered())));
+		}
+		default -> throw new TownyException(Translatable.of("msg_err_invalid_property", split[2]));
+		}
+		resident.save();
+	}
+
+	private static long parseVerifiedResidentTimestamp(String input) throws TownyException {
+		long timestamp;
+		try {
+			timestamp = Long.parseLong(input);
+		} catch (NumberFormatException e) {
+			throw new TownyException(Translatable.of("msg_error_must_be_int"));
+		}
+		if (timestamp <= 0)
+			throw new TownyException(Translatable.of("msg_err_amount_must_be_greater_than_zero"));
+		if (timestamp > System.currentTimeMillis())
+			throw new TownyException(Translatable.of("msg_err_time_cannot_be_in_the_future"));
+		return timestamp;
 	}
 
 	private void residentAbout(CommandSender sender, String[] split, Resident resident) throws TownyException {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
@@ -327,6 +327,7 @@ public enum PermissionNodes {
 		TOWNY_COMMAND_TOWNYADMIN_RESIDENT_META("towny.command.townyadmin.resident.meta"),
 		TOWNY_COMMAND_TOWNYADMIN_RESIDENT_UNJAIL("towny.command.townyadmin.resident.unjail"),
 		TOWNY_COMMAND_TOWNYADMIN_RESIDENT_DELETE("towny.command.townyadmin.resident.delete"),
+		TOWNY_COMMAND_TOWNYADMIN_RESIDENT_SET("towny.command.townyadmin.resident.set"),
 		
 	TOWNY_COMMAND_TOWNYADMIN_TOWN("towny.command.townyadmin.town.*"),
 		TOWNY_COMMAND_TOWNYADMIN_TOWN_INVITE("towny.command.townyadmin.town.invite"),

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -390,6 +390,7 @@ ta_resident_help_1: "Add or remove a friend."
 ta_resident_help_2: "List or clear the friend list."
 ta_resident_help_3: "Delete a resident from the database."
 ta_resident_help_4: "Removes a players about line."
+ta_resident_help_5: "Set a resident's last online or registered timestamp."
 
 ta_toggle_help_0: "Turn on/off the ability to use the Wilderness in all worlds."
 ta_toggle_help_1: "Turn on/off the regeneration features in all worlds."
@@ -2454,6 +2455,8 @@ townyadmin_town_set_help_0: "Sets the founding date of a town."
 townyadmin_nation_set_help_0: "Sets the founding date of a nation."
 msg_town_registered_set: "Founding date of town: '%s' set to: '%s'."
 msg_nation_registered_set: "Founding date of nation: '%s' set to: '%s'."
+msg_resident_registered_set: "Registered date of resident: '%s' set to: '%s'."
+msg_resident_lastonline_set: "Last online date of resident: '%s' set to: '%s'."
 msg_err_time_cannot_be_in_the_future: "Specified time cannot be in the future."
 
 # The format used for the /t say and /n say commands.

--- a/Towny/src/main/resources/plugin.yml
+++ b/Towny/src/main/resources/plugin.yml
@@ -734,6 +734,7 @@ permissions:
             towny.command.townyadmin.resident.delete: true
             towny.command.townyadmin.resident.friend: true
             towny.command.townyadmin.resident.unjail: true
+            towny.command.townyadmin.resident.set: true
 
     towny.command.townyadmin.eco.*:
         description: User can access the admin eco commands.


### PR DESCRIPTION

<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
- Add TownyAdmin resident subcommand: /ta resident <resident> set <lastonline|registered> <timestamp>

- Validate timestamp input (numeric, > 0, not in future)

- Persist resident changes after update

- Add tab-completion for set, lastonline, and registered

- Add new permission node towny.command.townyadmin.resident.set

- Register permission in plugin.yml under towny.command.townyadmin.resident.*

- Update TownyAdmin resident help menu and en-US language messages


____
#### New Nodes/Commands/ConfigOptions: 
New Commands
`/ta resident <resident> set <lastonline/registered> <timestamp>`

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [X] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
____

Before change:
<img width="659" height="129" alt="image" src="https://github.com/user-attachments/assets/b37fc7a0-3342-42a5-a4e1-e4b182ca2960" />

Change:
`/ta resident MarshalTactix set lastonline 1771981641282`
<img width="612" height="42" alt="image" src="https://github.com/user-attachments/assets/995f2aec-7e81-4f6e-9395-0102953be57d" />

`/ta resident MarshalTactix set registered 1771981641282`
<img width="617" height="44" alt="image" src="https://github.com/user-attachments/assets/e0be180d-3f33-4c66-8903-2a2a5ad7ff8f" />

After change:
<img width="621" height="130" alt="image" src="https://github.com/user-attachments/assets/78ad461d-6c17-4bad-ab10-62a6e24b7410" />
