### PR TITLE
Allow townless players to reclaim ruins.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -3510,6 +3510,11 @@ public enum ConfigNodes {
 			"# If this is true, when a town becomes a ruin they also become open to join,",
 			"# meaning any townless player could join the town and reclaim it.",
 			"# You should expect this to be abused by players who will reclaim a town to prevent someone else reclaiming it."),
+	TOWN_RUINING_TOWNS_CAN_BE_CLAIMED_BY_TOWNLESS_PLAYERS(
+			"town_ruining.town_ruins.ruins_can_be_reclaimed_by_townless_players",
+			"false",
+			"",
+			"# When this is true, players who have no town can also reclaim the ruin. While false, only residents of the Town can reclaim the ruin."),
 	TOWN_RUINING_TOWN_DEPOSITS_BANK_TO_NATION(
 			"town_ruining.town_ruins.town_bank_is_sent_to_nation",
 			"false",

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -3925,6 +3925,10 @@ public class TownySettings {
 		return getBoolean(ConfigNodes.TOWN_RUINING_TOWNS_BECOME_OPEN);
 	}
 
+	public static boolean canRuinsBeReclaimedByTownlessPlayers() {
+		return getBoolean(ConfigNodes.TOWN_RUINING_TOWNS_CAN_BE_CLAIMED_BY_TOWNLESS_PLAYERS);
+	}
+
 	public static boolean areRuinedTownsBanksPaidToNation() {
 		return getBoolean(ConfigNodes.TOWN_RUINING_TOWN_DEPOSITS_BANK_TO_NATION);
 	}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/TownRuinUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/TownRuinUtil.java
@@ -207,8 +207,9 @@ public class TownRuinUtil {
 			return;
 		}
 
-		if ((!TownySettings.canRuinsBeReclaimedByTownlessPlayers() && !town.hasResident(resident)) // Resident left the town before accepting the ruining confirmation.
-			|| (TownySettings.canRuinsBeReclaimedByTownlessPlayers() && resident.hasTown())) {     // Resident was townless, then joined another town before accepting the confirmation.
+		// Resident left the town before accepting the ruining confirmation and isn't allowed to be townless or,
+		// Resident was townless, then joined another town before accepting the confirmation.
+		if (!town.hasResident(resident) && (!TownySettings.canRuinsBeReclaimedByTownlessPlayers() || resident.hasTown())) {
 			if (resident.isOnline())
 				TownyMessaging.sendErrorMsg(resident.getPlayer(), Translatable.of("msg_err_dont_belong_town"));
 			return;

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/TownRuinUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/TownRuinUtil.java
@@ -207,6 +207,13 @@ public class TownRuinUtil {
 			return;
 		}
 
+		if ((!TownySettings.canRuinsBeReclaimedByTownlessPlayers() && !town.hasResident(resident)) // Resident left the town before accepting the ruining confirmation.
+			|| (TownySettings.canRuinsBeReclaimedByTownlessPlayers() && resident.hasTown())) {     // Resident was townless, then joined another town before accepting the confirmation.
+			if (resident.isOnline())
+				TownyMessaging.sendErrorMsg(resident.getPlayer(), Translatable.of("msg_err_dont_belong_town"));
+			return;
+		}
+
 		town.setRuined(false);
 		town.setRuinedTime(0);
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/TownRuinUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/TownRuinUtil.java
@@ -202,16 +202,14 @@ public class TownRuinUtil {
 	public static void reclaimTown(@NotNull Resident resident, @NotNull Town town) {
 		// Re-test that the town is still ruined, because Confirmations can be accepted out-of-order.
 		if (!town.isRuined()) {
-			if (resident.isOnline())
-				TownyMessaging.sendErrorMsg(resident.getPlayer(), Translatable.of("msg_err_cannot_reclaim_town_unless_ruined"));
+			TownyMessaging.sendErrorMsg(resident.getPlayer(), Translatable.of("msg_err_cannot_reclaim_town_unless_ruined"));
 			return;
 		}
 
 		// Resident left the town before accepting the ruining confirmation and isn't allowed to be townless or,
 		// Resident was townless, then joined another town before accepting the confirmation.
 		if (!town.hasResident(resident) && (!TownySettings.canRuinsBeReclaimedByTownlessPlayers() || resident.hasTown())) {
-			if (resident.isOnline())
-				TownyMessaging.sendErrorMsg(resident.getPlayer(), Translatable.of("msg_err_dont_belong_town"));
+			TownyMessaging.sendErrorMsg(resident.getPlayer(), Translatable.of("msg_err_dont_belong_town"));
 			return;
 		}
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/TownRuinUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/TownRuinUtil.java
@@ -163,10 +163,18 @@ public class TownRuinUtil {
 	public static void processRuinedTownReclaimRequest(Player player) {
 		try {
 			final Resident resident = TownyUniverse.getInstance().getResident(player.getUniqueId());
-			final Town town = resident != null ? resident.getTownOrNull() : null;
+			Town town = resident != null ? resident.getTownOrNull() : null;
 
-			if (town == null)
+			if (resident == null || (town == null && !TownySettings.canRuinsBeReclaimedByTownlessPlayers()))
 				throw new TownyException(Translatable.of("msg_err_dont_belong_town"));
+
+			// We have a townless player buying the ruined town, get the ruin from the player location.
+			if (town == null)
+				town = TownyAPI.getInstance().getTown(player.getLocation());
+
+			// Player is not stood in a town at all.
+			if (town == null)
+				throw new TownyException(Translatable.of("msg_err_no_ruined_town_here"));
 
 			//Ensure town is ruined
 			if (!town.isRuined())
@@ -175,12 +183,13 @@ public class TownRuinUtil {
 			//Get cost of reclaiming.
 			double townReclaimCost = TownySettings.getEcoPriceReclaimTown();
 
-			//Validate if player can remove at this time
+			//Validate if player can reclaim at this time
 			if (TownySettings.getTownRuinsMinDurationHours() - getTimeSinceRuining(town) > 0)
 				throw new TownyException(Translatable.of("msg_err_cannot_reclaim_town_yet", TownySettings.getTownRuinsMinDurationHours() - getTimeSinceRuining(town)));
 
+			final Town finalTown = town;
 			//Ask them to confirm they want to reclaim the town.
-			Confirmation.runOnAccept(() -> reclaimTown(resident, town))
+			Confirmation.runOnAccept(() -> reclaimTown(resident, finalTown))
 			.setCost(new ConfirmationTransaction(() -> townReclaimCost, resident, "Cost of town reclaim.", Translatable.of("msg_insuf_funds")))
 			.setTitle(Translatable.of("msg_confirm_purchase", TownyEconomyHandler.getFormattedBalance(townReclaimCost)))
 			.setCancellableEvent(new TownPreReclaimEvent(town, resident, player))
@@ -200,6 +209,14 @@ public class TownRuinUtil {
 
 		town.setRuined(false);
 		town.setRuinedTime(0);
+
+		// Townless players can be allowed to reclaim ruins, if configured.
+		if (!town.hasResident(resident)) {
+			try {
+				resident.setTown(town);
+				resident.save();
+			} catch (AlreadyRegisteredException ignored) {}
+		}
 
 		// The admin unruin command would result in the NPC mayor being deleted without this check.
 		if (!resident.equals(town.getMayor()))

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -2728,3 +2728,5 @@ msg_town_plots_trustlist_resident_title: "%s Trusted Plot List (%s)"
 msg_town_plots_trustlist_town_title: "%s Trusted Plot List"
 msg_list_plotgroups_trustlist_component: " (Group of %s plots)"
 msg_list_trusted_hover: "Trusts: %s"
+
+msg_err_no_ruined_town_here: "You must be standing in a ruined town to reclaim it when you're not a resident."


### PR DESCRIPTION


<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->

```
  - New Config Option:
town_ruining.town_ruins.ruins_can_be_reclaimed_by_townless_players
    - Default: false
    - When this is true, players who have no town can also reclaim the
ruin. While false, only residents of the Town can reclaim the ruin.
```
____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

Closes #8099


____

#### Attestations

- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.

In making this pull request, I declare that I have not used an AI toolset to design or code this pull request, and that I am a human who coded this without any influence from an LLM.
