### PR TITLE
Fix gradients not working when parsed through resident.formattedName().

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Resident.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Resident.java
@@ -793,18 +793,7 @@ public class Resident extends TownyObject implements InviteReceiver, EconomyHand
 
 	@Override
 	public Component formattedName() {
-		Component prefix = hasTitle() ? TownyComponents.USER_SAFE.deserialize(Colors.translateLegacyCharacters(getTitle()))
-			: TownyComponents.miniMessage(getNamePrefix());
-
-		Component postfix = hasSurname() ? TownyComponents.USER_SAFE.deserialize(Colors.translateLegacyCharacters(getSurname()))
-			: TownyComponents.miniMessage(getNamePostfix());
-
-		TownyObjectFormattedNameEvent event = new TownyObjectFormattedNameEvent(this, prefix, postfix);
-		event.callEvent();
-
-		return event.prefix().append(TownyComponents.plain(event.prefix()).isEmpty() ? Component.empty() : Component.space())
-			.append(Component.text(getName()))
-			.append((TownyComponents.plain(event.postfix()).isEmpty() ? Component.empty() : Component.space()).append(event.postfix()));
+		return TownyComponents.USER_SAFE.deserialize(Colors.translateLegacyCharacters(getFormattedName()));
 	}
 
 	/**


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

Resident names were not rendering the gradients stored in titles onto the player name.

Before:
<img width="397" height="54" alt="image" src="https://github.com/user-attachments/assets/ddfb4254-a9eb-49c1-aef9-359c16ca6739" />

After:

<img width="617" height="51" alt="image" src="https://github.com/user-attachments/assets/17d8e66f-d6eb-4610-b77d-11bc0fc4b6c2" />

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
