### PR TITLE
Make obfuscated decoration no longer user safe

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/TownyComponents.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/TownyComponents.java
@@ -2,6 +2,7 @@ package com.palmergames.bukkit.towny.utils;
 
 import com.palmergames.bukkit.util.Colors;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.kyori.adventure.text.minimessage.tag.standard.StandardTags;
@@ -12,6 +13,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * Internal utility class for common interactions with adventure components.
@@ -27,7 +29,7 @@ public class TownyComponents {
 	public static final MiniMessage USER_SAFE = MiniMessage.builder()
 		.tags(TagResolver.builder()
 			.resolver(StandardTags.color())
-			.resolvers(StandardTags.decorations())
+			.resolvers(TagResolver.resolver(Stream.of(TextDecoration.values()).filter(decoration -> decoration != TextDecoration.OBFUSCATED).map(StandardTags::decorations).toList()))
 			.resolvers(StandardTags.gradient())
 			.resolvers(StandardTags.rainbow())
 			.resolvers(getRecentlyAddedTagResolvers())


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Removes the obfuscated tag from being usable in titles to prevent users from making a mess of things

There's still a couple of places where USER_SAFE isn't used (the initial set title message, chunk notifications) but those are a bit more complex to take care of

____

#### Attestations

- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.

In making this pull request, I declare that I have not used an AI toolset to design or code this pull request, and that I am a human who coded this without any influence from an LLM.
