### PR TITLE
Add option to allow sanctioning of conquered towns from nationbonus

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1070,6 +1070,13 @@ public enum ConfigNodes {
 			"# treated as normal nation members when plot perms are calculated.",
 			"# When set to false plot permission tests will treat conquered towns' residents as not members of their nations,",
 			"# preventing them from using their host nation's plots while the nation's towns have nation plot perms enabled."),
+	GNATION_SETTINGS_CAN_CONQUERED_TOWNS_BE_SANCTIONED_FROM_NATION_BONUS(
+			"global_nation_settings.can_conquered_towns_be_sanctioned_from_nation_bonus",
+			"true",
+			"",
+			"# While true, conquered towns can be sanctioned by the nation who conquered them,",
+			"# and, if sanctioned, will not receive nation bonus blocks from the nation who conquered and sanctioned them.",
+			"# When set to false, conquered towns will always receive nation bonus, and cannot be sanctioned by the conquerer nation"),
 	GNATION_SETTINGS_PROXIMITY_ROOT(
 			"global_nation_settings.proximity", "", ""),
 	GNATION_SETTINGS_NATION_PROXIMITY_TO_CAPITAL(

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -1384,7 +1384,8 @@ public class TownySettings {
 			amount += numResidents * ratio;
 
 		final Nation nation = town.getNationOrNull();
-		if (nation != null) {
+		// Do not add nation bonus blocks if nation is null or if config setting and sanctioned and conquered are all true
+		if (nation != null && !(TownySettings.canConqueredTownsBeSanctionedFromNationBonus() && town.getNationOrNull().hasSanctionedTown(town) && town.isConquered())) {
 			amount += getNationBonusBlocks(nation, nationLevelModifier);
 		}
 
@@ -1455,7 +1456,9 @@ public class TownySettings {
 	public static int getNationBonusBlocks(Town town) {
 
 		if (town.hasNation())
-			return getNationBonusBlocks(town.getNationOrNull());
+			// Do not add nation bonus blocks if config setting and sanctioned and conquered are all true
+			if (!(TownySettings.canConqueredTownsBeSanctionedFromNationBonus() && town.getNationOrNull().hasSanctionedTown(town) && town.isConquered()))
+				return getNationBonusBlocks(town.getNationOrNull());
 		return 0;
 	}
 
@@ -3894,6 +3897,10 @@ public class TownySettings {
 		return getBoolean(ConfigNodes.GNATION_SETTINGS_ARE_CONQUERED_TOWNS_GIVEN_NATION_PLOT_PERMS);
 	}
 	
+	public static boolean canConqueredTownsBeSanctionedFromNationBonus() {
+		return getBoolean(ConfigNodes.GNATION_SETTINGS_CAN_CONQUERED_TOWNS_BE_SANCTIONED_FROM_NATION_BONUS);
+	}
+
 	public static String getBankHistoryBookFormat() {
 		return getString(ConfigNodes.BANKHISTORY_BOOK);
 	}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -273,7 +273,8 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 					if (args.length == 3 && (args[1].equalsIgnoreCase("add") || args[1].equalsIgnoreCase("remove")))
 						return NameUtil.filterByStart(TownyUniverse.getInstance().getTowns()
 							.stream()
-							.filter(t -> !nation.hasTown(t))
+							// Town is invalid tab complete if it is in the nation and not applicable to be sanctioned
+							.filter(t -> !(nation.hasTown(t) && !(TownySettings.canConqueredTownsBeSanctionedFromNationBonus() && t.isConquered())))
 							.map(Town::getName)
 							.collect(Collectors.toList()), args[2]);
 					if (args.length == 3 && args[1].equalsIgnoreCase("list"))
@@ -1447,7 +1448,8 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 	}
 
 	private static void nationSanctionTownAdd(CommandSender sender, Nation nation, Town town) throws TownyException {
-		if (nation.hasTown(town))
+		// You cannot sanction a town in your nation unless the config setting is true and the town is conquered by you.
+		if (nation.hasTown(town) && !(TownySettings.canConqueredTownsBeSanctionedFromNationBonus() && town.isConquered()))
 			throw new TownyException(Translatable.of("msg_err_nation_cannot_sanction_own_town"));
 
 		if (nation.hasSanctionedTown(town))
@@ -1457,7 +1459,12 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 
 		nation.addSanctionedTown(town);
 		nation.save();
-		TownyMessaging.sendMsg(sender, Translatable.of("msg_err_nation_town_sanctioned", town.getName()));
+		if (nation.hasTown(town)) {
+			// At this point, if nation has the town, it therefore must be a conquered town, so send the conquered town variant of the sanction message
+			TownyMessaging.sendMsg(sender, Translatable.of("msg_err_nation_conquered_town_sanctioned", town.getName()));
+		} else {
+			TownyMessaging.sendMsg(sender, Translatable.of("msg_err_nation_town_sanctioned", town.getName()));
+		}
 	}
 
 	private static void nationSactionTownRemove(CommandSender sender, Nation nation, Town town) throws TownyException {

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -2492,6 +2492,8 @@ msg_err_nation_town_already_sanctioned: "Your nation already sanctions that town
 
 msg_err_nation_town_sanctioned: "Your nation has now sanctioned %s, they will not be allowed to join your nation."
 
+msg_err_nation_conquered_town_sanctioned: "Your nation has now sanctioned %s, they will not receive nation bonus from your nation."
+
 msg_err_nation_town_unsanctioned: "Your nation is no longer sanctioning %s."
 
 msg_err_nation_has_no_sanctioned_towns: "The nation has no sanctioned towns."


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Adds a config option to enable the ability for nations to sanction towns they have conquered and prevent those towns from receiving nation bonus from their conquerer.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
- New config option `global_nation_settings.can_conquered_towns_be_sanctioned_from_nation_bonus`, defaults to true. Towns that a nation has conquered and sanctioned will not receive nation bonus from that nation, if the config option is enabled.
- `/n sanctiontown add [town]` can now sanction a conquered town within your own nation, if the config option is enabled.
- `msg_err_nation_conquered_town_sanctioned` feedback message for sanctioning a conquered town

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____

#### Attestations

- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.

In making this pull request, I declare that I have not used an AI toolset to design or code this pull request, and that I am a human who coded this without any influence from an LLM.
