### PR TITLE
Fix driver of minecarts not throwing playerchangeplotevent.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -1000,41 +1000,7 @@ public class TownyPlayerListener implements Listener {
 		if (cache != null)
 			cache.resetAndUpdate(to);
 
-		// Paper doesn't currently throw PlayerMoveEvents for passengers in vehicles who aren't the driver.
-		// This workaround ensures that any passengers that are players will cause PlayerChangePlotEvents.
-		if (player.isInsideVehicle())
-			handleAnimalVehiclesWorkaround(player.getVehicle(), from, to);
-
 		BukkitTools.fireEvent(new PlayerChangePlotEvent(player, from, to));
-	}
-	
-	/**
-	 * Paper doesn't throw PlayerMoveEvents for players riding in animals like
-	 * HappyGhasts or Camels. Those animals don't throw VehicleMoveEvents and when
-	 * ridden they stop throwing EntityMoveEvents. The driver is the only one who
-	 * will have a PlayerMoveEvent thrown which is why we're doing this here.
-	 * 
-	 * @param vehicle   Vehicle being driven.
-	 * @param from      WorldCoord the players are leaving.
-	 * @param to        WorldCoord the players are entering.
-	 */
-	private void handleAnimalVehiclesWorkaround(@Nullable Entity vehicle, WorldCoord from, WorldCoord to) {
-		if (vehicle == null || !EntityLists.MULTISEAT_ANIMAL_MOUNTS.contains(vehicle))
-			return;
-
-		if (vehicle.getPassengers().size() < 2)
-			return;
-
-		List<Entity> passengers = new ArrayList<>(vehicle.getPassengers());
-		// Remove the driver, they throw their own PlayerMoveEvents.
-		passengers.remove(0);
-
-		for (Entity entity : passengers) {
-			if (entity instanceof Player rider) {
-				plugin.resetCache(rider);
-				BukkitTools.fireEvent(new PlayerChangePlotEvent(rider, from, to));
-			}
-		}
 	}
 
 	/*

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -1000,7 +1000,42 @@ public class TownyPlayerListener implements Listener {
 		if (cache != null)
 			cache.resetAndUpdate(to);
 
+		// Paper doesn't currently throw PlayerMoveEvents for passengers in vehicles who
+		// aren't the driver (including minecarts.) This workaround ensures that any
+		// passengers that are players will cause PlayerChangePlotEvents.
+		if (player.isInsideVehicle())
+			handleAnimalVehiclesWorkaround(player.getVehicle(), from, to);
+
 		BukkitTools.fireEvent(new PlayerChangePlotEvent(player, from, to));
+	}
+	
+	/**
+	 * Paper doesn't throw PlayerMoveEvents for players riding in animals like
+	 * HappyGhasts or Camels. Those animals don't throw VehicleMoveEvents and when
+	 * ridden they stop throwing EntityMoveEvents. The driver is the only one who
+	 * will have a PlayerMoveEvent thrown which is why we're doing this here.
+	 * 
+	 * @param vehicle   Vehicle being driven.
+	 * @param from      WorldCoord the players are leaving.
+	 * @param to        WorldCoord the players are entering.
+	 */
+	private void handleAnimalVehiclesWorkaround(@Nullable Entity vehicle, WorldCoord from, WorldCoord to) {
+		if (vehicle == null || !EntityLists.MULTISEAT_ANIMAL_MOUNTS.contains(vehicle))
+			return;
+
+		if (vehicle.getPassengers().size() < 2)
+			return;
+
+		List<Entity> passengers = new ArrayList<>(vehicle.getPassengers());
+		// Remove the driver, they throw their own PlayerMoveEvents.
+		passengers.remove(0);
+
+		for (Entity entity : passengers) {
+			if (entity instanceof Player rider) {
+				plugin.resetCache(rider);
+				BukkitTools.fireEvent(new PlayerChangePlotEvent(rider, from, to));
+			}
+		}
 	}
 
 	/*

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyVehicleListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyVehicleListener.java
@@ -186,11 +186,12 @@ public class TownyVehicleListener implements Listener {
 	}
 
 	/**
-	 * Handles vehicles with passengers not throwing PlayerMoveEvents for the
-	 * passenger(s), resulting in PlayerChangePlotEvents not being thrown.
+	 * Handles vehicles with passengers not throwing PlayerMoveEvents for the driver
+	 * and any passengers, resulting in PlayerChangePlotEvents not being thrown.
 	 * <p>
 	 * For now Paper does not throw this event for camels and ghasts but we'll
-	 * future-proof ourselves in case they do add support later on.</p>
+	 * future-proof ourselves in case they do add support later on.
+	 * </p>
 	 * 
 	 * @param event VehicleMoveEvent.
 	 */
