### PR TITLE
Add option to preserve town ruin permissions

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -3526,6 +3526,13 @@ public enum ConfigNodes {
 			"false",
 			"",
 			"# If this is true, when a town becomes a ruin, and they are a member of a nation, any money in the town bank will be deposited to the nation bank."),
+	TOWN_RUINING_TOWN_PERMISSIONS_CHANGE_ON_RUIN(
+			"town_ruining.town_ruins.do_permissions_change_on_ruin",
+			"true",
+			"",
+			"# If this is false, a town's and its plots' permission settings will not change when the town becomes a ruin or is reclaimed.",
+			"# The ruins_become_open setting is independent and can still make the ruined town open to join.",
+			"# The do_plots_permissions_change_to_allow_all setting has no effect while this is false."),
 	TOWN_RUINING_TOWN_PLOTS_PERMISSIONS_OPEN_UP_PROGRESSIVELY(
 			"town_ruining.town_ruins.do_plots_permissions_change_to_allow_all",
 			"false",

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -3933,8 +3933,12 @@ public class TownySettings {
 		return getBoolean(ConfigNodes.TOWN_RUINING_TOWN_DEPOSITS_BANK_TO_NATION);
 	}
 
+	public static boolean doRuinsPermissionsChange() {
+		return getBoolean(ConfigNodes.TOWN_RUINING_TOWN_PERMISSIONS_CHANGE_ON_RUIN);
+	}
+
 	public static boolean doRuinsPlotPermissionsProgressivelyAllowAll() {
-		return getBoolean(ConfigNodes.TOWN_RUINING_TOWN_PLOTS_PERMISSIONS_OPEN_UP_PROGRESSIVELY);
+		return doRuinsPermissionsChange() && getBoolean(ConfigNodes.TOWN_RUINING_TOWN_PLOTS_PERMISSIONS_OPEN_UP_PROGRESSIVELY);
 	}
 
 	public static boolean isHideTownRuinedStatusEnabled() {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/TownRuinUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/TownRuinUtil.java
@@ -20,6 +20,7 @@ import com.palmergames.bukkit.towny.exceptions.AlreadyRegisteredException;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.District;
 import com.palmergames.bukkit.towny.object.Nation;
+import com.palmergames.bukkit.towny.object.PermissionData;
 import com.palmergames.bukkit.towny.object.PlotGroup;
 import com.palmergames.bukkit.towny.object.Resident;
 
@@ -39,8 +40,12 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 
@@ -69,7 +74,7 @@ public class TownRuinUtil {
 	 * Put town into ruined state:
 	 * 1. Remove town from nation
 	 * 2. Set mayor to NPC
-	 * 3. Enable all perms
+	 * 3. Enable all perms, if configured
 	 * 4. Now, the residents cannot run /plot commands, and some /t commands
 	 * 5. Town will later be deleted full, unless it is reclaimed
 	 * @param town The town to put into a "ruined" state.
@@ -112,18 +117,34 @@ public class TownRuinUtil {
 		town.setRuinedTime(System.currentTimeMillis());
 		town.setPublic(TownySettings.areRuinsMadePublic());
 		town.setOpen(TownySettings.areRuinsMadeOpen());
-		town.getPermissions().setAll(true);
+		final boolean changePermissions = TownySettings.doRuinsPermissionsChange();
+		if (changePermissions)
+			town.getPermissions().setAll(true);
 
 		//Return town blocks to the basic, unowned, type
 		for(TownBlock townBlock: town.getTownBlocks()) {
+			final String existingPermissions = changePermissions ? null : townBlock.getPermissions().toString();
+			final Map<Resident, PermissionData> existingPermissionOverrides = !changePermissions && townBlock.hasPermissionOverrides()
+				? new LinkedHashMap<>(townBlock.getPermissionOverrides())
+				: null;
+			final Set<Resident> existingTrustedResidents = !changePermissions && townBlock.hasTrustedResidents()
+				? new LinkedHashSet<>(townBlock.getTrustedResidents())
+				: null;
 			if (townBlock.hasResident())
 				townBlock.removeResident();               // Removes any personal ownership.
 			townBlock.setType(TownBlockType.RESIDENTIAL); // Sets the townblock's perm line to the Town's perm line set above.
 			townBlock.setPlotPrice(-1);                   // Makes the plot not for sale.
 			townBlock.removePlotObjectGroup();            // Removes plotgroup if it were present.
 			townBlock.removeDistrict();                   // Removes district if it were present.
-			townBlock.setPermissionOverrides(null);       // Removes all permission overrides from the plot.
-			townBlock.setTrustedResidents(null);          // Removes all trusted residents.
+			if (changePermissions) {
+				townBlock.setPermissionOverrides(null);   // Removes all permission overrides from the plot.
+				townBlock.setTrustedResidents(null);      // Removes all trusted residents.
+			} else {
+				townBlock.setPermissions(existingPermissions);
+				townBlock.setChanged(!existingPermissions.equals(town.getPermissions().toString()));
+				townBlock.setPermissionOverrides(existingPermissionOverrides);
+				townBlock.setTrustedResidents(existingTrustedResidents);
+			}
 			townBlock.save();
 		}
 		
@@ -228,12 +249,14 @@ public class TownRuinUtil {
 		if (!resident.equals(town.getMayor()))
 			setMayor(town, resident); //Set player as mayor (and remove npc)
 
-		// Set permission line to the config's default settings.
-		town.getPermissions().loadDefault(town);
-		for (TownBlock townBlock : town.getTownBlocks()) {
-			townBlock.getPermissions().loadDefault(town);
-			townBlock.setChanged(false);
-			townBlock.save();
+		if (TownySettings.doRuinsPermissionsChange()) {
+			// Set permission line to the config's default settings.
+			town.getPermissions().loadDefault(town);
+			for (TownBlock townBlock : town.getTownBlocks()) {
+				townBlock.getPermissions().loadDefault(town);
+				townBlock.setChanged(false);
+				townBlock.save();
+			}
 		}
 		
 		town.save();

--- a/Towny/src/main/resources/ChangeLog.txt
+++ b/Towny/src/main/resources/ChangeLog.txt
@@ -10995,3 +10995,9 @@ c
     - Closes #8262.
 0.103.2.0:
   - Bump version for Release.
+  - Add an option to preserve town and plot permission settings while towns are ruined.
+  - New Config Option: town_ruining.town_ruins.do_permissions_change_on_ruin
+    - Default: true
+    - When false, town and plot permission settings remain unchanged when a town becomes a ruin or is reclaimed.
+    - ruins_become_open still controls whether the ruined town is open to join.
+    - do_plots_permissions_change_to_allow_all has no effect while this option is false.

--- a/Towny/src/test/java/com/palmergames/bukkit/towny/config/TownRuinConfigTests.java
+++ b/Towny/src/test/java/com/palmergames/bukkit/towny/config/TownRuinConfigTests.java
@@ -1,0 +1,43 @@
+package com.palmergames.bukkit.towny.config;
+
+import com.palmergames.bukkit.config.ConfigNodes;
+import com.palmergames.bukkit.towny.TownySettings;
+import com.palmergames.bukkit.towny.test.TownyConfigExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(TownyConfigExtension.class)
+public class TownRuinConfigTests {
+	@BeforeEach
+	void reset() {
+		TownySettings.getConfig().set(ConfigNodes.TOWN_RUINING_TOWN_PERMISSIONS_CHANGE_ON_RUIN.getRoot(), true);
+		TownySettings.getConfig().set(ConfigNodes.TOWN_RUINING_TOWN_PLOTS_PERMISSIONS_OPEN_UP_PROGRESSIVELY.getRoot(), false);
+		TownySettings.getConfig().set(ConfigNodes.TOWN_RUINING_TOWNS_BECOME_OPEN.getRoot(), false);
+	}
+
+	@Test
+	void testRuinPermissionsChangeByDefault() {
+		assertTrue(TownySettings.doRuinsPermissionsChange());
+	}
+
+	@Test
+	void testProgressivePermissionChangesAreDisabledWhenRuinPermissionsArePreserved() {
+		TownySettings.getConfig().set(ConfigNodes.TOWN_RUINING_TOWN_PERMISSIONS_CHANGE_ON_RUIN.getRoot(), false);
+		TownySettings.getConfig().set(ConfigNodes.TOWN_RUINING_TOWN_PLOTS_PERMISSIONS_OPEN_UP_PROGRESSIVELY.getRoot(), true);
+
+		assertFalse(TownySettings.doRuinsPlotPermissionsProgressivelyAllowAll());
+	}
+
+	@Test
+	void testRuinsBecomeOpenIndependentlyOfPermissionChanges() {
+		TownySettings.getConfig().set(ConfigNodes.TOWN_RUINING_TOWN_PERMISSIONS_CHANGE_ON_RUIN.getRoot(), false);
+		TownySettings.getConfig().set(ConfigNodes.TOWN_RUINING_TOWNS_BECOME_OPEN.getRoot(), true);
+
+		assertTrue(TownySettings.areRuinsMadeOpen());
+		assertFalse(TownySettings.doRuinsPermissionsChange());
+	}
+}


### PR DESCRIPTION
#### Description:
Adds a backwards-compatible town ruin option that preserves town and plot permission settings, allowing ruins to serve as a final reclaim window without automatically making them lootable.

When disabled, permission lines, plot permission overrides, and trusted-resident settings remain intact through ruin and reclaim. `ruins_become_open` remains independent and can still make a ruined town joinable. `do_plots_permissions_change_to_allow_all` has no effect while ruin permission changes are disabled.

____
#### New Nodes/Commands/ConfigOptions:

- `town_ruining.town_ruins.do_permissions_change_on_ruin`
  - Default: `true` (preserves existing behavior)
  - Set to `false` to leave permission settings unchanged.

____
#### Relevant Towny Issue ticket:

None.

____
#### Testing:

- Full Maven reactor test suite: 146 tests passed, 0 failures.

____
#### Attestations

- [ ] I have tested this pull request on a server.

This implementation and its tests were prepared with Codex assistance, so the repository template's no-LLM-influence declaration cannot truthfully be made.