### PR TITLE
Improve WorldCoord hashCode uniqueness

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/WorldCoord.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/WorldCoord.java
@@ -8,6 +8,7 @@ import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
 
 import com.palmergames.util.Pair;
 
+import it.unimi.dsi.fastutil.HashCommon;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
@@ -102,7 +103,7 @@ public class WorldCoord extends Coord {
 
 		int hash = 17;
 		hash = hash * 27 + this.worldName.hashCode();
-		hash = hash * 27 + getX();
+		hash = hash * 27 + HashCommon.mix(getX());
 		hash = hash * 27 + getZ();
 		return hash;
 	}

--- a/Towny/src/test/java/com/palmergames/bukkit/towny/object/WorldCoordTests.java
+++ b/Towny/src/test/java/com/palmergames/bukkit/towny/object/WorldCoordTests.java
@@ -1,7 +1,7 @@
 package com.palmergames.bukkit.towny.object;
 
 import com.google.common.collect.Iterables;
-import com.palmergames.bukkit.towny.test.BukkitMockExtension;
+import com.palmergames.bukkit.towny.test.TownyConfigExtension;
 import com.palmergames.util.Pair;
 import org.bukkit.World;
 import org.junit.jupiter.api.RepeatedTest;
@@ -14,7 +14,7 @@ import java.util.Collection;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-@ExtendWith(BukkitMockExtension.class)
+@ExtendWith(TownyConfigExtension.class)
 public class WorldCoordTests {	
 	@Test
 	void testChunkPositions() {


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
recently i've been thinking more about hashcode uniqueness, testing with some real world data:
before:
> Unique worldcoord hashCodes: 93725, total worldcoords: 451079, uniqueness: 20.7779(...)%

after:
> Unique worldcoord hashCodes: 451065, total worldcoords: 451079, uniqueness: 99.9968(...)%

with fewer hash collisions hashmap reads/writes will be slightly more efficient compared to how they are now when a worldcoord is used as the key
____

#### Attestations

- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.

In making this pull request, I declare that I have not used an AI toolset to design or code this pull request, and that I am a human who coded this without any influence from an LLM.
