### PR TITLE
Improve on player cache efficiency

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/Towny.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/Towny.java
@@ -83,14 +83,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 
 /**
@@ -106,7 +105,7 @@ public class Towny extends JavaPlugin {
 	private final boolean isFolia = JavaUtil.classExists("io.papermc.paper.threadedregions.RegionizedServer");
 	private final TaskScheduler scheduler;
 
-	private final Map<UUID, PlayerCache> playerCache = Collections.synchronizedMap(new HashMap<>());
+	private final Map<UUID, PlayerCache> playerCache = new ConcurrentHashMap<>();
 	private final Set<TownyInitException.TownyError> errors = new HashSet<>();
 	
 	public Towny() {
@@ -626,9 +625,9 @@ public class Towny extends JavaPlugin {
 	 */
 	public void resetCache() {
 
-		for (Player player : BukkitTools.getOnlinePlayers())
-			if (player != null)
-				getCache(player).resetAndUpdate(WorldCoord.parseWorldCoord(player)); // Automatically resets permissions.
+		for (final PlayerCache cache : playerCache.values()) {
+			cache.resetAndUpdate(cache.getLastTownBlock());
+		}
 	}
 
 	/**
@@ -638,10 +637,13 @@ public class Towny extends JavaPlugin {
 	 */
 	public void updateCache(WorldCoord worldCoord) {
 
-		for (Player player : BukkitTools.getOnlinePlayers())
-			if (player != null)
-				if (WorldCoord.parseWorldCoord(player).equals(worldCoord))
-					getCache(player).resetAndUpdate(worldCoord); // Automatically resets permissions.
+		for (Player player : BukkitTools.getOnlinePlayers()) {
+			final PlayerCache cache = getCacheOrNull(player.getUniqueId());
+
+			if (cache != null && cache.getLastTownBlock().equals(worldCoord)) {
+				cache.resetAndUpdate(worldCoord);
+			}
+		}
 	}
 
 	/**

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyMessaging.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyMessaging.java
@@ -47,6 +47,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 /**
  * Towny message handling class
@@ -167,6 +168,19 @@ public class TownyMessaging {
 	 *
 	 * @param msg the message to be sent
 	 */
