### PR TITLE
Add res check to isHideTownBalanceEnabled

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -282,16 +282,8 @@ public class TownyFormatter {
 	 */
 	public static StatusScreen getStatus(Town town, CommandSender sender) {
 		boolean isSenderAdmin = TownyUniverse.getInstance().getPermissionSource().isTownyAdmin(sender);
-		boolean isSenderResidentOfTown = false;
+		boolean isSenderResidentOfTown = sender instanceof Player player && town.hasResident(player);
         
-        if (sender instanceof Player player) {
-            Resident resident = TownyAPI.getInstance().getResident(player);
-            
-        if (resident != null && resident.hasTown()) {
-            isSenderResidentOfTown = resident.getTownOrNull().equals(town);
-            }
-        }
-
 		final Translator translator = Translator.locale(sender);
 		StatusScreen screen = new StatusScreen(sender);
 		TownyWorld world = town.getHomeblockWorld();

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -356,7 +356,7 @@ public class TownyFormatter {
 			if (TownyEconomyHandler.isActive() && (!TownySettings.isHideTownBalanceEnabled() || isSenderAdmin || isSenderResidentOfTown))
 				MoneyUtil.addTownMoneyComponents(town, translator, screen);
 
-            // Mayor: MrSand
+			// Mayor: MrSand
 			if (town.getMayor() != null) {
 				screen.addComponentOf("mayor", colourKeyValue(translator.of("rank_list_mayor"), town.getMayor().getFormattedName()),
 					HoverEvent.showText(translator.component("registered_last_online", registeredFormat.format(town.getMayor().getRegistered()), lastOnlineFormatIncludeYear.format(town.getMayor().getLastOnline()))

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -353,13 +353,8 @@ public class TownyFormatter {
 		// Only display the remaining fields if town is not ruined
 		} else {
 			// | Bank: 534 coins
-				if (TownyEconomyHandler.isActive() 
-                && (!TownySettings.isHideTownBalanceEnabled()
-                    || isSenderAdmin 
-                    || isSenderResidentOfTown))
-            {        
-                MoneyUtil.addTownMoneyComponents(town, translator, screen);
-            }
+			if (TownyEconomyHandler.isActive() && (!TownySettings.isHideTownBalanceEnabled() || isSenderAdmin || isSenderResidentOfTown))
+				MoneyUtil.addTownMoneyComponents(town, translator, screen);
 
             // Mayor: MrSand
 			if (town.getMayor() != null) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -282,7 +282,16 @@ public class TownyFormatter {
 	 */
 	public static StatusScreen getStatus(Town town, CommandSender sender) {
 		boolean isSenderAdmin = TownyUniverse.getInstance().getPermissionSource().isTownyAdmin(sender);
-		
+		        boolean isSenderResidentOfTown = false;
+        
+        if (sender instanceof Player player) {
+            Resident resident = TownyAPI.getInstance().getResident(player);
+            
+        if (resident != null && resident.hasTown()) {
+            isSenderResidentOfTown = resident.getTownOrNull().equals(town);
+            }
+        }
+
 		final Translator translator = Translator.locale(sender);
 		StatusScreen screen = new StatusScreen(sender);
 		TownyWorld world = town.getHomeblockWorld();
@@ -352,10 +361,15 @@ public class TownyFormatter {
 		// Only display the remaining fields if town is not ruined
 		} else {
 			// | Bank: 534 coins
-			if (TownyEconomyHandler.isActive() && (!TownySettings.isHideTownBalanceEnabled() || isSenderAdmin))
-				MoneyUtil.addTownMoneyComponents(town, translator, screen);
+				if (TownyEconomyHandler.isActive() 
+                && (!TownySettings.isHideTownBalanceEnabled()
+                    || isSenderAdmin 
+                    || isSenderResidentOfTown))
+            {        
+                MoneyUtil.addTownMoneyComponents(town, translator, screen);
+            }
 
-			// Mayor: MrSand
+            // Mayor: MrSand
 			if (town.getMayor() != null) {
 				screen.addComponentOf("mayor", colourKeyValue(translator.of("rank_list_mayor"), town.getMayor().getFormattedName()),
 					HoverEvent.showText(translator.component("registered_last_online", registeredFormat.format(town.getMayor().getRegistered()), lastOnlineFormatIncludeYear.format(town.getMayor().getLastOnline()))

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -282,7 +282,7 @@ public class TownyFormatter {
 	 */
 	public static StatusScreen getStatus(Town town, CommandSender sender) {
 		boolean isSenderAdmin = TownyUniverse.getInstance().getPermissionSource().isTownyAdmin(sender);
-		        boolean isSenderResidentOfTown = false;
+		boolean isSenderResidentOfTown = false;
         
         if (sender instanceof Player player) {
             Resident resident = TownyAPI.getInstance().getResident(player);


### PR DESCRIPTION
#### Description: 
Adds resident check for new hide town balance. This allows town residents to still see town balance so they can manage upkeep while still blocking town balance from being publicly available if config is set.


#### Attestations

- [X ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.

In making this pull request, I declare that I have not used an AI toolset to design or code this pull request, and that I am a human who coded this without any influence from an LLM.
