### PR TITLE
Lower listener priorities for block events

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
@@ -329,7 +329,7 @@ public class TownyBlockListener implements Listener {
 	/*
 	* Prevents water or lava from going into other people's plots.
 	*/
-	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void onBlockFromToEvent(BlockFromToEvent event) {
 		if (plugin.isError()) {
 			event.setCancelled(true);
@@ -350,7 +350,7 @@ public class TownyBlockListener implements Listener {
 			event.setCancelled(true);
 	}
 
-	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void onBlockDispense(BlockDispenseEvent event) {
 		if (plugin.isError()) {
 			event.setCancelled(true);
@@ -378,7 +378,7 @@ public class TownyBlockListener implements Listener {
 	/*
 	 * Used to prevent bonemeal and moss growing into areas it shouldn't.
 	 */
-	@EventHandler(ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void onBlockFertilize(BlockFertilizeEvent event) {
 		if (plugin.isError()) {
 			event.setCancelled(true);
@@ -396,7 +396,7 @@ public class TownyBlockListener implements Listener {
 	/*
 	 * Used to prevent Sculk Spread.
 	 */
-	@EventHandler(ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void onSculkSpread(BlockSpreadEvent event) {
 		String sourceName = event.getSource().getType().getKey().getKey();
 		if (!sourceName.startsWith("sculk"))
@@ -417,7 +417,7 @@ public class TownyBlockListener implements Listener {
 		}
 	}
 	
-	@EventHandler(ignoreCancelled = true, priority = EventPriority.LOW)
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void onCauldronLevelChange(CauldronLevelChangeEvent event) {
 		if (!(event.getEntity() instanceof Player player))
 			return;


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Lowering the priority improves compatibility with plugins listening before us that have side effects in their listeners.

Removing the possibility of calling setCancelled(false) isn't necessary since we've got ignoreCancelled plastered everywhere (doesn't apply to events like PlayerInteractEvent, but not relevant here)

Supersedes #7828
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
