### PR TITLE
Allow other plugins to modify the list of residents displayed

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -4,6 +4,7 @@ import com.palmergames.bukkit.towny.event.statusscreen.NationStatusScreenEvent;
 import com.palmergames.bukkit.towny.event.statusscreen.ResidentStatusScreenEvent;
 import com.palmergames.bukkit.towny.event.statusscreen.TownBlockStatusScreenEvent;
 import com.palmergames.bukkit.towny.event.statusscreen.TownStatusScreenEvent;
+import com.palmergames.bukkit.towny.event.town.TownDisplayReslistEvent;
 import com.palmergames.bukkit.towny.object.Coord;
 import com.palmergames.bukkit.towny.object.Government;
 import com.palmergames.bukkit.towny.object.Nameable;
@@ -381,12 +382,14 @@ public class TownyFormatter {
 						ClickEvent.runCommand("/towny:town ranklist " + town.getName()));
 
 			// [Residents] with hover showing residents names.
-			List<String> residents = getFormattedNames(town.getResidents());
+			List<Resident> townResidents = new ArrayList<>(town.getResidents());
+			new TownDisplayReslistEvent(town, townResidents).callEvent();
+			List<String> residents = getFormattedNames(townResidents);
 			if (residents.size() > 34)
 				shortenOverLengthList(residents, 35, translator);
 			
 			screen.addComponentOf("residents", colourHoverKey(translator.of("res_list")),
-				HoverEvent.showText(TownyComponents.miniMessage(getFormattedStrings(translator.of("res_list"), residents, town.getResidents().size()))
+				HoverEvent.showText(TownyComponents.miniMessage(getFormattedStrings(translator.of("res_list"), residents, residents.size()))
 					.append(Component.newline())
 					.append(translator.component("status_hover_click_for_more"))),
 				ClickEvent.runCommand("/towny:town reslist "+ town.getName()));
@@ -927,7 +930,7 @@ public class TownyFormatter {
 	 * @param objectlist List of TownyObjects to list.
 	 * @return Formatted, prefixed list of TownyObjects.
 	 */
-	public static String getFormattedTownyObjects(String prefix, List<TownyObject> objectlist) {
+	public static String getFormattedTownyObjects(String prefix, List<? extends TownyObject> objectlist) {
 		return String.format(listPrefixFormat, prefix, objectlist.size(), Translation.of("status_format_list_1"), Translation.of("status_format_list_2"), Translation.of("status_format_list_3")) + StringMgmt.join(getFormattedTownyNames(objectlist), ", "); 
 	}
 	
@@ -957,7 +960,7 @@ public class TownyFormatter {
 	 * @param objs List of TownyObjects of which to make a list of names.
 	 * @return List of Names coloured, and potentially formatted.
 	 */
-	public static List<String> getFormattedTownyNames(List<TownyObject> objs) {
+	public static List<String> getFormattedTownyNames(List<? extends TownyObject> objs) {
 		List<String> names = new ArrayList<>();
 		for (TownyObject obj : objs) {
 			names.add(Colors.translateColorCodes(objs.size() < 20 ? obj.getFormattedName() : obj.getName()) + Colors.RESET);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -930,7 +930,7 @@ public class TownyFormatter {
 	 * @param objectlist List of TownyObjects to list.
 	 * @return Formatted, prefixed list of TownyObjects.
 	 */
-	public static String getFormattedTownyObjects(String prefix, List<? extends TownyObject> objectlist) {
+	public static String getFormattedTownyObjects(String prefix, List<TownyObject> objectlist) {
 		return String.format(listPrefixFormat, prefix, objectlist.size(), Translation.of("status_format_list_1"), Translation.of("status_format_list_2"), Translation.of("status_format_list_3")) + StringMgmt.join(getFormattedTownyNames(objectlist), ", "); 
 	}
 	
@@ -960,7 +960,7 @@ public class TownyFormatter {
 	 * @param objs List of TownyObjects of which to make a list of names.
 	 * @return List of Names coloured, and potentially formatted.
 	 */
-	public static List<String> getFormattedTownyNames(List<? extends TownyObject> objs) {
+	public static List<String> getFormattedTownyNames(List<TownyObject> objs) {
 		List<String> names = new ArrayList<>();
 		for (TownyObject obj : objs) {
 			names.add(Colors.translateColorCodes(objs.size() < 20 ? obj.getFormattedName() : obj.getName()) + Colors.RESET);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -383,7 +383,9 @@ public class TownyFormatter {
 
 			// [Residents] with hover showing residents names.
 			List<Resident> townResidents = new ArrayList<>(town.getResidents());
-			BukkitTools.fireEvent(new TownDisplayReslistEvent(town, townResidents));
+			TownDisplayReslistEvent event = new TownDisplayReslistEvent(town, townResidents);
+			BukkitTools.fireEvent(event);
+			townResidents = event.getResidents();
 			List<String> residents = getFormattedNames(townResidents);
 			if (residents.size() > 34)
 				shortenOverLengthList(residents, 35, translator);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -383,7 +383,7 @@ public class TownyFormatter {
 
 			// [Residents] with hover showing residents names.
 			List<Resident> townResidents = new ArrayList<>(town.getResidents());
-			new TownDisplayReslistEvent(town, townResidents).callEvent();
+			BukkitTools.fireEvent(new TownDisplayReslistEvent(town, townResidents));
 			List<String> residents = getFormattedNames(townResidents);
 			if (residents.size() > 34)
 				shortenOverLengthList(residents, 35, translator);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -4167,7 +4167,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		BukkitTools.fireEvent(new TownDisplayReslistEvent(town, residents));
 		
 		TownyMessaging.sendMessage(sender, ChatTools.formatTitle(town.getName() + " " + Translatable.of("res_list").forLocale(sender)));
-		TownyMessaging.sendMessage(sender, TownyFormatter.getFormattedTownyObjects(Translatable.of("res_list").forLocale(sender), residents));
+		TownyMessaging.sendMessage(sender, TownyFormatter.getFormattedTownyObjects(Translatable.of("res_list").forLocale(sender), new ArrayList<>(residents)));
 	}
 	
 	private void townPlotGroupList(CommandSender sender, String[] args) throws TownyException {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -4164,7 +4164,9 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 			throw new TownyException(Translatable.of("msg_specify_name"));
 		
 		List<Resident> residents = new ArrayList<>(town.getResidents());
-		BukkitTools.fireEvent(new TownDisplayReslistEvent(town, residents));
+		TownDisplayReslistEvent event = new TownDisplayReslistEvent(town, residents);
+		BukkitTools.fireEvent(event);
+		residents = event.getResidents();
 		
 		TownyMessaging.sendMessage(sender, ChatTools.formatTitle(town.getName() + " " + Translatable.of("res_list").forLocale(sender)));
 		TownyMessaging.sendMessage(sender, TownyFormatter.getFormattedTownyObjects(Translatable.of("res_list").forLocale(sender), new ArrayList<>(residents)));

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -4164,7 +4164,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 			throw new TownyException(Translatable.of("msg_specify_name"));
 		
 		List<Resident> residents = new ArrayList<>(town.getResidents());
-		new TownDisplayReslistEvent(town, residents).callEvent();
+		BukkitTools.fireEvent(new TownDisplayReslistEvent(town, residents));
 		
 		TownyMessaging.sendMessage(sender, ChatTools.formatTitle(town.getName() + " " + Translatable.of("res_list").forLocale(sender)));
 		TownyMessaging.sendMessage(sender, TownyFormatter.getFormattedTownyObjects(Translatable.of("res_list").forLocale(sender), residents));

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -25,6 +25,7 @@ import com.palmergames.bukkit.towny.event.nation.NationKingChangeEvent;
 import com.palmergames.bukkit.towny.event.teleport.OutlawTeleportEvent;
 import com.palmergames.bukkit.towny.event.TownPreAddResidentEvent;
 import com.palmergames.bukkit.towny.event.town.TownCedePlotEvent;
+import com.palmergames.bukkit.towny.event.town.TownDisplayReslistEvent;
 import com.palmergames.bukkit.towny.event.town.TownKickEvent;
 import com.palmergames.bukkit.towny.event.town.TownLeaveEvent;
 import com.palmergames.bukkit.towny.event.town.TownMayorChangeEvent;
@@ -4162,8 +4163,11 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		if (town == null)
 			throw new TownyException(Translatable.of("msg_specify_name"));
 		
+		List<Resident> residents = new ArrayList<>(town.getResidents());
+		new TownDisplayReslistEvent(town, residents).callEvent();
+		
 		TownyMessaging.sendMessage(sender, ChatTools.formatTitle(town.getName() + " " + Translatable.of("res_list").forLocale(sender)));
-		TownyMessaging.sendMessage(sender, TownyFormatter.getFormattedTownyObjects(Translatable.of("res_list").forLocale(sender), new ArrayList<>(town.getResidents())));
+		TownyMessaging.sendMessage(sender, TownyFormatter.getFormattedTownyObjects(Translatable.of("res_list").forLocale(sender), residents));
 	}
 	
 	private void townPlotGroupList(CommandSender sender, String[] args) throws TownyException {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/event/town/TownDisplayReslistEvent.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/event/town/TownDisplayReslistEvent.java
@@ -1,8 +1,8 @@
 package com.palmergames.bukkit.towny.event.town;
 
-import com.palmergames.bukkit.towny.event.CancellableTownyEvent;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
+import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
@@ -12,7 +12,7 @@ import java.util.List;
  * An event fired when the /town reslist command is used, or when the [Residents] button is generated for the /town status screen.
  * The purpose of the event is to allow other plugins to modify the list of residents to be displayed
  */
-public class TownDisplayReslistEvent extends CancellableTownyEvent {
+public class TownDisplayReslistEvent extends Event {
 	private static final HandlerList HANDLER_LIST = new HandlerList();
 	private final Town town;
 	private final List<Resident> residents;

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/event/town/TownDisplayReslistEvent.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/event/town/TownDisplayReslistEvent.java
@@ -6,6 +6,7 @@ import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -15,11 +16,11 @@ import java.util.List;
 public class TownDisplayReslistEvent extends Event {
 	private static final HandlerList HANDLER_LIST = new HandlerList();
 	private final Town town;
-	private final List<Resident> residents;
+	private List<Resident> residents;
 	
 	public TownDisplayReslistEvent(Town town, List<Resident> residents) {
 		this.town = town;
-		this.residents = residents;
+		this.residents = new ArrayList<>(residents);
 	}
 
 	public Town getTown() {
@@ -28,6 +29,10 @@ public class TownDisplayReslistEvent extends Event {
 
 	public List<Resident> getResidents() {
 		return residents;
+	}
+
+	public void setResidents(List<Resident> residents) {
+		this.residents = residents;
 	}
 
 	public static HandlerList getHandlerList() {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/event/town/TownDisplayReslistEvent.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/event/town/TownDisplayReslistEvent.java
@@ -1,0 +1,42 @@
+package com.palmergames.bukkit.towny.event.town;
+
+import com.palmergames.bukkit.towny.event.CancellableTownyEvent;
+import com.palmergames.bukkit.towny.object.Resident;
+import com.palmergames.bukkit.towny.object.Town;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * An event fired when the /town reslist command is used, or when the [Residents] button is generated for the /town status screen.
+ * The purpose of the event is to allow other plugins to modify the list of residents to be displayed
+ */
+public class TownDisplayReslistEvent extends CancellableTownyEvent {
+	private static final HandlerList HANDLER_LIST = new HandlerList();
+	private final Town town;
+	private final List<Resident> residents;
+	
+	public TownDisplayReslistEvent(Town town, List<Resident> residents) {
+		this.town = town;
+		this.residents = residents;
+	}
+
+	public Town getTown() {
+		return town;
+	}
+
+	public List<Resident> getResidents() {
+		return residents;
+	}
+
+	public static HandlerList getHandlerList() {
+		return HANDLER_LIST;
+	}
+
+	@NotNull
+	@Override
+	public HandlerList getHandlers() {
+		return HANDLER_LIST;
+	}
+}


### PR DESCRIPTION
…eslist

<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Add TownDisplayReslistEvent, an event fired when the `/town reslist` command is used, or when the `[Residents]` button is created in the `/town` status screen

____

#### Attestations

- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.

In making this pull request, I declare that I have not used an AI toolset to design or code this pull request, and that I am a human who coded this without any influence from an LLM.
