### PR TITLE
Improve NameValidation checks for banned names

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/util/NameValidation.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/NameValidation.java
@@ -461,7 +461,6 @@ public class NameValidation {
 	 */
 	static boolean isBannedName(String name) {
 		Map<TownyCommandAddonAPI.CommandType, Map<String, AddonCommand>> addons = TownyCommandAddonAPI.getAddedCommands();
-		bannedNames.addAll(addons.getOrDefault(TownyCommandAddonAPI.CommandType.RESIDENT, Map.of()).keySet());
 		bannedNames.addAll(addons.getOrDefault(TownyCommandAddonAPI.CommandType.TOWN, Map.of()).keySet());
 		bannedNames.addAll(addons.getOrDefault(TownyCommandAddonAPI.CommandType.NATION, Map.of()).keySet());
 		


### PR DESCRIPTION
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Fix NameValidation#isBannedName being a hardcoded set of names. It now imports directly from the Town & Nation command tabcompletes, as well as checking for addon commands from the TownyCommandAddonAPI

Addon commands are added to the list each time the validation method is called. If this is an issue, maybe some kind of listener registry can be added, where the list is updated when addon commands are added/removed

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
