### PR TITLE
NameValidation: Strip dangerous tags, not the allowed ones

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/TownyComponents.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/TownyComponents.java
@@ -33,6 +33,13 @@ public class TownyComponents {
 			.resolvers(getRecentlyAddedTagResolvers())
 			.build())
 		.build();
+
+	public static final MiniMessage STRIP_UNSAFE = MiniMessage.builder()
+			.tags(TagResolver.builder()
+					.resolvers(StandardTags.clickEvent())
+					.resolvers(StandardTags.hoverEvent())
+					.build())
+			.build();
 	
 	public static Component miniMessage(@NotNull String string) {
 		return MiniMessage.miniMessage().deserialize(Colors.translateLegacyCharacters(Colors.translateLegacyHex(string)));

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/TownyComponents.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/TownyComponents.java
@@ -33,13 +33,6 @@ public class TownyComponents {
 			.resolvers(getRecentlyAddedTagResolvers())
 			.build())
 		.build();
-
-	public static final MiniMessage STRIP_UNSAFE = MiniMessage.builder()
-			.tags(TagResolver.builder()
-					.resolvers(StandardTags.clickEvent())
-					.resolvers(StandardTags.hoverEvent())
-					.build())
-			.build();
 	
 	public static Component miniMessage(@NotNull String string) {
 		return MiniMessage.miniMessage().deserialize(Colors.translateLegacyCharacters(Colors.translateLegacyHex(string)));

--- a/Towny/src/main/java/com/palmergames/bukkit/util/NameValidation.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/NameValidation.java
@@ -192,7 +192,7 @@ public class NameValidation {
 		if (textLength > TownySettings.getMaxTitleLength())
 			throw new InvalidNameException(Translatable.of("msg_err_name_validation_title_too_long", title));
 
-		return TownyComponents.USER_SAFE.stripTags(title);
+		return TownyComponents.STRIP_UNSAFE.stripTags(title);
 	}
 
 	/**

--- a/Towny/src/main/java/com/palmergames/bukkit/util/NameValidation.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/NameValidation.java
@@ -192,7 +192,7 @@ public class NameValidation {
 		if (textLength > TownySettings.getMaxTitleLength())
 			throw new InvalidNameException(Translatable.of("msg_err_name_validation_title_too_long", title));
 
-		return TownyComponents.STRIP_UNSAFE.stripTags(title);
+		return title;
 	}
 
 	/**


### PR DESCRIPTION
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Fix nation (and town) titles stripping away allowed tags (colors, decorations, etc.) rather than the disallowed ones.
This happened because: while the tags specified in MiniMessage#Build are the only ones parsed in #deserialize, they are also the only tags removed in #stripTags.

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
