### PR TITLE
Use the pre spawn event for additionally preventing spawns

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/event/MobRemovalEvent.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/event/MobRemovalEvent.java
@@ -7,6 +7,9 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
+/**
+ * Called when Towny is attempting to remove an entity already in the world. If canceled, the entity will not be removed.
+ */
 public class MobRemovalEvent extends Event implements Cancellable {
 	private static final HandlerList handlers = new HandlerList();
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/event/mobs/MobSpawnRemovalEvent.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/event/mobs/MobSpawnRemovalEvent.java
@@ -1,30 +1,78 @@
 package com.palmergames.bukkit.towny.event.mobs;
 
-import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.entity.CreatureSpawnEvent;
+import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
+import java.util.Objects;
+
+/**
+ * Called when Towny wants to prevent a mob from spawning. If canceled, the mob will be allowed to spawn, but follow-up removal attempts can still happen. These would be handled using {@link com.palmergames.bukkit.towny.event.MobRemovalEvent}.
+ */
 public class MobSpawnRemovalEvent extends Event implements Cancellable {
-	private static final HandlerList handlers = new HandlerList();
+	private static final HandlerList HANDLER_LIST = new HandlerList();
 
 	private boolean cancelled = false;
-	private final Entity entity;
+	private final @Nullable Entity entity;
 
-	public MobSpawnRemovalEvent(Entity entity) {
-		super(!Bukkit.getServer().isPrimaryThread());
+	private final EntityType entityType;
+	private final Location location;
+	private final CreatureSpawnEvent.SpawnReason spawnReason;
+
+	@ApiStatus.Internal
+	public MobSpawnRemovalEvent(final @Nullable Entity entity, final EntityType entityType, final Location location, final CreatureSpawnEvent.SpawnReason spawnReason) {
 		this.entity = entity;
+		this.entityType = entityType;
+		this.location = location;
+		this.spawnReason = spawnReason;
 	}
 
-	@Override
-	public HandlerList getHandlers() {
-		return handlers;
+	/**
+	 * @deprecated An entity instance is not available if we are cancelling the mob spawn using the {@link com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent}. This method will
+	 * attempt to create a default entity when it is not available, but you should use {@link #getEntityOrNull()} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "0.103.0.5")
+	public @NonNull Entity getEntity() {
+		if (this.entity == null) {
+			return location.getWorld().createEntity(location, Objects.requireNonNull(entityType.getEntityClass(), "entity class"));
+		}
+
+		return this.entity;
 	}
 
-	public static HandlerList getHandlerList() {
-		return handlers;
+	/**
+	 * {@return the entity being attempted to be spawned, or null}
+	 */
+	public @Nullable Entity getEntityOrNull() {
+		return this.entity;
+	}
+
+	/**
+	 * {@return the type of the entity being attempted to be spawned}
+	 */
+	public EntityType getEntityType() {
+		return this.entityType;
+	}
+
+	/**
+	 * {@return the location at which the entity is being attempted to be spawned}
+	 */
+	public Location getLocation() {
+		return this.location.clone();
+	}
+
+	/**
+	 * {@return the reason for the entity being spawned}
+	 */
+	public CreatureSpawnEvent.SpawnReason getSpawnReason() {
+		return spawnReason;
 	}
 
 	@Override
@@ -37,12 +85,12 @@ public class MobSpawnRemovalEvent extends Event implements Cancellable {
 		cancelled = isCancelled;
 	}
 
-	public Entity getEntity() {
-		return this.entity;
+	@Override
+	public @NonNull HandlerList getHandlers() {
+		return HANDLER_LIST;
 	}
 
-	public EntityType getEntityType() {
-		return this.entity.getType();
+	public static HandlerList getHandlerList() {
+		return HANDLER_LIST;
 	}
-
 }

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
@@ -362,7 +362,7 @@ public class TownyEntityListener implements Listener {
 		if (townyWorld == null || !townyWorld.isUsingTowny())
 			return false;
 
-		// ignore Citizens NPCs and named-mobs (if configured.) 
+		// ignore Citizens NPCs, named-mobs (if configured) and ignored spawn reasons.
 		if ((livingEntity != null && entityIsExempt(livingEntity)) || MobRemovalTimerTask.isSpawnReasonIgnored(reason)) {
 			return false;
 		}
@@ -372,7 +372,7 @@ public class TownyEntityListener implements Listener {
 			|| disallowedWildernessMob(townyWorld.hasWildernessMobs(), (townBlock = TownyAPI.getInstance().getTownBlock(location)) == null, entityType) // Wilderness mobs
 			|| disallowedTownMob(entityType, livingEntity, townBlock, townyWorld)) { // Town mobs
 			
-			return weAreAllowedToRemoveThis(livingEntity, entityType, location, reason);
+			return areWeAllowedToRemoveThis(livingEntity, entityType, location, reason);
 		}
 
 		return false;
@@ -422,7 +422,7 @@ public class TownyEntityListener implements Listener {
 	 * @param spawnReason The reason for the spawn.   
 	 * @return true if Towny is allowed to remove this entity.
 	 */
-	private boolean weAreAllowedToRemoveThis(final @Nullable Entity entity, final EntityType entityType, final Location location, final CreatureSpawnEvent.SpawnReason spawnReason) {
+	private boolean areWeAllowedToRemoveThis(final @Nullable Entity entity, final EntityType entityType, final Location location, final CreatureSpawnEvent.SpawnReason spawnReason) {
 		return MobSpawnRemovalEvent.getHandlerList().getRegisteredListeners().length == 0 || new MobSpawnRemovalEvent(entity, entityType, location, spawnReason).callEvent();
 	}
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
@@ -1,5 +1,6 @@
 package com.palmergames.bukkit.towny.listeners;
 
+import com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent;
 import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownyMessaging;
@@ -28,6 +29,7 @@ import com.palmergames.util.JavaUtil;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.AreaEffectCloud;
@@ -335,36 +337,50 @@ public class TownyEntityListener implements Listener {
 			return;
 		}
 
-		final TownyWorld townyWorld = TownyAPI.getInstance().getTownyWorld(event.getEntity().getWorld());
-
-		// ignore non-Towny worlds.
-		if (townyWorld == null || !townyWorld.isUsingTowny())
-			return;
-
-		// ignore Citizens NPCs and named-mobs (if configured.) 
-		LivingEntity livingEntity = event.getEntity();
-		if (entityIsExempt(livingEntity, event.getSpawnReason()))
-			return;
-
-		if (disallowedWorldMob(townyWorld.hasWorldMobs(), livingEntity)) {
-			// Handle mob removal world-wide. 
-			if (weAreAllowedToRemoveThis(livingEntity))
-				event.setCancelled(true);
-		} else if (disallowedWildernessMob(townyWorld.hasWildernessMobs(), livingEntity)) {
-			// Handle mob removal specific to the wilderness.
-			if (weAreAllowedToRemoveThis(livingEntity))
-				event.setCancelled(true);
-		} else if (disallowedTownMob(livingEntity)) {
-			// Handle mob removal specific to towns.
-			if (weAreAllowedToRemoveThis(livingEntity))
-				event.setCancelled(true);
+		if (preventEntitySpawn(event.getEntityType(), event.getSpawnReason(), event.getLocation(), event.getEntity().getWorld(), event.getEntity())) {
+			event.setCancelled(true);
 		}
 	}
 
-	private boolean entityIsExempt(LivingEntity livingEntity, CreatureSpawnEvent.SpawnReason spawnReason) {
+	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+	public void onPreCreatureSpawn(final PreCreatureSpawnEvent event) {
+		if (plugin.isError()) {
+			event.setCancelled(true);
+			return;
+		}
+
+		final Location location = event.getSpawnLocation();
+		if (preventEntitySpawn(event.getType(), event.getReason(), location, location.getWorld(), null)) {
+			event.setCancelled(true);
+		}
+	}
+
+	private boolean preventEntitySpawn(final EntityType entityType, final CreatureSpawnEvent.SpawnReason reason, final Location location, final World world, final @Nullable LivingEntity livingEntity) {
+		final TownyWorld townyWorld = TownyAPI.getInstance().getTownyWorld(world);
+	
+		// ignore non-Towny worlds.
+		if (townyWorld == null || !townyWorld.isUsingTowny())
+			return false;
+
+		// ignore Citizens NPCs and named-mobs (if configured.) 
+		if ((livingEntity != null && entityIsExempt(livingEntity)) || MobRemovalTimerTask.isSpawnReasonIgnored(reason)) {
+			return false;
+		}
+
+		final TownBlock townBlock;
+		if (disallowedWorldMob(townyWorld.hasWorldMobs(), entityType, livingEntity) // World mobs
+			|| disallowedWildernessMob(townyWorld.hasWildernessMobs(), (townBlock = TownyAPI.getInstance().getTownBlock(location)) == null, entityType) // Wilderness mobs
+			|| disallowedTownMob(entityType, livingEntity, townBlock, townyWorld)) { // Town mobs
+			
+			return weAreAllowedToRemoveThis(livingEntity, entityType, location, reason);
+		}
+
+		return false;
+	}
+
+	private boolean entityIsExempt(LivingEntity livingEntity) {
 		return PluginIntegrations.getInstance().isNPC(livingEntity)
-			|| entityIsExemptByName(livingEntity)
-			|| MobRemovalTimerTask.isSpawnReasonIgnored(livingEntity, spawnReason);
+			|| entityIsExemptByName(livingEntity);
 	}
 
 	private boolean entityIsExemptByName(LivingEntity livingEntity) {
@@ -372,41 +388,42 @@ public class TownyEntityListener implements Listener {
 				&& !PluginIntegrations.getInstance().checkHostileEliteMobs(livingEntity);
 	}
 
-	private boolean disallowedWorldMob(boolean worldAllowsMobs, LivingEntity livingEntity) {
-		return (!worldAllowsMobs && MobRemovalTimerTask.isRemovingWorldEntity(livingEntity))
+	private boolean disallowedWorldMob(boolean worldAllowsMobs, final EntityType entityType, final @Nullable LivingEntity livingEntity) {
+		return (!worldAllowsMobs && MobRemovalTimerTask.isRemovingWorldEntity(entityType))
 				|| disallowedWorldVillagerBaby(livingEntity);
 	}
 
-	private boolean disallowedWorldVillagerBaby(LivingEntity livingEntity) {
-		return TownySettings.isRemovingVillagerBabiesWorld() && livingEntity instanceof Villager villager && !villager.isAdult();
+	private boolean disallowedWorldVillagerBaby(@Nullable LivingEntity livingEntity) {
+		return livingEntity instanceof Villager villager && !villager.isAdult() && TownySettings.isRemovingVillagerBabiesWorld();
 	}
 
-	private boolean disallowedWildernessMob(boolean wildernessAllowsMobs, LivingEntity livingEntity) {
-		return TownyAPI.getInstance().isWilderness(livingEntity.getLocation()) && !wildernessAllowsMobs && MobRemovalTimerTask.isRemovingWildernessEntity(livingEntity);
+	private boolean disallowedWildernessMob(boolean wildernessAllowsMobs, final boolean isWilderness, final EntityType entityType) {
+		return isWilderness && !wildernessAllowsMobs && MobRemovalTimerTask.isRemovingWildernessEntity(entityType);
+	}
+	private boolean disallowedTownMob(final EntityType entityType, final @Nullable LivingEntity livingEntity, final @Nullable TownBlock townBlock, final TownyWorld world) {
+		return townBlock != null && (disallowedByTown(entityType, townBlock, world) || disallowedTownVillagerBaby(livingEntity));
 	}
 
-	private boolean disallowedTownMob(LivingEntity livingEntity) {
-		return !TownyAPI.getInstance().isWilderness(livingEntity.getLocation()) && (disallowedByTown(livingEntity) || disallowedTownVillagerBaby(livingEntity));
+	private boolean disallowedByTown(final EntityType entityType, final TownBlock townBlock, final TownyWorld world) {
+		return !(world.isForceTownMobs() || townBlock.getPermissions().mobs || (townBlock.getTownOrNull() != null && townBlock.getTownOrNull().isAdminEnabledMobs())) && MobRemovalTimerTask.isRemovingTownEntity(entityType);
 	}
 
-	private boolean disallowedByTown(LivingEntity livingEntity) {
-		return !TownyAPI.getInstance().areMobsEnabled(livingEntity.getLocation()) && MobRemovalTimerTask.isRemovingTownEntity(livingEntity);
-	}
-
-	private boolean disallowedTownVillagerBaby(LivingEntity livingEntity) {
-		return TownySettings.isRemovingVillagerBabiesTown() && livingEntity instanceof Villager villager && !villager.isAdult();
+	private boolean disallowedTownVillagerBaby(@Nullable LivingEntity livingEntity) {
+		return livingEntity instanceof Villager villager && !villager.isAdult() && TownySettings.isRemovingVillagerBabiesTown();
 	}
 
 	/**
 	 * Towny would normally remove this entity, but we use a
-	 * {@link MobSpawnRemovalEvent} to allow other plugins to override us. The event
-	 * starts out in a cancelled state.
+	 * {@link MobSpawnRemovalEvent} to allow other plugins to override us.
 	 * 
-	 * @param livingEntity LivingEntity which spawned.
+	 * @param entity Instance of the entity which spawned (if available).
+	 * @param entityType The type of the entity which spawned.
+	 * @param location The location at which the entity is being spawned.
+	 * @param spawnReason The reason for the spawn.   
 	 * @return true if Towny is allowed to remove this entity.
 	 */
-	private boolean weAreAllowedToRemoveThis(LivingEntity livingEntity) {
-		return !BukkitTools.isEventCancelled(new MobSpawnRemovalEvent(livingEntity));
+	private boolean weAreAllowedToRemoveThis(final @Nullable Entity entity, final EntityType entityType, final Location location, final CreatureSpawnEvent.SpawnReason spawnReason) {
+		return MobSpawnRemovalEvent.getHandlerList().getRegisteredListeners().length == 0 || new MobSpawnRemovalEvent(entity, entityType, location, spawnReason).callEvent();
 	}
 
 	/**

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/MobRemovalTimerTask.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/MobRemovalTimerTask.java
@@ -49,15 +49,27 @@ public class MobRemovalTimerTask extends TownyTimerTask {
 	}
 
 	public static boolean isRemovingWorldEntity(LivingEntity livingEntity) {
-		return typesOfWorldMobsToRemove.contains(livingEntity.getType());
+		return isRemovingWorldEntity(livingEntity.getType());
+	}
+
+	public static boolean isRemovingWorldEntity(final EntityType entityType) {
+		return typesOfWorldMobsToRemove.contains(entityType);
 	}
 	
 	public static boolean isRemovingWildernessEntity(LivingEntity livingEntity) {
-		return typesOfWildernessMobsToRemove.contains(livingEntity.getType());
+		return isRemovingWildernessEntity(livingEntity.getType());
+	}
+
+	public static boolean isRemovingWildernessEntity(final EntityType entityType) {
+		return typesOfWildernessMobsToRemove.contains(entityType);
 	}
 
 	public static boolean isRemovingTownEntity(LivingEntity livingEntity) {
-		return typesOfTownMobsToRemove.contains(livingEntity.getType());
+		return isRemovingTownEntity(livingEntity.getType());
+	}
+
+	public static boolean isRemovingTownEntity(final EntityType entityType) {
+		return typesOfTownMobsToRemove.contains(entityType);
 	}
 	
 	public static boolean isSpawnReasonIgnored(@NotNull Entity entity) {
@@ -69,6 +81,10 @@ public class MobRemovalTimerTask extends TownyTimerTask {
 			return true;
 
 		return ignoredSpawnReasons.contains(entity.getEntitySpawnReason().name());
+	}
+
+	public static boolean isSpawnReasonIgnored(final @NotNull CreatureSpawnEvent.SpawnReason spawnReason) {
+		return ignoredSpawnReasons.contains(spawnReason.name());
 	}
 
 	@Override


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This PR adds a listener for the pre creature spawn event, with this event we can hook earlier into the entity spawning process and prevent the server from doing work for entities that would not be able to spawn, such as performing light level checks.

One additional feature that makes using this event nice is that the server has a back-off for the amount of spawning attempts it will try for a player if it sees that this event is being consistently cancelled. This would be especially helpful for servers that have large towns with mobs disabled where it would be hard for the server to reach mob caps for players inside it.
____

#### Attestations

- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.

In making this pull request, I declare that I have not used an AI toolset to design or code this pull request, and that I am a human who coded this without any influence from an LLM.
