### PR TITLE
Prevent renaming town/nation files when name is invalid

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyUniverse.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyUniverse.java
@@ -1151,7 +1151,8 @@ public class TownyUniverse {
 		return wildernessMapDataMap;
 	}
 	
-	public Map<String,String> getReplacementNameMap() {
+	@ApiStatus.Internal
+	public Map<String, String> getReplacementNameMap() {
 		return replacementNamesMap;
 	}
 }

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -321,9 +321,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 		List<String> towns = receiveListFromLegacyFile("towns.txt");
 		File[] townFiles = receiveObjectFiles("towns", ".txt");
 
-		record RejectedTown(String name, UUID uuid, File file) {}
-
-		List<RejectedTown> rejectedTowns = new ArrayList<>();
+		List<NameAndId> rejectedTowns = new ArrayList<>();
 		
 		for (File townFile : townFiles) {
 			String fileName = townFile.getName().replace(".txt", "");
@@ -352,7 +350,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 				universe.newTownInternal(nameAndId.name(), nameAndId.uuid());
 			} catch (AlreadyRegisteredException | InvalidNameException e) {
 				// Thrown if the town name does not pass the filters.
-				rejectedTowns.add(new RejectedTown(nameAndId.name(), nameAndId.uuid(), townFile));
+				rejectedTowns.add(nameAndId);
 			}
 		}
 		
@@ -361,21 +359,18 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 			deleteFile(dataFolderPath + File.separator + "towns.txt");
 
 		// Handle rejected town names after all the rest are loaded.
-		for (RejectedTown town : rejectedTowns) {
-			String name = town.name;
+		for (NameAndId town : rejectedTowns) {
+			String name = town.name();
 			String newName = generateReplacementName(true);
 			universe.getReplacementNameMap().put(name, newName);
-			TownyMessaging.sendErrorMsg(String.format("The town %s (%s) tried to load an invalid name, attempting to rename it to %s.", name, town.uuid, newName));
+			TownyMessaging.sendErrorMsg(String.format("The town %s (%s) tried to load an invalid name, attempting to rename it to %s.", name, town.uuid(), newName));
 			try {
-				universe.newTownInternal(newName, town.uuid);
+				universe.newTownInternal(newName, town.uuid());
 			} catch (AlreadyRegisteredException | InvalidNameException e1) {
 				// We really hope this doesn't fail again.
-				plugin.getSLF4JLogger().warn("exception occurred while registering town '{}' ({}) internally", newName, town.uuid, e1);
+				plugin.getSLF4JLogger().warn("exception occurred while registering town '{}' ({}) internally", newName, town.uuid(), e1);
 				return false;
 			}
-			
-			File newFile = new File(town.file.getParent(), newName + ".txt");
-			town.file.renameTo(newFile);
 		}
 
 		return true;
@@ -389,7 +384,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 		List<String> nations = receiveListFromLegacyFile("nations.txt");
 		File[] nationFiles = receiveObjectFiles("nations", ".txt");
 
-		List<File> rejectedNations = new ArrayList<>();
+		List<NameAndId> rejectedNations = new ArrayList<>();
 		
 		for (File nationFile : nationFiles) {
 			String fileName = nationFile.getName().replace(".txt", "");
@@ -418,7 +413,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 				newNation(nameAndId.name(), nameAndId.uuid());
 			} catch (AlreadyRegisteredException | NotRegisteredException e) {
 				// Thrown if the town name does not pass the filters.
-				rejectedNations.add(nationFile);
+				rejectedNations.add(nameAndId);
 			}
 		}
 		
@@ -427,20 +422,18 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 			deleteFile(dataFolderPath + File.separator + "nations.txt");
 			
 		// Handle rejected nation names after all the rest are loaded.
-		for (File nation : rejectedNations) {
-			String name = nation.getName().replace(".txt", "");
+		for (NameAndId nation : rejectedNations) {
+			String name = nation.name();
 			String newName = generateReplacementName(false);
 			universe.getReplacementNameMap().put(name, newName);
-			TownyMessaging.sendErrorMsg(String.format("The nation %s tried to load an invalid name, attempting to rename it to %s.", name, newName));
+			TownyMessaging.sendErrorMsg(String.format("The nation %s (%s) tried to load an invalid name, attempting to rename it to %s.", name, nation.uuid(), newName));
 			try {
-				newNation(newName);
+				newNation(newName, nation.uuid());
 			} catch (AlreadyRegisteredException | NotRegisteredException e1) {
 				// we really hope this doesn't fail a second time.
 				plugin.getLogger().log(Level.WARNING, "exception occurred while registering nation '" + newName + "' internally", e1);
 				return false;
 			}
-			File newFile = new File(nation.getParent(), newName + ".txt");
-			nation.renameTo(newFile);
 		}
 		return true;
 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
(only affects flatfile databases)

Spotted by Llmdl, towns & nations files are no longer name-based when using flatfile, so we shouldn't be renaming them back to a name. Nations with bad names were also being re-registered with a different UUID, which is bad.

Added internal to the name replacement map since it is, for now it's still necessary for the rare case someone has a pre-uuid db with a town with an invalid name and is updating to a newer version.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
