### PR TITLE
Fix non-player portal creation not working when the town is the same on both ends.

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyWorldListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyWorldListener.java
@@ -182,6 +182,7 @@ public class TownyWorldListener implements Listener {
 			}
 		} else {
 			WorldCoord lastWorldCoord = null;
+			WorldCoord originCoord = event.getEntity() != null ? WorldCoord.parseWorldCoord(event.getEntity()) : null;
 
 			// No player is involved in the event as far as we can tell, prevent creating the portal based on whether there's a town on the other side.
 			for (final BlockState block : event.getBlocks()) {
@@ -194,8 +195,13 @@ public class TownyWorldListener implements Listener {
 				}
 
 				if (worldCoord.hasTownBlock()) {
-					event.setCancelled(true);
-					break;
+					// When originCoord isn't null we can assume a non-player entity is creating
+					// this portal, and use that entity to judge the town on the origin side.
+					if (originCoord == null || !originCoord.hasTown(worldCoord.getTownOrNull())) {
+						event.setCancelled(true);
+						break;
+					}
+					// originCoord isn't null and the town there is the same as our worldCoord.
 				}
 			}
 		}


### PR DESCRIPTION

<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


Closes #8262


____

#### Attestations

- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.

In making this pull request, I declare that I have not used an AI toolset to design or code this pull request, and that I am a human who coded this without any influence from an LLM.
