### PR TITLE
Add DisplayedTownsListSortEvent

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/event/town/DisplayedTownsListSortEvent.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/event/town/DisplayedTownsListSortEvent.java
@@ -1,0 +1,44 @@
+package com.palmergames.bukkit.towny.event.town;
+
+import com.palmergames.bukkit.towny.object.Town;
+import com.palmergames.bukkit.towny.object.comparators.ComparatorType;
+import org.bukkit.Bukkit;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class DisplayedTownsListSortEvent extends Event {
+	private static final HandlerList handlers = new HandlerList();
+	private List<Town> towns;
+	private final ComparatorType comparatorType;
+
+	public DisplayedTownsListSortEvent(List<Town> towns, ComparatorType comparatorType) {
+		super(!Bukkit.getServer().isPrimaryThread());
+		this.towns = towns;
+		this.comparatorType = comparatorType;
+	}
+
+	@NotNull
+	@Override
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
+
+	public List<Town> getTowns() {
+		return towns;
+	}
+
+	public void setTowns(List<Town> towns) {
+		this.towns = towns;
+	}
+
+	public ComparatorType getComparatorType() {
+		return comparatorType;
+	}
+}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/comparators/ComparatorCaches.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/comparators/ComparatorCaches.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 
 import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.TownySettings;
+import com.palmergames.bukkit.towny.event.town.DisplayedTownsListSortEvent;
 import com.palmergames.bukkit.towny.object.Translatable;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -82,7 +83,11 @@ public class ComparatorCaches {
 			.filter(Town::isVisibleOnTopLists)
 			.filter((Predicate<? super Town>) compType.getPredicate())
 			.sorted((Comparator<? super Town>) compType.getComparator())
-			.toList();
+			.collect(Collectors.toCollection(ArrayList::new));
+
+		DisplayedTownsListSortEvent townListSortEvent = new DisplayedTownsListSortEvent(towns, compType);
+		BukkitTools.fireEvent(townListSortEvent);
+		towns = townListSortEvent.getTowns();
 
 		boolean spawningFullyDisabled = !TownySettings.isConfigAllowingTownSpawn() && !TownySettings.isConfigAllowingPublicTownSpawnTravel()
 				&& !TownySettings.isConfigAllowingTownSpawnNationTravel() && !TownySettings.isConfigAllowingTownSpawnNationAllyTravel();


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Add DisplayedTownsListSortEvent. pretty much the town equivalent of DisplayedNationsListSortEvent which already exists. 

Current problem: while TownListDisplayedNumResidentsCalculationEvent is fired, allowing other plugins to modify the displayed value of town residents, the towns list is not sorted correctly. it's possible to change it in Towny itself, but adding a sort event is overall a better solution

#### Attestations

- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.

In making this pull request, I declare that I have not used an AI toolset to design or code this pull request, and that I am a human who coded this without any influence from an LLM.
