### PR TITLE
Remove multi-job aspect from deploy prerelease action.

### DIFF
--- a/.github/workflows/deploy_prerelease.yml
+++ b/.github/workflows/deploy_prerelease.yml
@@ -45,7 +45,6 @@ jobs:
         with:
           body_path: ./staging/prerelease.txt
           prerelease: true
-          draft: true
           token: ${{ github.token }}
           tag_name: ${{ env.CURR_VER }}
           name: ${{ env.CURR_VER }}${{ env.SUPPORTED }}


### PR DESCRIPTION
Let this attempt be a lesson in how many hoops Actions can want you to jump through, environment variables do not persist between jobs. The final straw.