### PR TITLE
Skip intermediate Location step of parsing a WC from entities

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyAPI.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyAPI.java
@@ -655,7 +655,7 @@ public class TownyAPI {
      */
     @Nullable
     public TownBlock getTownBlock(@NotNull Player player) {
-		return WorldCoord.parseWorldCoord(player.getLocation()).getTownBlockOrNull();
+		return WorldCoord.parseWorldCoord(player).getTownBlockOrNull();
     }
     
     /** 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyAsciiMap.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyAsciiMap.java
@@ -116,7 +116,7 @@ public class TownyAsciiMap {
 			return;
 		}
 		
-		WorldCoord pos = WorldCoord.parseWorldCoord(player.getLocation());
+		WorldCoord pos = WorldCoord.parseWorldCoord(player);
 		final Translator translator = Translator.locale(player);
 
 		// Generate Map 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -2621,16 +2621,15 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		if (!world.isClaimable())
 			throw new TownyException(Translatable.of("msg_not_claimable"));
 
-		Location spawnLocation = player.getLocation();
-		Coord key = Coord.parseCoord(player);
+		WorldCoord key = WorldCoord.parseWorldCoord(player);
 
-		if (!TownyAPI.getInstance().isWilderness(spawnLocation))
+		if (!TownyAPI.getInstance().isWilderness(key))
 			throw new TownyException(Translatable.of("msg_already_claimed_1", key));
 
 		if (!adminCreated) {
 			// Check that a town isn't being formed inside of a biome that isn't allowed to be claimed.
 			if (TownySettings.isUnwantedBiomeClaimingEnabled() || TownySettings.isOceanClaimingBlocked()) {
-				List<WorldCoord> selection = Arrays.asList(WorldCoord.parseWorldCoord(spawnLocation));
+				List<WorldCoord> selection = Arrays.asList(key);
 				selection = AreaSelectionUtil.filterOutUnwantedBiomeWorldCoords(player, selection);
 				selection = AreaSelectionUtil.filterOutOceanBiomeWorldCoords(player, selection);
 				if (selection.isEmpty())
@@ -2639,6 +2638,8 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 	
 			ProximityUtil.allowTownHomeBlockOrThrow(world, key, null, true);
 		}
+
+		Location spawnLocation = player.getLocation();
 
 		// If the town doesn't cost money to create, just make the Town.
 		if (noCharge || !TownyEconomyHandler.isActive()) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/CellSurface.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/CellSurface.java
@@ -34,13 +34,15 @@ public class CellSurface {
 
 	public void runClaimingParticleOverSurfaceAtPlayer(Player player) {
 		final World world = worldCoord.getBukkitWorld();
-		if (world == null)
+		if (world == null || !world.equals(player.getWorld()))
 			return;
 
 		// Create a Map of rings of BlockPos' which will expand outwards from the Player
 		// location if they are stood in the WorldCoord (or from the correct edge block
 		// of the WorldCoord if they are stood outside of it.)
-		Map<Integer, Set<BlockPos>> toRender = mapRingsOfClaimParticles(getX(player.getLocation()), getZ(player.getLocation()));
+		final int x = Location.locToBlock(player.getX());
+		final int z = Location.locToBlock(player.getZ());
+		Map<Integer, Set<BlockPos>> toRender = mapRingsOfClaimParticles(getX(x, z), getZ(x, z));
 
 		// Parse over the Map to generate particles on each successive ring with an
 		// added tick of delay (using the Map's Integer key to determine delay.)
@@ -99,20 +101,20 @@ public class CellSurface {
 		return new Location(world, x, world.getHighestBlockYAt(x, z, HeightMap.MOTION_BLOCKING_NO_LEAVES), z).add(0.5, 0.95, 0.5); // centre and raise slightly.
 	}
 
-	private int getX(Location playerLoc) {
-		if (WorldCoord.parseWorldCoord(playerLoc).equals(worldCoord))
-			return playerLoc.getBlockX();
+	private int getX(int playerX, int playerZ) {
+		if (worldCoord.containsCoordinates(playerX, playerZ))
+			return playerX;
 
 		// Player is outside of the WorldCoord, try to match up their X with an X in the WorldCoord or hit the correct corner.
-		return findSuitableXorZ(playerLoc.getBlockX(), worldCoord.getBoundingBox().getMaxX(), worldCoord.getBoundingBox().getMinX());
+		return findSuitableXorZ(playerX, worldCoord.getBoundingBox().getMaxX(), worldCoord.getBoundingBox().getMinX());
 	}
 
-	private int getZ(Location playerLoc) {
-		if (WorldCoord.parseWorldCoord(playerLoc).equals(worldCoord))
-			return playerLoc.getBlockZ();
+	private int getZ(int playerX, int playerZ) {
+		if (worldCoord.containsCoordinates(playerX, playerZ))
+			return playerZ;
 
 		// Player is outside of the WorldCoord, try to match up their Z with an Z in the WorldCoord or hit the correct corner.
-		return findSuitableXorZ(playerLoc.getBlockZ(), worldCoord.getBoundingBox().getMaxZ(), worldCoord.getBoundingBox().getMinZ());
+		return findSuitableXorZ(playerZ, worldCoord.getBoundingBox().getMaxZ(), worldCoord.getBoundingBox().getMinZ());
 	}
 
 	private int findSuitableXorZ(int player, double max, double min) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/CellSurface.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/CellSurface.java
@@ -102,7 +102,7 @@ public class CellSurface {
 	}
 
 	private int getX(int playerX, int playerZ) {
-		if (worldCoord.containsCoordinates(playerX, playerZ))
+		if (worldCoord.containsCoordinate(playerX, playerZ))
 			return playerX;
 
 		// Player is outside of the WorldCoord, try to match up their X with an X in the WorldCoord or hit the correct corner.
@@ -110,7 +110,7 @@ public class CellSurface {
 	}
 
 	private int getZ(int playerX, int playerZ) {
-		if (worldCoord.containsCoordinates(playerX, playerZ))
+		if (worldCoord.containsCoordinate(playerX, playerZ))
 			return playerZ;
 
 		// Player is outside of the WorldCoord, try to match up their Z with an Z in the WorldCoord or hit the correct corner.

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/WorldCoord.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/WorldCoord.java
@@ -338,11 +338,11 @@ public class WorldCoord extends Coord {
 		return this.getX() == toCell(location.getBlockX()) && this.getZ() == toCell(location.getBlockZ()) && this.getWorldName().equals(location.getWorld().getName());
 	}
 
-	public boolean containsCoordinates(final double x, final double z) {
-		return containsCoordinates(Location.locToBlock(x), Location.locToBlock(z));
+	public boolean containsCoordinate(final double x, final double z) {
+		return containsCoordinate(Location.locToBlock(x), Location.locToBlock(z));
 	}
 
-	public boolean containsCoordinates(final int x, final int z) {
+	public boolean containsCoordinate(final int x, final int z) {
 		return this.getX() == toCell(x) && this.getZ() == toCell(z);
 	}
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/WorldCoord.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/WorldCoord.java
@@ -74,7 +74,7 @@ public class WorldCoord extends Coord {
 	}
 
 	public static WorldCoord parseWorldCoord(Entity entity) {
-		return parseWorldCoord(entity.getLocation());
+		return new WorldCoord(entity.getWorld(), toCell(Location.locToBlock(entity.getX())), toCell(Location.locToBlock(entity.getZ())));
 	}
 
 	public static WorldCoord parseWorldCoord(String worldName, int blockX, int blockZ) {
@@ -125,7 +125,7 @@ public class WorldCoord extends Coord {
 
 	@Override
 	public String toString() {
-		return getWorldName() + "," + super.toString();
+		return getWorldName() + ", " + super.toString();
 	}
 
 	/**
@@ -336,6 +336,14 @@ public class WorldCoord extends Coord {
 	 */
 	public boolean containsLocation(final Location location) {
 		return this.getX() == toCell(location.getBlockX()) && this.getZ() == toCell(location.getBlockZ()) && this.getWorldName().equals(location.getWorld().getName());
+	}
+
+	public boolean containsCoordinates(final double x, final double z) {
+		return containsCoordinates(Location.locToBlock(x), Location.locToBlock(z));
+	}
+
+	public boolean containsCoordinates(final int x, final int z) {
+		return this.getX() == toCell(x) && this.getZ() == toCell(z);
 	}
 
 	public List<WorldCoord> getCardinallyAdjacentWorldCoords(boolean... includeOrdinalFlag) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/SpawnUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/SpawnUtil.java
@@ -834,7 +834,7 @@ public class SpawnUtil {
 				player.getVehicle().eject();
 
 			// Teleporting a player can cause the chunk to unload too fast, abandoning pets.
-			addAndRemoveChunkTicket(WorldCoord.parseWorldCoord(player.getLocation()));
+			addAndRemoveChunkTicket(WorldCoord.parseWorldCoord(player));
 
 			final Location prior = player.getLocation();
 			player.teleportAsync(spawnLoc, TeleportCause.COMMAND).thenAccept(successfulTeleport -> {


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Instead of having an intermediate step that creates a new Location instance when getting the worldcoord for an entity, we can instead skip that and just access the x/z directly. Realistically, this won't really matter, but it's still a gain

____

#### Attestations

- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.

In making this pull request, I declare that I have not used an AI toolset to design or code this pull request, and that I am a human who coded this without any influence from an LLM.
