### PR TITLE
New config option to ingore ruined town in claiming distance check rules

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1221,7 +1221,7 @@ public enum ConfigNodes {
 			"# will be ignored for towns that are mutually allied. Setting to false will keep all towns separated the same."),
 	CLAIMING_MIN_DISTANCE_IGNORED_FOR_RUINED_TOWN(
 			"claiming.distance_rules.min_distances_ignored_for_ruined_towns",
-			"true",
+			"false",
 			"",
 			"# If true, the below settings: min_plot_distance_from_town_plot and min_distance_from_town_homeblock",
 			"# will be ignored for towns that are ruined. Setting to false will keep all towns separated the same."),

--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1219,6 +1219,12 @@ public enum ConfigNodes {
 			"",
 			"# If true, the below settings: min_plot_distance_from_town_plot and min_distance_from_town_homeblock",
 			"# will be ignored for towns that are mutually allied. Setting to false will keep all towns separated the same."),
+	CLAIMING_MIN_DISTANCE_IGNORED_FOR_RUINED_TOWN(
+			"claiming.distance_rules.min_distances_ignored_for_ruined_towns",
+			"true",
+			"",
+			"# If true, the below settings: min_plot_distance_from_town_plot and min_distance_from_town_homeblock",
+			"# will be ignored for towns that are ruined. Setting to false will keep all towns separated the same."),
 	CLAIMING_MIN_PLOT_DISTANCE_FROM_TOWN_PLOT(
 			"claiming.distance_rules.min_plot_distance_from_town_plot",
 			"5",

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -2817,6 +2817,10 @@ public class TownySettings {
 		return getBoolean(ConfigNodes.CLAIMING_MIN_DISTANCE_IGNORED_FOR_ALLIES);
 	}
 
+	public static boolean isMinDistanceIgnoringRuinedTowns() {
+		return getBoolean(ConfigNodes.CLAIMING_MIN_DISTANCE_IGNORED_FOR_RUINED_TOWN);
+	}
+
 	public static int getMinDistanceBetweenHomeblocks() {
 		return getInt(ConfigNodes.CLAIMING_MIN_DISTANCE_BETWEEN_HOMEBLOCKS);
 	}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownyWorld.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownyWorld.java
@@ -820,7 +820,8 @@ public class TownyWorld extends TownyObject {
 					// both towns are in the same nation (and this is set to ignore distance in the config,) skip over the proximity filter.
 					if (homeTown.getUUID().equals(town.getUUID())
 						|| (TownySettings.isMinDistanceIgnoringTownsInSameNation() && homeTown.hasNation() && town.hasNation() && town.getNationOrNull().equals(homeTown.getNationOrNull()))
-						|| (TownySettings.isMinDistanceIgnoringTownsInAlliedNation() && homeTown.isAlliedWith(town)))
+						|| (TownySettings.isMinDistanceIgnoringTownsInAlliedNation() && homeTown.isAlliedWith(town))
+						|| (TownySettings.isMinDistanceIgnoringRuinedTowns() && town.isRuined()))
 						continue;
 				}
 				if (!town.getHomeblockWorld().equals(this)) continue;
@@ -862,7 +863,8 @@ public class TownyWorld extends TownyObject {
 				// both towns are in the same nation (and this is set to ignore distance in the config,) skip over the proximity filter.
 				if (homeTown.getUUID().equals(town.getUUID())
 					|| (TownySettings.isMinDistanceIgnoringTownsInSameNation() && homeTown.hasNation() && town.hasNation() && town.getNationOrNull().equals(homeTown.getNationOrNull()))
-					|| (TownySettings.isMinDistanceIgnoringTownsInAlliedNation() && homeTown.isAlliedWith(town)))
+					|| (TownySettings.isMinDistanceIgnoringTownsInAlliedNation() && homeTown.isAlliedWith(town))
+					|| (TownySettings.isMinDistanceIgnoringRuinedTowns() && town.isRuined()))
 					continue;
 			for (TownBlock b : town.getTownBlocks()) {
 				if (!b.getWorld().equals(this)) continue;


### PR DESCRIPTION
#### Description: 
I think it would make sense that ruined town don't prevent near by town to claim near them.
So I added a new config option to ingore ruined town in distance check rules.
It works exacly the same than ingoring same nation/ally towns.

____
#### New Nodes/Commands/ConfigOptions: 
**`CLAIMING_MIN_DISTANCE_IGNORED_FOR_RUINED_TOWN`**: "claiming.distance_rules.min_distances_ignored_for_ruined_towns"
It has almost the same description than `CLAIMING_MIN_DISTANCE_IGNORED_FOR_NATIONS` & `CLAIMING_MIN_DISTANCE_IGNORED_FOR_ALLIES`.
I think it would make more sense to have it `true` by default, but if you don't think it should, I can switch it to `false` by default.

____
#### Relevant Towny Issue ticket:
No ticket


____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
