### PR TITLE
Fix dispensers allowing harmful potions logic

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/CombatUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/CombatUtil.java
@@ -739,14 +739,13 @@ public class CombatUtil {
 	}
 
 	private static boolean allowDispenserDamagingProtectedEntity(ProjectileSource shooter, @NotNull TownBlock defenderTB, TownBlock attackerTB) {
-		if (TownySettings.areProtectedEntitiesProtectedAgainstBlockProjectileSource()) {
+		if (TownySettings.areProtectedEntitiesProtectedAgainstBlockProjectileSource() || !(shooter instanceof BlockProjectileSource)) {
 			return false;
 		}
 
-		boolean isDispenser = shooter instanceof BlockProjectileSource;
 		boolean sameTBOrGroup = defenderTB.equals(attackerTB) || (defenderTB.hasPlotObjectGroup() && defenderTB.getPlotObjectGroup().hasTownBlock(attackerTB));
 		boolean pvp = isPvP(defenderTB) && isPvP(attackerTB);
 
-		return isDispenser && sameTBOrGroup && pvp;
+		return sameTBOrGroup && pvp;
 	}
 }

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/CombatUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/CombatUtil.java
@@ -277,7 +277,7 @@ public class CombatUtil {
 				 * Allows projectiles fired by a BlockProjectileSource (e.g. dispenser) harming protected entities, only if allowed in the config, and the entity is in the same townblock
 				 * A check to ensure PvP is enabled already happened for a BlockProjectSource
 				 */
-				if (allowDispenserDamagingProtectedEntity(projectileAttacker, defenderTB, attackerTB)) {
+				if (projectileAttacker != null && allowDispenserDamagingProtectedEntity(projectileAttacker.getShooter(), defenderTB, attackerTB)) {
 					return false;
 				}
 
@@ -738,11 +738,15 @@ public class CombatUtil {
 		return TownySettings.isPVPAlwaysAllowedForAdmins() && TownyUniverse.getInstance().getPermissionSource().isTownyAdmin(attackingPlayer);
 	}
 
-	private static boolean allowDispenserDamagingProtectedEntity(Projectile projectileAttacker, @NotNull TownBlock defenderTB, TownBlock attackerTB) {
+	private static boolean allowDispenserDamagingProtectedEntity(ProjectileSource shooter, @NotNull TownBlock defenderTB, TownBlock attackerTB) {
 		if (TownySettings.areProtectedEntitiesProtectedAgainstBlockProjectileSource()) {
 			return false;
 		}
 
-		return projectileAttacker instanceof BlockProjectileSource && defenderTB.equals(attackerTB);
+		boolean isDispenser = shooter instanceof BlockProjectileSource;
+		boolean sameTBOrGroup = defenderTB.equals(attackerTB) || (defenderTB.hasPlotObjectGroup() && defenderTB.getPlotObjectGroup().hasTownBlock(attackerTB));
+		boolean pvp = isPvP(defenderTB) && isPvP(attackerTB);
+
+		return isDispenser && sameTBOrGroup && pvp;
 	}
 }


### PR DESCRIPTION
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Fix an issue in https://github.com/TownyAdvanced/Towny/pull/8180 - While cleaning up the code, I made a mistake and forgot to test it, so as of now the config option doesn't have any effect in-game

Additionally, I expanded the same-townblock check. The initial argument was to have some distance limitation to prevent abuse
so I made it check for either of two things; either it's the same townblock, or they have the same plotgroup - where both chunks have PvP enabled
____

I made sure to test the final version this time, and it works as intended
____

#### Attestations

- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.

In making this pull request, I declare that I have not used an AI toolset to design or code this pull request, and that I am a human who coded this without any influence from an LLM.
