### PR TITLE
Fix compile issue on 26.2 due to legacy method being removed

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/util/BiomeUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/BiomeUtil.java
@@ -1,13 +1,17 @@
 package com.palmergames.bukkit.util;
 
+import java.lang.invoke.MethodHandle;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 import java.util.function.Predicate;
 
 import com.palmergames.bukkit.towny.Towny;
+import com.palmergames.util.JavaUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
+import org.bukkit.RegionAccessor;
+import org.bukkit.UnsafeValues;
 import org.bukkit.World;
 import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.object.WorldCoord;
@@ -56,17 +60,24 @@ public class BiomeUtil {
 		int badBiomeBlocks = 0;
 		for (int z = 0; z < plotSize; z++)
 			for (int x = 0; x < plotSize; x++)
-				if (biomePredicate.test(getBiomeKey(world, worldX, world.getHighestBlockYAt(worldX + x, worldZ + z), worldZ)))
+				if (biomePredicate.test(getBiomeKey(world, worldX + x, world.getHighestBlockYAt(worldX + x, worldZ + z), worldZ + z)))
 					badBiomeBlocks++;
 
 		return (double) badBiomeBlocks / total;
 	}
 	
-	@SuppressWarnings({"deprecation", "removal"})
+	@SuppressWarnings("deprecation")
+	private static final MethodHandle LEGACY_GET_BIOME_KEY = JavaUtil.getMethodHandle(UnsafeValues.class, "getBiomeKey", RegionAccessor.class, int.class, int.class, int.class);
+
+	@SuppressWarnings("deprecation")
 	public static NamespacedKey getBiomeKey(final World world, final int x, final int y, final int z) {
-		if (Biome.class.isEnum()) {
+		if (Biome.class.isEnum() && LEGACY_GET_BIOME_KEY != null) {
 			// pre 1.21
-			return Bukkit.getUnsafe().getBiomeKey(world, x, y, z);
+			try {
+				return (NamespacedKey) LEGACY_GET_BIOME_KEY.invokeExact(Bukkit.getUnsafe(), (RegionAccessor) world, x, y, z);
+			} catch (Throwable throwable) {
+				return NamespacedKey.minecraft("forest");
+			}
 		}
 
 		return world.getBiome(x, y, z).getKey();

--- a/Towny/src/main/java/com/palmergames/bukkit/util/BiomeUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/BiomeUtil.java
@@ -71,7 +71,7 @@ public class BiomeUtil {
 
 	@SuppressWarnings("deprecation")
 	public static NamespacedKey getBiomeKey(final World world, final int x, final int y, final int z) {
-		if (Biome.class.isEnum() && LEGACY_GET_BIOME_KEY != null) {
+		if (LEGACY_GET_BIOME_KEY != null) {
 			// pre 1.21
 			try {
 				return (NamespacedKey) LEGACY_GET_BIOME_KEY.invokeExact(Bukkit.getUnsafe(), (RegionAccessor) world, x, y, z);


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Fixes compilation on 26.2 due to the obsolete getBiomeKey method being removed, and fixes a 2 year old bug where the same block was being sampled for it's biome over and over.

____

#### Attestations

- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.

In making this pull request, I declare that I have not used an AI toolset to design or code this pull request, and that I am a human who coded this without any influence from an LLM.
