### PR TITLE
Add optional limits to town and nation ranks uses.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -762,6 +762,12 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 					throw new TownyException(Translatable.of("msg_town_or_nation_level_not_high_enough_for_this_rank", nationWord, rank, nationWord, levelNumber, rankLevelReq));
 			}
 
+			if (!TownyPerms.governmentIsAllowedToAssignRank(rank, nation)) {
+				int uses = TownyPerms.numberOfTimesRankIsUsedByGovernment(rank, nation);
+				int limit = TownyPerms.governmentRankLimit(rank, nation);
+				throw new TownyException(Translatable.of("msg_rank_can_only_be_assigned_x_times", rank, target.getName(), limit, nationWord, uses));
+			}
+
 			BukkitTools.ifCancelledThenThrow(new NationRankAddEvent(nation, rank, target));
 
 			target.addNationRank(rank);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -1898,6 +1898,13 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 				throw new TownyException(Translatable.of("msg_town_or_nation_level_not_high_enough_for_this_rank", townWord, rank, townWord, levelNumber, rankLevelReq));
 		}
 
+		if (!TownyPerms.governmentIsAllowedToAssignRank(rank, target.getTownOrNull())) {
+			Town town = target.getTownOrNull();
+			int uses = TownyPerms.numberOfTimesRankIsUsedByGovernment(rank, town);
+			int limit = TownyPerms.governmentRankLimit(rank, town);
+			throw new TownyException(Translatable.of("msg_rank_can_only_be_assigned_x_times", rank, target.getName(), limit, townWord, uses));
+		}
+
 		BukkitTools.ifCancelledThenThrow(new TownAddResidentRankEvent(target, rank, target.getTownOrNull()));
 
 		target.addTownRank(rank);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/TownyPerms.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/TownyPerms.java
