### PR TITLE
Fix unhandled legacy colors being added during resident name formatting

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Resident.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Resident.java
@@ -782,8 +782,17 @@ public class Resident extends TownyObject implements InviteReceiver, EconomyHand
 
 	@Override
 	public String getFormattedName() {
-		String prefix = Colors.translateColorCodes(hasTitle() ? getTitle() + " " : getNamePrefix());
-		String postfix = Colors.translateColorCodes(hasSurname() ? " " + getSurname() : getNamePostfix());
+		String prefix = Colors.translateLegacyHex(Colors.translateLegacyCharacters(hasTitle() ? getTitle() : getNamePrefix()));
+		String postfix = Colors.translateLegacyHex(Colors.translateLegacyCharacters(hasSurname() ? getSurname() : getNamePostfix()));
+		
+		// Only add a trailing/leading space if the prefix/postfix has text contents, 
+		if (hasTitle() && !TownyComponents.plain(TownyComponents.miniMessage(prefix)).isEmpty()) {
+			prefix += " ";
+		}
+		
+		if (hasSurname() && !TownyComponents.plain(TownyComponents.miniMessage(postfix)).isEmpty()) {
+			postfix = " " + postfix;
+		}
 
 		TownyObjectFormattedNameEvent event = new TownyObjectFormattedNameEvent(this, prefix, postfix);
 		BukkitTools.fireEvent(event);
@@ -793,7 +802,7 @@ public class Resident extends TownyObject implements InviteReceiver, EconomyHand
 
 	@Override
 	public Component formattedName() {
-		return TownyComponents.USER_SAFE.deserialize(Colors.translateLegacyCharacters(getFormattedName()));
+		return TownyComponents.USER_SAFE.deserialize(getFormattedName());
 	}
 
 	/**


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
When using a title/surname containing a gradient with uppercase characters like `<#AABBCC>`, towny would turn this into a legacy gradient and then fail to properly turn it back into minimessage afterwards. This PR fixes that by instead converting only from legacy -> minimessage, instead of legacy/minimessage -> legacy -> minimessage. Also only adds spacing when necessary, so that titles that only contain a color tag don't add an unnecessary space.

____

#### Attestations

- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.

In making this pull request, I declare that I have not used an AI toolset to design or code this pull request, and that I am a human who coded this without any influence from an LLM.
