### PR TITLE
Add a config option to allow dispensers damaging protected entities in PvP plots

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -2079,6 +2079,12 @@ public enum ConfigNodes {
 			"",
 			"# Setting this to false will allow non-player entities to harm the above protected mobs.",
 			"# This would include withers damaging protected mobs, and can be quite harmful."),
+	PROT_MOB_TYPES_MOB_VS_BLOCK_PROJECTILE_SOURCE_BYPASS(
+			"protection.are_mob_types_protected_against_block_projectile_sources",
+			"true",
+			"",
+			"# Setting this to false will allow block projectile sources, namely dispensers, to harm the above protected mobs (using potions, arrows, etc.), if they're in the same townblock and PvP is enabled."
+	),
 	PROT_POTION_TYPES(
 			"protection.potion_types",
 			"BLINDNESS,NAUSEA,INSTANT_DAMAGE,HUNGER,POISON,SLOWNESS,MINING_FATIGUE,WEAKNESS,WITHER,WIND_CHARGED,WEAVING,INFESTED,OOZING",

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -4074,6 +4074,10 @@ public class TownySettings {
 	public static boolean areProtectedEntitiesProtectedAgainstMobs() {
 		return getBoolean(ConfigNodes.PROT_MOB_TYPES_MOB_VS_MOB_BYPASS);
 	}
+
+	public static boolean areProtectedEntitiesProtectedAgainstBlockProjectileSource() {
+		return getBoolean(ConfigNodes.PROT_MOB_TYPES_MOB_VS_BLOCK_PROJECTILE_SOURCE_BYPASS);
+	}
 	
 	public static String getBossBarNotificationColor() {
 		return getString(ConfigNodes.NOTIFICATION_BOSSBARS_COLOR);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/CombatUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/CombatUtil.java
@@ -273,6 +273,14 @@ public class CombatUtil {
 				if (!TownySettings.areProtectedEntitiesProtectedAgainstMobs())
 					return false;
 
+				/*
+				 * Allows projectiles fired by a BlockProjectileSource (e.g. dispenser) harming protected entities, only if allowed in the config, and the entity is in the same townblock
+				 * A check to ensure PvP is enabled already happened for a BlockProjectSource
+				 */
+				if (allowDispenserDamagingProtectedEntity(projectileAttacker, defenderTB, attackerTB)) {
+					return false;
+				}
+
 			    /*
 			     * Prevents projectiles fired by non-players harming non-player entities.
 			     * Could be a monster or it could be a dispenser.
@@ -728,5 +736,13 @@ public class CombatUtil {
 
 	private static boolean isTownyAdminBypassingPVP(Player attackingPlayer) {
 		return TownySettings.isPVPAlwaysAllowedForAdmins() && TownyUniverse.getInstance().getPermissionSource().isTownyAdmin(attackingPlayer);
+	}
+
+	private static boolean allowDispenserDamagingProtectedEntity(Projectile projectileAttacker, @NotNull TownBlock defenderTB, TownBlock attackerTB) {
+		if (TownySettings.areProtectedEntitiesProtectedAgainstBlockProjectileSource()) {
+			return false;
+		}
+
+		return projectileAttacker instanceof BlockProjectileSource && defenderTB.equals(attackerTB);
 	}
 }


### PR DESCRIPTION
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Let server admins allow dispensers damaging protected entities, if the dispenser and entity are in the same townblock, and PvP is enabled

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
Config node `protection.are_mob_types_protected_against_block_projectile_sources`, default true (current behavior)

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