+	public static void sendDevMsg(final Supplier<String> msg) {
+		final Player townyDev;
+		if (TownySettings.isDevMode() && (townyDev = BukkitTools.getPlayerExact(TownySettings.getDevName())) != null) {
+			sendMessage(townyDev, Translatable.of("default_towny_prefix").forLocale(townyDev) + " DevMode: " + Colors.DARK_RED + msg.get());
+		}
+	}
+
+	/**
+	 * Sends a message (red) to the named Dev (if DevMode is enabled)
+	 * Uses default_towny_prefix
+	 *
+	 * @param msg the message to be sent
+	 */
 	public static void sendDevMsg(String[] msg) {
 		for (String line : msg) {
 			sendDevMsg(line);
@@ -181,6 +195,18 @@ public class TownyMessaging {
 	public static void sendDebugMsg(String msg) {
 		if (TownySettings.getDebug()) {
 			LOGGER.debug(Colors.strip(msg));
+		}
+		sendDevMsg(msg);
+	}
+
+	/**
+	 * Sends a message to the debug logger (and hence the console and debug.log)
+	 *
+	 * @param msg the message to be sent
+	 */
+	public static void sendDebugMsg(final Supplier<String> msg) {
+		if (TownySettings.getDebug()) {
+			LOGGER.debug(Colors.strip(msg.get()));
 		}
 		sendDevMsg(msg);
 	}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -1030,8 +1030,10 @@ public class TownyPlayerListener implements Listener {
 		passengers.remove(0);
 
 		for (Entity entity : passengers) {
-			if (entity instanceof Player rider)
+			if (entity instanceof Player rider) {
+				plugin.resetCache(rider);
 				BukkitTools.fireEvent(new PlayerChangePlotEvent(rider, from, to));
+			}
 		}
 	}
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/PlayerCache.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/PlayerCache.java
@@ -4,6 +4,7 @@ import com.palmergames.bukkit.towny.object.TownyPermission.ActionType;
 
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import java.util.HashMap;
 import java.util.Map;
@@ -76,12 +77,16 @@ public class PlayerCache {
 	 * @throws NullPointerException if passed an invalid or NULL ActionType
 	 */
 	public boolean getCachePermission(Material material, ActionType action) throws NullPointerException {
+		return getCachedPermission(material, action);
+	}
 
+	@ApiStatus.Internal
+	public Boolean getCachedPermission(final Material material, final ActionType action) {
 		return switch (action) {
-		case BUILD -> getBlockPermission(buildMatPermission, material);
-		case DESTROY -> getBlockPermission(destroyMatPermission, material);
-		case SWITCH -> getBlockPermission(switchMatPermission, material);
-		case ITEM_USE -> getBlockPermission(itemUseMatPermission, material);
+			case BUILD -> buildMatPermission.get(material);
+			case DESTROY -> destroyMatPermission.get(material);
+			case SWITCH -> switchMatPermission.get(material);
+			case ITEM_USE -> itemUseMatPermission.get(material);
 		};
 
 	}
@@ -130,7 +135,7 @@ public class PlayerCache {
 	private void reset(WorldCoord wc) {
 
 		lastWorldCoord = wc;
-		townBlockStatus = null;
+		townBlockStatus = TownBlockStatus.UNKNOWN;
 		blockErrMsg = null;
 		
 		// Clear all maps
@@ -160,19 +165,16 @@ public class PlayerCache {
 		PLOT_TRUSTED,
 	}
 
-	private TownBlockStatus townBlockStatus = TownBlockStatus.UNKNOWN;
+	private @NotNull TownBlockStatus townBlockStatus = TownBlockStatus.UNKNOWN;
 
-	public void setStatus(TownBlockStatus townBlockStatus) {
+	public void setStatus(@NotNull TownBlockStatus townBlockStatus) {
 
 		this.townBlockStatus = townBlockStatus;
 	}
 
-	public TownBlockStatus getStatus() throws NullPointerException {
+	public TownBlockStatus getStatus() {
 
-		if (townBlockStatus == null)
-			throw new NullPointerException();
-		else
-			return townBlockStatus;
+		return townBlockStatus;
 	}
 
 	public void setBlockErrMsg(String blockErrMsg) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/WorldCoord.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/WorldCoord.java
@@ -328,6 +328,16 @@ public class WorldCoord extends Coord {
 			   !Objects.equals(from.getWorld(), to.getWorld());
 	}
 
+	/**
+	 * Checks if the given location is located inside of this WorldCoord.
+	 * 
+	 * @param location The location to check.
+	 * @return Whether the location is contained inside of this WorldCoord.
+	 */
+	public boolean containsLocation(final Location location) {
+		return this.getX() == toCell(location.getBlockX()) && this.getZ() == toCell(location.getBlockZ()) && this.getWorldName().equals(location.getWorld().getName());
+	}
+
 	public List<WorldCoord> getCardinallyAdjacentWorldCoords(boolean... includeOrdinalFlag) {
 		boolean includeOrdinal = (includeOrdinalFlag.length >= 1) ? includeOrdinalFlag[0] : false;
 		List<WorldCoord> list =new ArrayList<>(includeOrdinal ? 8 : 4);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/PlayerCacheUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/PlayerCacheUtil.java
@@ -56,56 +56,56 @@ public class PlayerCacheUtil {
 	/**
 	 * Returns player cached permission for BUILD, DESTROY, SWITCH or ITEM_USE
 	 * at this location for the specified item id.
-	 * 
+	 * <p>
 	 * Generates the cache if it doesn't exist.
 	 * 
-	 * @param player - Player to check
-	 * @param location - Location 
-	 * @param material - Material
-	 * @param action - ActionType
+	 * @param player The player to check permissions for.
+	 * @param location The location to check the permissions at.
+	 * @param material The material type involved in this action.
+	 * @param action The action being tested for.
 	 * @return true if the player has permission.
 	 */
 	public static boolean getCachePermission(Player player, Location location, Material material, ActionType action) {
 
-		final WorldCoord worldCoord = WorldCoord.parseWorldCoord(location);
+		final PlayerCache cache = plugin.getCache(player);
+		final WorldCoord lastWorldCoord = cache.getLastTownBlock();
 
-		try {
-			PlayerCache cache = plugin.getCache(player);
-			cache.updateCoord(worldCoord);
-
-			boolean result = cache.getCachePermission(material, action); // Throws NullPointerException if the cache is empty
-			TownyMessaging.sendDebugMsg("Cache permissions for " + player.getName() + " using " + material.getKey() + ":" + action + " = " + result);
-			return result;
-
-		} catch (NullPointerException e) {
-			// New or old cache permission was null, update it
-			TownBlockStatus status = cacheStatus(player, worldCoord, fetchTownBlockStatus(player, worldCoord));
-			triggerCacheCreate(player, location, worldCoord, status, material, action);
-
-			PlayerCache cache = plugin.getCache(player);
-			cache.updateCoord(worldCoord);
-
-			boolean result = cache.getCachePermission(material, action);
-			TownyMessaging.sendDebugMsg("New Cache created for " + player.getName() + " using " + material.getKey() + ":" + action + ":" + status.name() + " = " + result);
-			return result;
+		// Check if we can re-use the lastWorldCoord instance
+		final WorldCoord worldCoord;
+		if (lastWorldCoord.containsLocation(location)) {
+			worldCoord = lastWorldCoord;
+		} else {
+			worldCoord = WorldCoord.parseWorldCoord(location);
+			cache.resetAndUpdate(worldCoord);
 		}
+
+		final Boolean cachedValue = cache.getCachedPermission(material, action);
+		final boolean result;
+		if (cachedValue == null) {
+			// New or old cache permission was null, update it
+			// Only fetch status if it hasn't been cached previously
+			final TownBlockStatus status = cache.getStatus() == TownBlockStatus.UNKNOWN ? cacheStatus(player, cache, worldCoord, fetchTownBlockStatus(player, worldCoord)) : cache.getStatus();
+			result = triggerCacheCreate(player, cache, worldCoord, status, material, action);
+		} else {
+			result = cachedValue;
+		}
+
+		TownyMessaging.sendDebugMsg(() -> (cachedValue == null ? "New Cache created" : "Cache permissions") + " for " + player.getName() + " using " + material.getKey().asMinimalString() + ":" + action + ":" + cache.getStatus() + " = " + result);
+		return result;
 	}
 
 	/**
 	 * Generate a new cache for this player/action.
 	 * 
 	 * @param player - Player
-	 * @param location - Location
+	 * @param cache The player's cache.
 	 * @param worldCoord - WorldCoord
 	 * @param status - TownBlockStatus
 	 * @param material - Material
 	 * @param action - ActionType
 	 */
-	private static void triggerCacheCreate(Player player, Location location, WorldCoord worldCoord, TownBlockStatus status, Material material, ActionType action) {
-		final boolean permission = getPermission(player, status, worldCoord, material, action);
-
-		PlayerCache cache = plugin.getCache(player);
-		cache.updateCoord(worldCoord);
+	private static boolean triggerCacheCreate(Player player, PlayerCache cache, WorldCoord worldCoord, TownBlockStatus status, Material material, ActionType action) {
+		final boolean permission = getPermission(player, cache, status, worldCoord, material, action);
 
 		switch (action) {
 			case BUILD -> cache.setBuildPermission(material, permission);
@@ -114,7 +114,14 @@ public class PlayerCacheUtil {
 			case ITEM_USE -> cache.setItemUsePermission(material, permission);
 		}
 
-		TownyMessaging.sendDebugMsg(player.getName() + " (" + worldCoord + ") Cached " + action.getCommonName() + ": " + permission);
+		TownyMessaging.sendDebugMsg(() -> player.getName() + " (" + worldCoord + ") Cached " + action.getCommonName() + ": " + permission);
+		return permission;
+	}
+
+	public static TownBlockStatus cacheStatus(Player player, WorldCoord worldCoord, TownBlockStatus townBlockStatus) {
+		final PlayerCache cache = plugin.getCache(player);
+		cache.updateCoord(worldCoord);
+		return cacheStatus(player, cache, worldCoord, townBlockStatus);
 	}
 	
 	/**
@@ -122,17 +129,16 @@ public class PlayerCacheUtil {
 	 * worldCoord.
 	 * 
 	 * @param player - Player
+	 * @param cache The player's cache   
 	 * @param worldCoord - WorldCoord
 	 * @param townBlockStatus - TownBlockStatus
 	 * @return TownBlockStatus type.
 	 */
-	public static TownBlockStatus cacheStatus(Player player, WorldCoord worldCoord, TownBlockStatus townBlockStatus) {
+	public static TownBlockStatus cacheStatus(Player player, final PlayerCache cache, WorldCoord worldCoord, TownBlockStatus townBlockStatus) {
 
-		PlayerCache cache = plugin.getCache(player);
-		cache.updateCoord(worldCoord);
 		cache.setStatus(townBlockStatus);
 
-		TownyMessaging.sendDebugMsg(player.getName() + " (" + worldCoord + ") Cached Status: " + townBlockStatus);
+		TownyMessaging.sendDebugMsg(() -> player.getName() + " (" + worldCoord + ") Cached Status: " + townBlockStatus);
 		return townBlockStatus;
 	}
 
@@ -263,7 +269,7 @@ public class PlayerCacheUtil {
 	 * @param action {@link ActionType}
 	 * @return true if allowed.
 	 */
-	private static boolean getPermission(Player player, TownBlockStatus status, WorldCoord pos, Material material, TownyPermission.ActionType action) {
+	private static boolean getPermission(Player player, PlayerCache cache, TownBlockStatus status, WorldCoord pos, Material material, TownyPermission.ActionType action) {
 		// Allow admins to have ALL permissions
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
 		if (townyUniverse.getPermissionSource().isTownyAdmin(player))
@@ -277,7 +283,7 @@ public class PlayerCacheUtil {
 			&& action == ActionType.BUILD
 			&& targetTown.isBankrupt() 
 			&& !targetTown.isRuined()) {
-				cacheBlockErrMsg(player, Translatable.of("msg_err_bankrupt_town_cannot_build").forLocale(player));
+				cache.setBlockErrMsg(Translatable.of("msg_err_bankrupt_town_cannot_build").forLocale(player));
 				return false;
 		}
 
@@ -286,12 +292,12 @@ public class PlayerCacheUtil {
 		
 		Resident res = townyUniverse.getResident(player.getUniqueId());
 		if (res == null) {
-			cacheBlockErrMsg(player, Translatable.of("msg_err_not_registered").forLocale(player));
+			cache.setBlockErrMsg(Translatable.of("msg_err_not_registered").forLocale(player));
 			return false;
 		}
 
 		if (status == TownBlockStatus.NOT_REGISTERED) {
-			cacheBlockErrMsg(player, Translatable.of("msg_cache_block_error").forLocale(player));
+			cache.setBlockErrMsg(Translatable.of("msg_cache_block_error").forLocale(player));
 			return false;
 		}
 
@@ -310,7 +316,7 @@ public class PlayerCacheUtil {
 					return true;
 
 				// Don't have permission to build/destroy/switch/item_use here
-				cacheBlockErrMsg(player, Translatable.of("msg_cache_block_error_wild", Translatable.of(action.toString())).forLocale(player));
+				cache.setBlockErrMsg(Translatable.of("msg_cache_block_error_wild", Translatable.of(action.toString())).forLocale(player));
 				return false;
 			}
 			
@@ -326,7 +332,7 @@ public class PlayerCacheUtil {
 
 				// Wasn't able to build in the wilderness, regardless.
 				if (!hasWildOverride) {
-					cacheBlockErrMsg(player, Translatable.of("msg_cache_block_error_wild", Translatable.of(action.toString())).forLocale(player));
+					cache.setBlockErrMsg(Translatable.of("msg_cache_block_error_wild", Translatable.of(action.toString())).forLocale(player));
 					return false;
 				}
 
@@ -339,13 +345,13 @@ public class PlayerCacheUtil {
 
 					// Prevent conquered towns using their nation's Nation Zone, unless that nation zone is surrounding the conquered town.
 					if (TownySettings.getNationZonesSkipConqueredTowns() && res.getTownOrNull().isConquered() && !nearestTown.hasResident(res)) {
-						cacheBlockErrMsg(player, Translatable.of("nation_zone_conquered_status_denies_use").forLocale(res));
+						cache.setBlockErrMsg(Translatable.of("nation_zone_conquered_status_denies_use").forLocale(res));
 						return false;
 					}
 
 					// Prevent conquering nations using the nation zones surrounding a conquered town.
 					if (TownySettings.getNationZonesProtectsConqueredTowns() && nearestTown.isConquered() && !nearestTown.hasResident(res)) {
-						cacheBlockErrMsg(player, Translatable.of("nation_zone_conquered_status_denies_use").forLocale(res));
+						cache.setBlockErrMsg(Translatable.of("nation_zone_conquered_status_denies_use").forLocale(res));
 						return false;
 					}
 
@@ -354,7 +360,7 @@ public class PlayerCacheUtil {
 				}
 
 				// The player is not a nation member of this NationZone.
-				cacheBlockErrMsg(player, Translatable.of("nation_zone_this_area_under_protection_of", pos.getTownyWorld().getFormattedUnclaimedZoneName(), nearestNation.getName()).forLocale(player));
+				cache.setBlockErrMsg(Translatable.of("nation_zone_this_area_under_protection_of", pos.getTownyWorld().getFormattedUnclaimedZoneName(), nearestNation.getName()).forLocale(player));
 				return false;
 			}
 		}
@@ -389,7 +395,7 @@ public class PlayerCacheUtil {
 		if (override != null && override.getPermissionTypes()[action.getIndex()] != SetPermissionType.UNSET) {
 			SetPermissionType type = override.getPermissionTypes()[action.getIndex()];
 			if (type == SetPermissionType.NEGATED)
-				cacheBlockErrMsg(player, Translatable.of("msg_cache_block_err", Translatable.of(action.toString())).forLocale(player));
+				cache.setBlockErrMsg(Translatable.of("msg_cache_block_err", Translatable.of(action.toString())).forLocale(player));
 			
 			return type.equals(SetPermissionType.SET);				
 		}
@@ -409,7 +415,7 @@ public class PlayerCacheUtil {
 			if (townBlock.getPermissions().getResidentPerm(action) && isAllowedMaterial(townBlock, material, action))
 				return true;
 
-			cacheBlockErrMsg(player, Translatable.of("msg_cache_block_error_plot", Translatable.of("msg_cache_block_error_plot_friends"), Translatable.of(action.toString())).forLocale(player));
+			cache.setBlockErrMsg(Translatable.of("msg_cache_block_error_plot", Translatable.of("msg_cache_block_error_plot_friends"), Translatable.of(action.toString())).forLocale(player));
 			return false;
 		} 
 		
@@ -419,7 +425,7 @@ public class PlayerCacheUtil {
 			if (townBlock.getPermissions().getNationPerm(action) && isAllowedMaterial(townBlock, material, action))
 				return true;
 			
-			cacheBlockErrMsg(player, Translatable.of("msg_cache_block_error_plot", Translatable.of("msg_cache_block_error_plot_town_members"), Translatable.of(action.toString())).forLocale(player));
+			cache.setBlockErrMsg(Translatable.of("msg_cache_block_error_plot", Translatable.of("msg_cache_block_error_plot_town_members"), Translatable.of(action.toString())).forLocale(player));
 			return false;
 		}
 
@@ -432,7 +438,7 @@ public class PlayerCacheUtil {
 			if (townBlock.getPermissions().getResidentPerm(action) && isAllowedMaterial(townBlock, material, action))
 				return true;
 
-			cacheBlockErrMsg(player, Translatable.of("msg_cache_block_error_town_resident", Translatable.of(action.toString())).forLocale(player));
+			cache.setBlockErrMsg(Translatable.of("msg_cache_block_error_town_resident", Translatable.of(action.toString())).forLocale(player));
 			return false;
 		} 
 		
@@ -442,7 +448,7 @@ public class PlayerCacheUtil {
 			if (townBlock.getPermissions().getNationPerm(action) && isAllowedMaterial(townBlock, material, action))
 				return true;
 
-			cacheBlockErrMsg(player, Translatable.of("msg_cache_block_error_town_nation", Translatable.of(action.toString())).forLocale(player));
+			cache.setBlockErrMsg(Translatable.of("msg_cache_block_error_town_nation", Translatable.of(action.toString())).forLocale(player));
 			return false;
 		}
 		
@@ -457,9 +463,9 @@ public class PlayerCacheUtil {
 
 			// Choose which error message will be shown.
 			if (status == TownBlockStatus.PLOT_ALLY) 
-				cacheBlockErrMsg(player, Translatable.of("msg_cache_block_error_plot", Translatable.of("msg_cache_block_error_plot_allies"), Translatable.of(action.toString())).forLocale(player));
+				cache.setBlockErrMsg(Translatable.of("msg_cache_block_error_plot", Translatable.of("msg_cache_block_error_plot_allies"), Translatable.of(action.toString())).forLocale(player));
 			else 
-				cacheBlockErrMsg(player, Translatable.of("msg_cache_block_error_town_allies", Translatable.of(action.toString())).forLocale(player));
+				cache.setBlockErrMsg(Translatable.of("msg_cache_block_error_town_allies", Translatable.of(action.toString())).forLocale(player));
 			return false;
 		}
 		
@@ -474,9 +480,9 @@ public class PlayerCacheUtil {
 
 			// Choose which error message will be shown.
 			if (townBlock.hasResident())
-				cacheBlockErrMsg(player, Translatable.of("msg_cache_block_error_plot", Translatable.of("msg_cache_block_error_plot_outsiders"), Translatable.of(action.toString())).forLocale(player));
+				cache.setBlockErrMsg(Translatable.of("msg_cache_block_error_plot", Translatable.of("msg_cache_block_error_plot_outsiders"), Translatable.of(action.toString())).forLocale(player));
 			else 
-				cacheBlockErrMsg(player, Translatable.of("msg_cache_block_error_town_outsider", Translatable.of(action.toString())).forLocale(player));
+				cache.setBlockErrMsg(Translatable.of("msg_cache_block_error_town_outsider", Translatable.of(action.toString())).forLocale(player));
 			return false;
 		}
 		
@@ -486,7 +492,7 @@ public class PlayerCacheUtil {
 		if (status == TownBlockStatus.WARZONE)
 			return true;
 
-		TownyMessaging.sendErrorMsg(player, "Error updating " + action.toString() + " permission.");
+		TownyMessaging.sendErrorMsg(player, "Error updating " + action + " permission.");
 		return false;
 	}
 
@@ -513,12 +519,8 @@ public class PlayerCacheUtil {
 	 */
 	public static boolean isOwnerCache(@NotNull PlayerCache cache) {
 		Preconditions.checkNotNull(cache, "Cache cannot be null.");
-		TownBlockStatus status;
-		try {
-			status = cache.getStatus();
-		} catch (NullPointerException e) {
-			return false;
-		}
+		TownBlockStatus status = cache.getStatus();
+
 		return status.equals(TownBlockStatus.ADMIN) || status.equals(TownBlockStatus.PLOT_OWNER) || status.equals(TownBlockStatus.TOWN_OWNER);
 	}
 }

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/PlayerCacheUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/PlayerCacheUtil.java
@@ -147,7 +147,9 @@ public class PlayerCacheUtil {
 	 * 
 	 * @param player - Player
 	 * @param msg - String
+	 * @deprecated Unused by Towny now, use {@link PlayerCache#setBlockErrMsg(String)} instead.   
 	 */
+	@Deprecated(since = "0.103.0.2", forRemoval = true)
 	public static void cacheBlockErrMsg(Player player, String msg) {
 
 		PlayerCache cache = plugin.getCache(player);


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Makes a bunch of small improvements to the player cache.
- Removes an NPE being used for control flow for cache misses, prevents stacktraces from unnecessarily being filled in (at least, until the JVM optimizes it out)
- makes use of the cached TownBlockStatus instead of calculating it again during a cache miss, seems fine to do since we already heavily invalidate the whole cache when permissions change.
- some other stuff

____

#### Attestations

- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.

In making this pull request, I declare that I have not used an AI toolset to design or code this pull request, and that I am a human who coded this without any influence from an LLM.
