### PR TITLE
Fix spectators/vanished players being able to prevent pvp toggling

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -744,8 +744,7 @@ public enum ConfigNodes {
 			"global_town_settings.outsiders_prevent_pvp_toggle",
 			"false",
 			"",
-			"# If set to true, Towny will prevent a town or plot from enabling PVP while an outsider is within the town's or plot's boundaries.",
-			"# When active this feature can cause a bit of lag when the /t toggle pvp command is used, depending on how many players are online."
+			"# If set to true, Towny will prevent a town or plot from enabling PVP while an outsider is within the town's or plot's boundaries."
 	),
 	GTOWN_SETTINGS_HOMEBLOCKS_PREVENT_FORCEPVP(
 			"global_town_settings.homeblocks_prevent_forcepvp",

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/PlotCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/PlotCommand.java
@@ -686,8 +686,9 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 
 		if (TownBlockType.ARENA.equals(townBlockType) && TownySettings.getOutsidersPreventPVPToggle()) {
 			for (Player target : Bukkit.getOnlinePlayers()) {
-				if (!townBlock.getTownOrNull().hasResident(target) && !player.getName().equals(target.getName()) && townBlock.getWorldCoord().equals(WorldCoord.parseWorldCoord(target)))
+				if (!townBlock.getTownOrNull().hasResident(target) && !player.equals(target) && townBlock.getWorldCoord().containsCoordinate(target.getX(), target.getZ()) && !target.getGameMode().isInvulnerable()) {
 					throw new TownyException(Translatable.of("msg_cant_toggle_pvp_outsider_in_plot"));
+				}
 			}
 		}
 
@@ -1210,8 +1211,9 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 
 		if (TownySettings.getOutsidersPreventPVPToggle() && choice.orElse(!townBlock.getPermissions().pvp)) {
 			for (Player target : Bukkit.getOnlinePlayers()) {
-				if (!town.hasResident(target) && !player.getName().equals(target.getName()) && townBlock.getWorldCoord().equals(WorldCoord.parseWorldCoord(target)))
+				if (!town.hasResident(target) && !player.equals(target) && townBlock.getWorldCoord().containsCoordinate(target.getX(), target.getZ()) && !target.getGameMode().isInvulnerable()) {
 					throw new TownyException(Translatable.of("msg_cant_toggle_pvp_outsider_in_plot"));
+				}
 			}
 		}
 
@@ -1927,8 +1929,9 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 
 			if (TownBlockType.ARENA.equals(type) && TownySettings.getOutsidersPreventPVPToggle()) {
 				for (Player target : Bukkit.getOnlinePlayers()) {
-					if (!town.hasResident(target) && !player.getName().equals(target.getName()) && tb.getWorldCoord().equals(WorldCoord.parseWorldCoord(target)))
+					if (!town.hasResident(target) && !player.equals(target) && tb.getWorldCoord().containsCoordinate(target.getX(), target.getZ()) && !target.getGameMode().isInvulnerable()) {
 						throw new TownyException(Translatable.of("msg_cant_toggle_pvp_outsider_in_plot"));
+					}
 				}
 			}
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/PlotCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/PlotCommand.java
@@ -686,7 +686,7 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 
 		if (TownBlockType.ARENA.equals(townBlockType) && TownySettings.getOutsidersPreventPVPToggle()) {
 			for (Player target : Bukkit.getOnlinePlayers()) {
-				if (!townBlock.getTownOrNull().hasResident(target) && !player.equals(target) && townBlock.getWorldCoord().containsCoordinate(target.getX(), target.getZ()) && !target.getGameMode().isInvulnerable()) {
+				if (!townBlock.getTownOrNull().hasResident(target) && !player.equals(target) && townBlock.getWorldCoord().containsCoordinate(target.getX(), target.getZ()) && !target.getGameMode().isInvulnerable() && player.canSee(target)) {
 					throw new TownyException(Translatable.of("msg_cant_toggle_pvp_outsider_in_plot"));
 				}
 			}
@@ -1211,7 +1211,7 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 
 		if (TownySettings.getOutsidersPreventPVPToggle() && choice.orElse(!townBlock.getPermissions().pvp)) {
 			for (Player target : Bukkit.getOnlinePlayers()) {
-				if (!town.hasResident(target) && !player.equals(target) && townBlock.getWorldCoord().containsCoordinate(target.getX(), target.getZ()) && !target.getGameMode().isInvulnerable()) {
+				if (!town.hasResident(target) && !player.equals(target) && townBlock.getWorldCoord().containsCoordinate(target.getX(), target.getZ()) && !target.getGameMode().isInvulnerable() && player.canSee(target)) {
 					throw new TownyException(Translatable.of("msg_cant_toggle_pvp_outsider_in_plot"));
 				}
 			}
@@ -1929,7 +1929,7 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 
 			if (TownBlockType.ARENA.equals(type) && TownySettings.getOutsidersPreventPVPToggle()) {
 				for (Player target : Bukkit.getOnlinePlayers()) {
-					if (!town.hasResident(target) && !player.equals(target) && tb.getWorldCoord().containsCoordinate(target.getX(), target.getZ()) && !target.getGameMode().isInvulnerable()) {
+					if (!town.hasResident(target) && !player.equals(target) && tb.getWorldCoord().containsCoordinate(target.getX(), target.getZ()) && !target.getGameMode().isInvulnerable() && player.canSee(target)) {
 						throw new TownyException(Translatable.of("msg_cant_toggle_pvp_outsider_in_plot"));
 					}
 				}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -1522,8 +1522,9 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 			// Test to see if an outsider being inside of the Town would prevent toggling PVP.
 			if (TownySettings.getOutsidersPreventPVPToggle() && choice.orElse(!town.isPVP())) {
 				for (Player target : Bukkit.getOnlinePlayers()) {
-					if (!town.hasResident(target) && town.equals(TownyAPI.getInstance().getTown(target.getLocation())))
+					if (!town.hasResident(target) && !sender.equals(target) && town.equals(WorldCoord.parseWorldCoord(target).getTownOrNull()) && !target.getGameMode().isInvulnerable()) {
 						throw new TownyException(Translatable.of("msg_cant_toggle_pvp_outsider_in_town"));
+					}
 				}
 			}
 		}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -1522,7 +1522,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 			// Test to see if an outsider being inside of the Town would prevent toggling PVP.
 			if (TownySettings.getOutsidersPreventPVPToggle() && choice.orElse(!town.isPVP())) {
 				for (Player target : Bukkit.getOnlinePlayers()) {
-					if (!town.hasResident(target) && !sender.equals(target) && town.equals(WorldCoord.parseWorldCoord(target).getTownOrNull()) && !target.getGameMode().isInvulnerable()) {
+					if (!town.hasResident(target) && !sender.equals(target) && town.equals(WorldCoord.parseWorldCoord(target).getTownOrNull()) && !target.getGameMode().isInvulnerable() && (!(sender instanceof Player player) || player.canSee(target))) {
 						throw new TownyException(Translatable.of("msg_cant_toggle_pvp_outsider_in_town"));
 					}
 				}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Fixes an admin in creative/spectator/vanish being able to prevent pvp from being toggled in a plot when using the outsiders_prevent_pvp_toggle option. Also removes a comment about the option possibly causing lag when /t toggle pvp is used, as the checks it does aren't able to cause lag on even the worst of servers.

____

#### Attestations

- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.

In making this pull request, I declare that I have not used an AI toolset to design or code this pull request, and that I am a human who coded this without any influence from an LLM.
