### PR TITLE
Adds option to deny cross world teleportation.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1370,6 +1370,13 @@ public enum ConfigNodes {
 			"# +------------------------------------------------------+ #",
 			"############################################################",
 			""),
+	SPAWNING_REQUIRE_SPAWN_POINT_SAME_WORLD(
+		"spawning.require_spawn_destination_same_world",
+		"false",
+		"",
+		"# When true, using /res, /t, /n spawn or /t outpost will fail when those spawn points are not in the same world as the player.",
+		"# Use this feature to require players use special portals to travel between your server's worlds."
+	),
 	SPAWNING_SAFE_TELEPORT(
 		"spawning.safe_teleport",
 		"false",

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -2140,6 +2140,10 @@ public class TownySettings {
 		return getBoolean(ConfigNodes.SPAWNING_COST_SPAWN_WARNINGS);
 	}
 
+	public static boolean isSpawnCommandsRequireSameWorld() {
+		return getBoolean(ConfigNodes.SPAWNING_REQUIRE_SPAWN_POINT_SAME_WORLD);
+	}
+
 	public static boolean isTaxingDaily() {
 
 		return getBoolean(ConfigNodes.ECO_DAILY_TAXES_ENABLED);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/SpawnUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/SpawnUtil.java
@@ -90,6 +90,11 @@ public class SpawnUtil {
 			notAffordMSG, outpost, spawnType, resident, town, nation);
 
 		getSpawnLoc(player, town, nation, spawnType, outpost, split).thenAccept(spawnLoc -> {
+			if (TownySettings.isSpawnCommandsRequireSameWorld() && !spawnLoc.getWorld().getName().equalsIgnoreCase(player.getWorld().getName())) {
+				TownyMessaging.sendErrorMsg(player, Translatable.of("msg_err_world_not_same_cant_teleport"));
+				return;
+			}
+
 			if (!spawnLoc.isWorldLoaded()) {
 				TownyMessaging.sendErrorMsg(player, Translatable.of("msg_err_world_not_loaded"));
 				return;

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -2430,6 +2430,9 @@ msg_err_your_cannot_overclaim_for_another: "You cannot overclaim again for anoth
 # Generic error message for when a world isn't loaded
 msg_err_world_not_loaded: "<red>World is not loaded."
 
+# Message shown when denying a cross world teleport
+msg_err_world_not_same_cant_teleport: "<red>You cannot teleport to a different world using this command."
+
 # Message shown when a mayor toggles a plots taxed status.
 msg_changed_plot_taxed: '&cThis plot has had its taxed status set to %s.'
 msg_changed_plotgroup_taxed: '&cThis plotgroup has had its taxed status set to %s.'


### PR DESCRIPTION



<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
```
  - New Config Option: spawning.require_spawn_destination_same_world
    - Default: false
    - When true, using /res, /t, /n spawn or /t outpost will fail when
those spawn points are not in the same world as the player.
    - Use this feature to require players use special portals to travel
between your server's worlds.
```

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #8162

____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
