### PR TITLE
Fix unclaiming near to outposts while min_adjacent_claims feature is in use.

### DIFF
--- a/Towny/pom.xml
+++ b/Towny/pom.xml
@@ -13,7 +13,7 @@
 
     <artifactId>towny</artifactId>
     <packaging>jar</packaging>
-    <version>0.102.0.14</version>
+    <version>0.102.0.15</version>
 
     <licenses>
         <license>

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/hooks/TownyPlaceholderExpansion.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/hooks/TownyPlaceholderExpansion.java
@@ -763,6 +763,7 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 		String value = switch(identifier) {
 		case "town_balance" -> getMoney(town.getAccount().getCachedBalance()); // %townyadvanced_top_town_balance_n%
 		case "town_residents" -> String.valueOf(town.getNumResidents());       // %townyadvanced_top_town_residents_n%
+		case "town_residents_and_open" -> String.valueOf(town.getNumResidents());       // %townyadvanced_top_town_residents_and_open_n%
 		case "town_land" -> String.valueOf(town.getNumTownBlocks());           // %townyadvanced_top_town_land_n%
 		default -> "";
 		};
@@ -775,6 +776,7 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 		ComparatorType type = switch (identifier) {
 		case "town_balance" -> ComparatorType.BALANCE;     // %townyadvanced_top_town_balance_n%
 		case "town_residents" -> ComparatorType.RESIDENTS; // %townyadvanced_top_town_residents_n%
+		case "town_residents_and_open" -> ComparatorType.OPEN; // %townyadvanced_top_town_residents_and_open_n%
 		case "town_land" -> ComparatorType.TOWNBLOCKS;     // %townyadvanced_top_town_land_n%
 		default -> null;
 		};

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/ProximityUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/ProximityUtil.java
@@ -174,6 +174,10 @@ public class ProximityUtil {
 	}
 	
 	public static void testAdjacentUnclaimsRulesOrThrow(WorldCoord townBlockToUnclaim, Town town, int minAdjacentBlocks) throws TownyException {
+		// When there is an adjacent outpost we let them unclaim.
+		if (numAdjacentOutposts(town, townBlockToUnclaim) > 0)
+			return;
+
 		// Prevent unclaiming land that would reduce the number of adjacent claims of neighbouring plots below the threshold.
 		if (minAdjacentBlocks > 0 && townHasClaimedEnoughLandToBeRestrictedByAdjacentClaims(town, minAdjacentBlocks)) {
 			WorldCoord firstWorldCoord = townBlockToUnclaim;
@@ -181,8 +185,8 @@ public class ProximityUtil {
 				if (wc.isWilderness() || !wc.hasTown(town))
 					continue;
 				int numAdjacent = numAdjacentTownOwnedTownBlocks(town, wc);
-				// The number of adjacent TBs is not enough and there is not a nearby outpost.
-				if (numAdjacent - 1 < minAdjacentBlocks && numAdjacentOutposts(town, wc) == 0)
+				// The number of adjacent TBs is not enough.
+				if (numAdjacent - 1 < minAdjacentBlocks)
 					throw new TownyException(Translatable.of("msg_err_cannot_unclaim_not_enough_adjacent_claims", wc.getX(), wc.getZ(), numAdjacent));
 			}
 		}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/ProximityUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/ProximityUtil.java
@@ -108,7 +108,7 @@ public class ProximityUtil {
 			// Only consider the first worldCoord, larger selection-claims will automatically "bubble" anyways.
 			int numAdjacent = numAdjacentTownOwnedTownBlocks(town, townBlockToClaim);
 			// The number of adjacent TBs is not enough and there is not a nearby outpost.
-			if (numAdjacent < minAdjacentBlocks && numAdjacentOutposts(town, townBlockToClaim) == 0)
+			if (numAdjacent < minAdjacentBlocks && numAdjacentOutposts(town, townBlockToClaim, true) == 0)
 				throw new TownyException(Translatable.of("msg_min_adjacent_blocks", minAdjacentBlocks, numAdjacent));
 		}
 	}
@@ -126,8 +126,14 @@ public class ProximityUtil {
 			.count();
 	}
 