@@ -642,7 +642,7 @@ public class TownyPerms {
 	}
 
 	private static int getRankLimit(List<String> nodes) {
-		for (String node: nodes) {
+		for (String node : nodes) {
 			if (node.startsWith(RANKLIMIT)) {
 				return getIntFromNode(node, RANKLIMIT.length());
 			}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/TownyPerms.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/TownyPerms.java
@@ -604,21 +604,17 @@ public class TownyPerms {
 	 */
 
 	public static boolean governmentIsAllowedToAssignRank(String rank, Government gov) {
-		if (rankIsNotLimitedByNumberOfAssignments(rank, gov))
-			return true;
-		int uses = numberOfTimesRankIsUsedByGovernment(rank, gov);
 		int limit = governmentRankLimit(rank, gov);
+		if (limit == -1) {
+			return true;
+		}
+
+		int uses = numberOfTimesRankIsUsedByGovernment(rank, gov);
 		return uses < limit;
 	}
 
 	public static boolean rankIsNotLimitedByNumberOfAssignments(String rank, Government gov) {
-		if (gov instanceof Town && getTownRanks().contains(rank)) {
-			return getRankLimit(getTownRankPermissions(rank)) == -1;
-		}
-		if (gov instanceof Nation && getNationRanks().contains(rank)) {
-			return getRankLimit(getNationRankPermissions(rank)) == -1;
-		}
-		return false;
+		return governmentRankLimit(rank, gov) == -1;
 	}
 
 	public static int numberOfTimesRankIsUsedByGovernment(String rank, Government gov ) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/TownyPerms.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/TownyPerms.java
@@ -60,8 +60,8 @@ public class TownyPerms {
 	private static Towny plugin;
 	private static final List<String> vitalGroups = Arrays.asList("nomad","towns.default","towns.mayor","towns.ranks","nations.default","nations.king","nations.ranks");
 	private static final HashMap<UUID, String> residentPrefixMap = new HashMap<>();
-	private static final String RANKPRIORITY_PREFIX = "towny.rankpriority.";
 	private static final String RANKLIMIT = "towny.ranklimit.";
+	private static final String RANKPRIORITY_PREFIX = "towny.rankpriority.";
 	private static final String RANKPREFIX_PREFIX = "towny.rankprefix.";
 	private static final String RANK_TOWN_LEVEL_REQUIREMENT_PREFIX = "towny.town_level_requirement.";
 	private static final String RANK_NATION_LEVEL_REQUIREMENT_PREFIX = "towny.nation_level_requirement.";
@@ -600,52 +600,6 @@ public class TownyPerms {
 	}
 
 	/*
-	 * Resident Primary Rank / Rank Prefix 
-	 */
-
-	public static String getResidentPrimaryRankPrefix(Resident resident) {
-		return residentPrefixMap.getOrDefault(resident.getUUID(), setResidentPrimaryRankPrefix(resident));
-	}
-
-	private static String setResidentPrimaryRankPrefix(Resident resident) {
-		String prefix = getPrimaryRankPrefix(resident);
-		residentPrefixMap.put(resident.getUUID(), prefix);
-		return prefix;
-	}
-
-
-	private static String getPrimaryRankPrefix(Resident resident) {
-		String prefix = getHighestPriorityRankPrefix(resident);
-		return prefix == null ? "" : prefix;
-	}
-
-	@Nullable
-	private static String getHighestPriorityRankPrefix(Resident resident) {
-		if (resident.hasNation() && !resident.getNationRanks().isEmpty()) {
-			String rank = getHighestPriorityRank(resident, resident.getNationRanks(), r -> getNationRankPermissions(r));
-			String prefix = getPrefixFromRank(getNationRankPermissions(rank));
-			if (prefix != null)
-				return prefix;
-		}
-
-		if (resident.hasTown() && !resident.getTownRanks().isEmpty()) {
-			String rank = getHighestPriorityRank(resident, resident.getTownRanks(), r -> getTownRankPermissions(r));
-			String prefix = getPrefixFromRank(getTownRankPermissions(rank));
-			if (prefix != null)
-				return prefix;
-		}
-
-		return null;
-	}
-
-	private static String getPrefixFromRank(List<String> nodes) {
-		for (String node : nodes)
-			if (node.startsWith(RANKPREFIX_PREFIX))
-				return node.substring(RANKPREFIX_PREFIX.length());
-		return null;
-	}
-
-	/*
 	 * Rank Limits
 	 */
 
@@ -694,6 +648,52 @@ public class TownyPerms {
 			}
 		}
 		return -1;
+	}
+
+	/*
+	 * Resident Primary Rank / Rank Prefix 
+	 */
+
+	public static String getResidentPrimaryRankPrefix(Resident resident) {
+		return residentPrefixMap.getOrDefault(resident.getUUID(), setResidentPrimaryRankPrefix(resident));
+	}
+
+	private static String setResidentPrimaryRankPrefix(Resident resident) {
+		String prefix = getPrimaryRankPrefix(resident);
+		residentPrefixMap.put(resident.getUUID(), prefix);
+		return prefix;
+	}
+
+
+	private static String getPrimaryRankPrefix(Resident resident) {
+		String prefix = getHighestPriorityRankPrefix(resident);
+		return prefix == null ? "" : prefix;
+	}
+
+	@Nullable
+	private static String getHighestPriorityRankPrefix(Resident resident) {
+		if (resident.hasNation() && !resident.getNationRanks().isEmpty()) {
+			String rank = getHighestPriorityRank(resident, resident.getNationRanks(), r -> getNationRankPermissions(r));
+			String prefix = getPrefixFromRank(getNationRankPermissions(rank));
+			if (prefix != null)
+				return prefix;
+		}
+
+		if (resident.hasTown() && !resident.getTownRanks().isEmpty()) {
+			String rank = getHighestPriorityRank(resident, resident.getTownRanks(), r -> getTownRankPermissions(r));
+			String prefix = getPrefixFromRank(getTownRankPermissions(rank));
+			if (prefix != null)
+				return prefix;
+		}
+
+		return null;
+	}
+
+	private static String getPrefixFromRank(List<String> nodes) {
+		for (String node : nodes)
+			if (node.startsWith(RANKPREFIX_PREFIX))
+				return node.substring(RANKPREFIX_PREFIX.length());
+		return null;
 	}
 
 	/*

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/TownyPerms.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/TownyPerms.java
@@ -5,6 +5,7 @@ import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.exceptions.initialization.TownyInitException;
+import com.palmergames.bukkit.towny.object.Government;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
@@ -60,6 +61,7 @@ public class TownyPerms {
 	private static final List<String> vitalGroups = Arrays.asList("nomad","towns.default","towns.mayor","towns.ranks","nations.default","nations.king","nations.ranks");
 	private static final HashMap<UUID, String> residentPrefixMap = new HashMap<>();
 	private static final String RANKPRIORITY_PREFIX = "towny.rankpriority.";
+	private static final String RANKLIMIT = "towny.ranklimit.";
 	private static final String RANKPREFIX_PREFIX = "towny.rankprefix.";
 	private static final String RANK_TOWN_LEVEL_REQUIREMENT_PREFIX = "towny.town_level_requirement.";
 	private static final String RANK_NATION_LEVEL_REQUIREMENT_PREFIX = "towny.nation_level_requirement.";
@@ -643,6 +645,61 @@ public class TownyPerms {
 		return null;
 	}
 
+	/*
+	 * Rank Limits
+	 */
+
+	public static boolean governmentIsAllowedToAssignRank(String rank, Government gov) {
+		if (rankIsNotLimitedByNumberOfAssignments(rank, gov))
+			return true;
+		int uses = numberOfTimesRankIsUsedByGovernment(rank, gov);
+		int limit = governmentRankLimit(rank, gov);
+		return uses < limit;
+	}
+
+	public static boolean rankIsNotLimitedByNumberOfAssignments(String rank, Government gov) {
+		if (gov instanceof Town && getTownRanks().contains(rank)) {
+			return getRankLimit(getTownRankPermissions(rank)) == -1;
+		}
+		if (gov instanceof Nation && getNationRanks().contains(rank)) {
+			return getRankLimit(getNationRankPermissions(rank)) == -1;
+		}
+		return false;
+	}
+
+	public static int numberOfTimesRankIsUsedByGovernment(String rank, Government gov ) {
+		if (gov instanceof Town town && getTownRanks().contains(rank)) {
+			return (int) town.getResidents().stream().filter(res -> res.hasTownRank(rank)).count();
+		}
+		if (gov instanceof Nation nation && getNationRanks().contains(rank)) {
+			return (int) nation.getResidents().stream().filter(res -> res.hasNationRank(rank)).count();
+		}
+		return 0;
+	}
+
+	public static int governmentRankLimit(String rank, Government gov) {
+		if (gov instanceof Town && getTownRanks().contains(rank)) {
+			return getRankLimit(getTownRankPermissions(rank));
+		}
+		if (gov instanceof Nation && getNationRanks().contains(rank)) {
+			return getRankLimit(getNationRankPermissions(rank));
+		}
+		return -1;
+	}
+
+	private static int getRankLimit(List<String> nodes) {
+		for (String node: nodes) {
+			if (node.startsWith(RANKLIMIT)) {
+				return getIntFromNode(node, RANKLIMIT.length());
+			}
+		}
+		return -1;
+	}
+
+	/*
+	 * Rank Priorities
+	 */
+
 	public static String getHighestPriorityRank(Resident resident, List<String> ranks, Function<String, List<String>> rankFunction) {
 		Map<String, Integer> rankPriorityMap = new HashMap<>(); 
 		for (String rank : ranks)
@@ -654,7 +711,7 @@ public class TownyPerms {
 		int topValue = 0;
 		for (String node : nodes) {
 			if (node.startsWith(RANKPRIORITY_PREFIX)) {
-				int priorityValue = getNodePriority(node, RANKPRIORITY_PREFIX.length());
+				int priorityValue = getIntFromNode(node, RANKPRIORITY_PREFIX.length());
 				if (topValue >= priorityValue)
 					continue;
 				topValue = priorityValue;
@@ -663,7 +720,7 @@ public class TownyPerms {
 		return topValue;
 	}
 
-	private static int getNodePriority(String node, int length) {
+	private static int getIntFromNode(String node, int length) {
 		try {
 			return Integer.parseInt(node.substring(length));
 		} catch (NumberFormatException ignored) {
@@ -684,14 +741,14 @@ public class TownyPerms {
 	public static int getRankTownLevelReq(String rank) {
 		for (String node : getTownRankPermissions(rank))
 			if (node.startsWith(RANK_TOWN_LEVEL_REQUIREMENT_PREFIX))
-				return getNodePriority(node, RANK_TOWN_LEVEL_REQUIREMENT_PREFIX.length());
+				return getIntFromNode(node, RANK_TOWN_LEVEL_REQUIREMENT_PREFIX.length());
 		return 0;
 	}
 
 	public static int getRankNationLevelReq(String rank) {
 		for (String node : getNationRankPermissions(rank))
 			if (node.startsWith(RANK_NATION_LEVEL_REQUIREMENT_PREFIX))
-				return getNodePriority(node, RANK_NATION_LEVEL_REQUIREMENT_PREFIX.length());
+				return getIntFromNode(node, RANK_NATION_LEVEL_REQUIREMENT_PREFIX.length());
 		return 0;
 	}
 
@@ -896,6 +953,14 @@ public class TownyPerms {
 				"# Ex:                                                                                       #",
 				"#    - towny.rankpriority.100                                                               #",
 				"#    - towny.rankprefix.&a<&2Sheriff&a>                                                     #",
+				"#                                                                                           #",
+				"# The towns.ranks and nations.ranks sections support adding limits to how many times a town #",
+				"# or nation can assign each rank to their residents. This is done using the                 #",
+				"# towny.ranklimit.# node. When added to a rank, with a number replacing pound/hashtag       #",
+				"# symbol, that rank will only be able to be assigned that number of times. In the below     #",
+				"# example the rank will only be able to be used by a town twice.                            #",
+				"# Ex:                                                                                       #",
+				"#    - towny.ranklimit.2                                                                    #",
 				"#                                                                                           #",
 				"# The towns.ranks and nations.ranks sections support requiring their town or nation to have #",
 				"# a minimum town_level or nation_level. This means that you can lock ranks behind a town or #",

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -806,6 +806,7 @@ msg_you_have_given_rank: 'You have granted the %s rank of %s to %s.'
 msg_resident_not_your_town: 'That resident isn''t a member of a town!'
 msg_resident_already_has_rank: '%s already holds this %s rank.'
 msg_town_or_nation_level_not_high_enough_for_this_rank: "Your %s level is not high enough to assign the %s rank. Your %s's Level: %s/%s required."
+msg_rank_can_only_be_assigned_x_times: "You cannot assign the rank of %s to %s because it can only be assigned %s times, your %s has used it %s times."
 msg_you_have_had_rank_taken: 'You have been demoted from the %s rank of %s.'
 msg_you_have_taken_rank_from: 'You have removed the %s rank of %s from %s.'
 msg_resident_doesnt_have_rank: '%s doesn''t hold this %s rank.'


### PR DESCRIPTION


<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->


New towny.ranklimit.# node which can be added to town and nation ranks to limit how many times a town or nation can use the rank.

Only concern is that town and nation merging isn't handling them being over-assigned.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #8035.

____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
