### PR TITLE
Fix maxJailedUnjail method when town has no jailed residents

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/JailUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/JailUtil.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Stream;
 
 import com.palmergames.bukkit.towny.object.Position;
 import org.bukkit.Location;
@@ -316,12 +315,15 @@ public class JailUtil {
 	
 	public static void maxJailedUnjail(Town town) {
 		// Grab jailedResidents list from town
-		Stream<Resident> jailedResidents = town.getJailedResidents().stream();
+		List<Resident> jailedResidents = town.getJailedResidents();
+		// Nothing to do if there are no jailed residents
+		if (jailedResidents.isEmpty())
+			return;
 		Resident unjailedresident = TownySettings.getMaxJailedNewJailBehavior() == 1
 				// Setting 1 gets the jailed player with lowest JailHours
-				? jailedResidents.min(Comparator.comparingInt(Resident::getJailHours)).get()
+				? jailedResidents.stream().min(Comparator.comparingInt(Resident::getJailHours)).get()
 				// Setting 2 gets the jailed player with lowest set Bail
-				: jailedResidents.min(Comparator.comparingDouble(Resident::getJailBailCost)).get();
+				: jailedResidents.stream().min(Comparator.comparingDouble(Resident::getJailBailCost)).get();
 		unJailResident(unjailedresident, UnJailReason.OUT_OF_SPACE);
 	}
 }


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->

#### Description: 
When a town has no jailed residents, .get() on an empty Optional throws a NoSuchElementException. Added an isEmpty() check to fix this.

____
#### New Nodes/Commands/ConfigOptions: -


____
#### Relevant Towny Issue ticket: -


____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