@@ -199,12 +200,9 @@ public class TownyVehicleListener implements Listener {
 		if (!TownyAPI.getInstance().isTownyWorld(event.getVehicle().getWorld()))
 			return;
 
-		if (!EntityLists.MULTISEAT_MOUNTABLES.contains(event.getVehicle().getType()))
-			return;
-
 		List<Entity> passengers = new ArrayList<>(event.getVehicle().getPassengers());
 		// Vehicles can be empty and a driver exiting the vehicle makes a passenger into the driver.
-		if (passengers.size() < 2)
+		if (passengers.size() < 1)
 			return;
 
 		Location from = event.getFrom();
@@ -214,10 +212,6 @@ public class TownyVehicleListener implements Listener {
 		if (toCoord.equals(fromCoord))
 			return;
 
-		// Driver always throws a PlayerMoveEvent.
-		passengers.remove(0);
-
-		// HappyGhasts can have more than one passenger & a driver will have a PlayerMoveEvent.
 		for (Entity rider : passengers) {
 			if (rider instanceof Player player)
 				BukkitTools.fireEvent(new PlayerChangePlotEvent(player, fromCoord, toCoord));

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyVehicleListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyVehicleListener.java
@@ -22,6 +22,7 @@ import org.bukkit.event.vehicle.VehicleDamageEvent;
 import org.bukkit.event.vehicle.VehicleEnterEvent;
 import org.bukkit.event.vehicle.VehicleMoveEvent;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
 
 import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.TownyAPI;
@@ -186,12 +187,11 @@ public class TownyVehicleListener implements Listener {
 	}
 
 	/**
-	 * Handles vehicles with passengers not throwing PlayerMoveEvents for the driver
-	 * and any passengers, resulting in PlayerChangePlotEvents not being thrown.
+	 * Handles vehicles with passengers not throwing PlayerMoveEvents for the
+	 * passenger(s), resulting in PlayerChangePlotEvents not being thrown.
 	 * <p>
 	 * For now Paper does not throw this event for camels and ghasts but we'll
-	 * future-proof ourselves in case they do add support later on.
-	 * </p>
+	 * future-proof ourselves in case they do add support later on.</p>
 	 * 
 	 * @param event VehicleMoveEvent.
 	 */
@@ -200,9 +200,27 @@ public class TownyVehicleListener implements Listener {
 		if (!TownyAPI.getInstance().isTownyWorld(event.getVehicle().getWorld()))
 			return;
 
+		// Minecarts also do not throw PlayerMoveEvents and requires us to use the VehicleMoveEvent.
+		if (event.getVehicle().getType().equals(EntityType.MINECART)) {
+			if (event.getVehicle().getPassengers().size() > 0 && event.getVehicle().getPassengers().get(0) instanceof Player player) {
+				Location from = event.getFrom();
+				Location to = event.getTo();
+				WorldCoord fromCoord = WorldCoord.parseWorldCoord(from);
+				WorldCoord toCoord = WorldCoord.parseWorldCoord(to);
+				if (toCoord.equals(fromCoord))
+					return;
+
+				BukkitTools.fireEvent(new PlayerChangePlotEvent(player, fromCoord, toCoord));
+			}
+			return;
+		}
+
+		if (!EntityLists.MULTISEAT_MOUNTABLES.contains(event.getVehicle().getType()))
+			return;
+
 		List<Entity> passengers = new ArrayList<>(event.getVehicle().getPassengers());
 		// Vehicles can be empty and a driver exiting the vehicle makes a passenger into the driver.
-		if (passengers.size() < 1)
+		if (passengers.size() < 2)
 			return;
 
 		Location from = event.getFrom();
@@ -212,6 +230,10 @@ public class TownyVehicleListener implements Listener {
 		if (toCoord.equals(fromCoord))
 			return;
 
+		// Driver always throws a PlayerMoveEvent.
+		passengers.remove(0);
+
+		// HappyGhasts can have more than one passenger & a driver will have a PlayerMoveEvent.
 		for (Entity rider : passengers) {
 			if (rider instanceof Player player)
 				BukkitTools.fireEvent(new PlayerChangePlotEvent(player, fromCoord, toCoord));


### PR DESCRIPTION


<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Somehow the driver of minecarts stopped throwing player change plot events. This PR makes it so that vehicles with any passengers greater than 0 will throw a PlayerChangePlotEvent.



____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____

#### Attestations

- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.

In making this pull request, I declare that I have not used an AI toolset to design or code this pull request, and that I am a human who coded this without any influence from an LLM.
