### PR TITLE
Add option to consider nation enemies as town outlaws

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -657,6 +657,13 @@ public enum ConfigNodes {
 			"somecommandhere,othercommandhere",
 			"",
 			"# Commands an outlawed player cannot use while in the town they are outlawed in."),
+	GTOWN_SETTINGS_CONSIDER_ENEMIES_OUTLAWS(
+		"global_town_settings.consider_enemies_outlaws",
+		"false",
+		"",
+		"# If set to true, when a town is in a nation any player in another nation that",
+		"# the town's nation considers enemies will be considered an outlaw in that town."
+	),
 	GTOWN_SETTINGS_WAR_BLACKLISTED_COMMANDS(
 			"global_town_settings.war_blacklisted_commands",
 			"somecommandhere,othercommandhere",

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -3688,6 +3688,10 @@ public class TownySettings {
 	public static List<String> getOutlawBlacklistedCommands() {
 		return getStrArr(ConfigNodes.GTOWN_SETTINGS_OUTLAW_BLACKLISTED_COMMANDS);
 	}
+	
+	public static boolean areEnemiesOutlaws() {
+		return getBoolean(ConfigNodes.GTOWN_SETTINGS_CONSIDER_ENEMIES_OUTLAWS);
+	}
 
 	public static List<String> getWarBlacklistedCommands() {
 		return getStrArr(ConfigNodes.GTOWN_SETTINGS_WAR_BLACKLISTED_COMMANDS);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Town.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Town.java
@@ -1256,11 +1256,26 @@ public class Town extends Government implements TownBlockOwner {
 	}
 	
 	public boolean hasOutlaw (String name) {
+		if (TownySettings.areEnemiesOutlaws() && nation != null) {
+			for (Nation enemyNation : nation.getEnemies()) {
+				if (enemyNation.getResidents().stream().anyMatch(enemy -> enemy.getName().equalsIgnoreCase(name))) {
+					return true;
+				}
+			}
+		}
+		
 		return outlaws.stream().anyMatch(outlaw -> outlaw.getName().equalsIgnoreCase(name));
 	}
 	
 	public boolean hasOutlaw(Resident outlaw) {
-
+		if (TownySettings.areEnemiesOutlaws() && nation != null) {
+			for (Nation enemyNation : nation.getEnemies()) {
+				if (enemyNation.getResidents().contains(outlaw)) {
+					return true;
+				}
+			}
+		}
+		
 		return outlaws.contains(outlaw);
 	}
 	


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
Adds a configuration option to consider a nation's enemies as outlaws in that nation's towns.

____
#### New Nodes/Commands/ConfigOptions: 
Adds global_town_settings.consider_enemies_outlaws configuration option, default false

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
