### PR TITLE
Fix `/plot claim` allowing plot groups to be claimed when the plot group is not for sale.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/ChunkNotification.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/ChunkNotification.java
@@ -91,7 +91,7 @@ public class ChunkNotification {
 			fromForSale = fromTownBlock.getPlotPrice() != -1;
 			if (fromTownBlock.hasPlotObjectGroup()) {
 				fromPlotGroup = fromTownBlock.getPlotObjectGroup();
-				fromForSale = fromPlotGroup.getPrice() != -1;
+				fromForSale = fromPlotGroup.isForSale();
 			}
 			if (fromTownBlock.hasDistrict()) {
 				fromDistrict = fromTownBlock.getDistrict();
@@ -115,7 +115,7 @@ public class ChunkNotification {
 			toPlotGroupBlock = toTownBlock.hasPlotObjectGroup();
 			if (toPlotGroupBlock) {
 				toPlotGroup = toTownBlock.getPlotObjectGroup();
-				toForSale = toPlotGroup.getPrice() != -1;
+				toForSale = toPlotGroup.isForSale();
 			}
 			toDistrictBlock = toTownBlock.hasDistrict();
 			if (toDistrictBlock) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyAsciiMap.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyAsciiMap.java
@@ -163,7 +163,7 @@ public class TownyAsciiMap {
 						townyMap[y][x] = townyMap[y][x].color(townblock.getData().getColour());
 
 					// Registered town block
-					if (townblock.getPlotPrice() != -1 || townblock.hasPlotObjectGroup() && townblock.getPlotObjectGroup().getPrice() != -1) {
+					if (townblock.getPlotPrice() != -1 || townblock.hasPlotObjectGroup() && townblock.getPlotObjectGroup().isForSale()) {
 						townyMap[y][x] = townyMap[y][x].content(forSaleSymbol);
 					} else if (townblock.isHomeBlock())
 						townyMap[y][x] = townyMap[y][x].content(homeSymbol);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyMessaging.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyMessaging.java
@@ -828,7 +828,7 @@ public class TownyMessaging {
 			TextComponent line = Component.text(Integer.toString(i + 1), NamedTextColor.GOLD);
 			line = line.append(dash).append(name).append(dash).append(size);
 			
-			if (TownyEconomyHandler.isActive() && group.getPrice() != -1)
+			if (TownyEconomyHandler.isActive() && group.isForSale())
 				line = line.append(dash).append(Component.text("(", NamedTextColor.BLUE).append(translator.component("towny_map_forsale")).append(Component.text(": " + TownyEconomyHandler.getFormattedBalance(group.getPrice()) + ")", NamedTextColor.BLUE)));
 
 			groupsFormatted[i % 10] = line;

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/PlotCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/PlotCommand.java
@@ -1600,8 +1600,11 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 		townBlock.setPlotObjectGroup(newGroup);
 
 		// Check if a plot price is available.
-		if (townBlock.getPlotPrice() > 0)
+		if (townBlock.getPlotPrice() > 0) {
 			newGroup.addPlotPrice(townBlock.getPlotPrice());
+			// Remove the townBlock's plot price.
+			townBlock.setPlotPrice(-1);
+		}
 
 		// Add the plot group to the town set.
 		town.addPlotGroup(newGroup);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/huds/MapHUD.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/huds/MapHUD.java
@@ -194,7 +194,7 @@ public class MapHUD implements HUDImplementer {
 	}
 
 	private static boolean isForSale(final TownBlock townBlock) {
-		return townBlock.getPlotPrice() != -1 || townBlock.hasPlotObjectGroup() && townBlock.getPlotObjectGroup().getPrice() != -1;
+		return townBlock.isForSale() || townBlock.hasPlotObjectGroup() && townBlock.getPlotObjectGroup().isForSale();
 	}
 
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/huds/PermHUD.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/huds/PermHUD.java
@@ -145,12 +145,12 @@ public class PermHUD implements HUDImplementer {
 	private static Component getPlotPrice(Translator translator, TownBlock townBlock, boolean plotGroup) {
 		String forSale = translator.of("msg_perm_hud_no");
 		if (TownyEconomyHandler.isActive()) {
-			forSale = plotGroup && townBlock.getPlotObjectGroup().getPrice() > -1
+			forSale = plotGroup && townBlock.getPlotObjectGroup().isForSale()
 				? prettyMoney(townBlock.getPlotObjectGroup().getPrice())
 				: townBlock.isForSale() ? prettyMoney(townBlock.getPlotPrice()) : forSale;
 		} else {
 			// No economy is active but plots can be put up for sale (they're just free.)
-			forSale = (plotGroup && townBlock.getPlotObjectGroup().getPrice() > -1) || (!plotGroup && townBlock.isForSale())
+			forSale = (plotGroup && townBlock.getPlotObjectGroup().isForSale()) || (!plotGroup && townBlock.isForSale())
 					? translator.of("msg_perm_hud_yes") : forSale;
 		}
 		return miniMessage(WHITE + forSale);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/PlotGroup.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/PlotGroup.java
@@ -89,6 +89,10 @@ public class PlotGroup extends ObjectGroup implements TownBlockOwner, Savable {
 		return "Group{" + this.toString() + "}";
 	}
 
+	public boolean isForSale() {
+		return price > -1;
+	}
+
 	public double getPrice() {
 		return price;
 	}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/PlotClaim.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/PlotClaim.java
@@ -146,7 +146,7 @@ public class PlotClaim implements Runnable {
 	private void residentGroupClaim(PlotGroup group) {
 		Town town = group.getTown();
 		@Nullable Resident owner = group.getResident();
-		if (owner != null && group.getPrice() > 0)
+		if (owner != null && group.isForSale())
 			TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_buy_resident_plot_group", resident.getName(), owner.getName(), group.getPrice()));
 
 		for (TownBlock townBlock : group.getTownBlocks())

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/AreaSelectionUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/AreaSelectionUtil.java
@@ -525,7 +525,11 @@ public class AreaSelectionUtil {
 	}
 
 	private static boolean townBlockIsForSale(TownBlock townBlock) {
-		return townBlock.isForSale() || (townBlock.hasPlotObjectGroup() && townBlock.getPlotObjectGroup().getPrice() != -1);
+		// Plot groups should take precedence over any underlying townblocks' forsale setting.
+		if (townBlock.hasPlotObjectGroup())
+			return townBlock.getPlotObjectGroup().getPrice() != -1;
+
+		return townBlock.isForSale();
 	}
 
 	/**

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/AreaSelectionUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/AreaSelectionUtil.java
@@ -527,7 +527,7 @@ public class AreaSelectionUtil {
 	private static boolean townBlockIsForSale(TownBlock townBlock) {
 		// Plot groups should take precedence over any underlying townblocks' forsale setting.
 		if (townBlock.hasPlotObjectGroup())
-			return townBlock.getPlotObjectGroup().getPrice() != -1;
+			return townBlock.getPlotObjectGroup().isForSale();
 
 		return townBlock.isForSale();
 	}


### PR DESCRIPTION

<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->


AreaSelectionUtil was checking if the underlying townblock is forsale, skipping the plotgroup forsale check.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____

#### Attestations

- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.

In making this pull request, I declare that I have not used an AI toolset to design or code this pull request, and that I am a human who coded this without any influence from an LLM.