-	private static int numAdjacentOutposts(Town town, WorldCoord worldCoord) {
-		return (int) worldCoord.getCardinallyAdjacentWorldCoords(true).stream()
+	private static int numAdjacentTownOwnedTownBlocksIgnoring(Town town, WorldCoord worldCoord, WorldCoord ignoredWorldCoord, boolean useCardinal) {
+		return (int) worldCoord.getCardinallyAdjacentWorldCoords(useCardinal).stream()
+			.filter(wc -> wc.hasTown(town) && !wc.equals(ignoredWorldCoord))
+			.count();
+	}
+
+	private static int numAdjacentOutposts(Town town, WorldCoord worldCoord, boolean useCardinal) {
+		return (int) worldCoord.getCardinallyAdjacentWorldCoords(useCardinal).stream()
 			.filter(wc -> wc.hasTown(town))
 			.map(WorldCoord::getTownBlockOrNull)
 			.filter(Objects::nonNull)
@@ -174,20 +180,30 @@ public class ProximityUtil {
 	}
 	
 	public static void testAdjacentUnclaimsRulesOrThrow(WorldCoord townBlockToUnclaim, Town town, int minAdjacentBlocks) throws TownyException {
-		// When there is an adjacent outpost we let them unclaim.
-		if (numAdjacentOutposts(town, townBlockToUnclaim) > 0)
-			return;
-
 		// Prevent unclaiming land that would reduce the number of adjacent claims of neighbouring plots below the threshold.
 		if (minAdjacentBlocks > 0 && townHasClaimedEnoughLandToBeRestrictedByAdjacentClaims(town, minAdjacentBlocks)) {
+
+			// Outposts cannot be unclaimed when there are any connected townblocks.
+			if (townBlockToUnclaim.getTownBlockOrNull().isOutpost() && numAdjacentTownOwnedTownBlocks(town, townBlockToUnclaim) > 0)
+				throw new TownyException(Translatable.of("msg_err_cannot_unclaim_outpost_with_adjacent_claims"));
+
 			WorldCoord firstWorldCoord = townBlockToUnclaim;
 			for (WorldCoord wc : firstWorldCoord.getCardinallyAdjacentWorldCoords(true)) {
-				if (wc.isWilderness() || !wc.hasTown(town))
+				if (wc.isWilderness() || !wc.hasTown(town) || wc.getTownBlockOrNull().isOutpost())
 					continue;
-				int numAdjacent = numAdjacentTownOwnedTownBlocks(town, wc);
+
+				// The wc could become an island when tested in the NESW directions. This var used to prevent unclaiming the centre of an + shape of claims.
+				int numAdjacentNonCardinal = numAdjacentTownOwnedTownBlocksIgnoring(town, wc, townBlockToUnclaim, false);
+
+				int numAdjacent = numAdjacentTownOwnedTownBlocksIgnoring(town, wc, townBlockToUnclaim, true);
+
+				// Handle the scenario where the townblock being unclaimed is the last townblock beside an outpost.
+				if (numAdjacent == 1 && numAdjacentOutposts(town, wc, false) == 1)
+					continue;
+
 				// The number of adjacent TBs is not enough.
-				if (numAdjacent - 1 < minAdjacentBlocks)
-					throw new TownyException(Translatable.of("msg_err_cannot_unclaim_not_enough_adjacent_claims", wc.getX(), wc.getZ(), numAdjacent));
+				if (numAdjacentNonCardinal == 0 || numAdjacent < minAdjacentBlocks)
+					throw new TownyException(Translatable.of("msg_err_cannot_unclaim_not_enough_adjacent_claims", wc.getX(), wc.getZ(), minAdjacentBlocks));
 			}
 		}
 	}

--- a/Towny/src/main/resources/ChangeLog.txt
+++ b/Towny/src/main/resources/ChangeLog.txt
@@ -10837,3 +10837,5 @@ v0.92.0.11:
     - Allow regular residents to use /nation outpost [town] [outpost] (TP to other towns' outposts if they are public).
     - Valid values are: true, false, war, peace.
     - When war or peace is set, it is only possible to teleport to the nation, when there is a war or peace.
+0.102.0.15:
+  - New PlaceholderAPI placeholder: %townyadvanced_top_town_residents_and_open_n% - (Replace n with a number) Displays the nth Town that is open, arranged by the number of residents.

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -2399,6 +2399,9 @@ msg_folia_scoreboard: "Changing scoreboards is currently not supported on Folia.
 #Message shown when a player cannot unclaim land because at least one plot wouldn't have enough adjacent claims.
 msg_err_cannot_unclaim_not_enough_adjacent_claims: "You cannot unclaim this townblock because the townblock at %s,%s would not have enough adjacent claims (%s are required.)"
 
+#Message shown when a player tries to unclaim an outpost with attached townblocks, while the min_adjacent_blocks setting is in use.
+msg_err_cannot_unclaim_outpost_with_adjacent_claims: "You cannot unclaim an outpost that has any attached townblocks."
+
 #Message shown when a nation collects taxes from its towns.
 msg_tax_collected_from_towns: "<aqua>Your nation collected %s in tax from its towns."
 

--- a/Towny/src/test/java/com/palmergames/bukkit/towny/config/ConfigMigrationTests.java
+++ b/Towny/src/test/java/com/palmergames/bukkit/towny/config/ConfigMigrationTests.java
@@ -20,7 +20,7 @@ public class ConfigMigrationTests {
 	
 	@Test
 	void testEntityClassMigration() {
-		TownySettings.getConfig().set(ConfigNodes.NWS_PLOT_MANAGEMENT_WILD_ENTITY_REVERT_LIST.getRoot(), "Creeper,EnderCrystal,EnderDragon,SmallFireball,Fireball,TNTPrimed,ExplosiveMinecart,Wither,WitherSkull");
+		TownySettings.getConfig().set(ConfigNodes.NWS_PLOT_MANAGEMENT_WILD_ENTITY_REVERT_LIST.getRoot(), "Creeper,EnderCrystal,EnderDragon,SmallFireball,LargeFireball,TNTPrimed,ExplosiveMinecart,Wither,WitherSkull");
 		
 		Consumer<CommentedConfiguration> migration = runnableMigrations.getByName("convert_entity_class_names");
 		assertNotNull(migration);


### PR DESCRIPTION


<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->


It appears as though we were testing each `wc` surrounding the plot being unclaimed for nearby outposts when we should have been checking for nearby outposts next to the plot being unclaimed.

Still untested, to do:

- [x] Test that unclaiming the outpost is allowed.
- [x] Test that this doesn't allow for undesireable unclaiming patterns, ie: holes when used inside of a large landmass.


____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

Closes #7891
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
