### PR TITLE
Replace deprecated PigZapEvent use

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
@@ -1,5 +1,6 @@
 package com.palmergames.bukkit.towny.listeners;
 
+import com.destroystokyo.paper.event.entity.EntityZapEvent;
 import com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent;
 import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.TownyAPI;
@@ -849,12 +850,12 @@ public class TownyEntityListener implements Listener {
 	}
 
 	/**
-	 * When a Pig is zapped by lightning
+	 * When an entity is zapped by lightning
 	 * 
-	 * @param event - PigZapEvent
+	 * @param event - EntityZapEvent
 	 */
 	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
-	public void onPigHitByLightning(PigZapEvent event) {
+	public void onPigHitByLightning(EntityZapEvent event) {
 		if (plugin.isError()) {
 			event.setCancelled(true);
 			return;

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
@@ -70,7 +70,6 @@ import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.entity.EntityInteractEvent;
 import org.bukkit.event.entity.EntityTargetLivingEntityEvent;
-import org.bukkit.event.entity.PigZapEvent;
 import org.bukkit.event.entity.PotionSplashEvent;
 import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.hanging.HangingBreakByEntityEvent;
@@ -855,7 +854,7 @@ public class TownyEntityListener implements Listener {
 	 * @param event - EntityZapEvent
 	 */
 	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
-	public void onPigHitByLightning(EntityZapEvent event) {
+	public void onEntityHitByLightning(EntityZapEvent event) {
 		if (plugin.isError()) {
 			event.setCancelled(true);
 			return;


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
The PigZapEvent has been deprecated in 26.2 with EntityZapEvent as it's replacement, switching to this event has the added benefit of villagers being protected from being turned into witches within town borders (with explosions off).

____

#### Attestations

- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.

In making this pull request, I declare that I have not used an AI toolset to design or code this pull request, and that I am a human who coded this without any influence from an LLM.
