### PR TITLE
Add resident trustlist command

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/ResidentCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/ResidentCommand.java
@@ -55,6 +55,7 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 		"jail",
 		"plotlist",
 		"outlawlist",
+		"trustlist",
 		"spawn",
 		"toggle",
 		"set",
@@ -148,6 +149,7 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 					break;
 				case "tax":
 				case "outlawlist":
+				case "trustlist":
 					if (args.length == 2)
 						return getTownyStartingWith(args[1], "r");
 					break;
@@ -250,6 +252,7 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 		case "tax" -> parseResidentTax(player, StringMgmt.remFirstArg(split));
 		case "plotlist" -> parseResidentPlotlist(player, StringMgmt.remFirstArg(split));
 		case "outlawlist" -> parseResidentOutlawlist(player, StringMgmt.remFirstArg(split));
+		case "trustlist" -> parseResidentTrustlist(player, StringMgmt.remFirstArg(split));
 		case "jail" -> parseResidentJail(player, StringMgmt.remFirstArg(split));
 		case "set" -> residentSet(player, StringMgmt.remFirstArg(split));
 		case "toggle" -> residentToggle(player, StringMgmt.remFirstArg(split));
@@ -332,6 +335,14 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 		}
 
 		TownyMessaging.sendMessage(player, TownyFormatter.getFormattedTownyObjects(Translatable.of("outlawed_in").forLocale(player), new ArrayList<>(resident.getTownsOutlawedIn())));
+	}
+
+	private void parseResidentTrustlist(Player player, String[] split) throws TownyException {
+		checkPermOrThrow(player, PermissionNodes.TOWNY_COMMAND_RESIDENT_TRUSTLIST.getNode());
+
+		Resident resident = split.length == 0 ? getResidentOrThrow(player) : getResidentOrThrow(split[0]);
+
+		TownyMessaging.sendMessage(player, TownyFormatter.getFormattedTownyObjects(Translatable.of("trusted_in").forLocale(player), new ArrayList<>(resident.getTownsTrustedIn())));
 	}
 
 	private void parseResidentJail(Player player, String[] split) throws TownyException {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Resident.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Resident.java
@@ -833,6 +833,13 @@ public class Resident extends TownyObject implements InviteReceiver, EconomyHand
 		return TownyUniverse.getInstance().getTowns().stream().filter(t -> t.hasOutlaw(this)).collect(Collectors.toList());
 	}
 
+	/**
+	 * @return All towns that the resident is trusted in.
+	 */
+	public List<Town> getTownsTrustedIn() {
+		return TownyUniverse.getInstance().getTowns().stream().filter(t -> t.hasTrustedResident(this)).collect(Collectors.toList());
+	}
+
 	@Override
 	public boolean hasTownBlock(TownBlock townBlock) {
 		return townBlocks.contains(townBlock);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
@@ -267,6 +267,7 @@ public enum PermissionNodes {
 	TOWNY_COMMAND_RESIDENT_TAX("towny.command.resident.tax"),
 	TOWNY_COMMAND_RESIDENT_PLOTLIST("towny.command.resident.plotlist"),
 	TOWNY_COMMAND_RESIDENT_OUTLAWLIST("towny.command.resident.outlawlist"),
+	TOWNY_COMMAND_RESIDENT_TRUSTLIST("towny.command.resident.trustlist"),
 	TOWNY_COMMAND_RESIDENT_JAIL("towny.command.resident.jail"),
 	TOWNY_COMMAND_RESIDENT_SET("towny.command.resident.set.*"),
 		TOWNY_COMMAND_RESIDENT_SET_PERM("towny.command.resident.set.perm"),

--- a/Towny/src/main/resources/config-migration.json
+++ b/Towny/src/main/resources/config-migration.json
@@ -961,7 +961,7 @@
     ]
   },
   {
-    "version": "0.103.3.0",
+    "version": "0.103.2.1",
     "changes": [
       {
         "type": "TOWNYPERMS_ADD",

--- a/Towny/src/main/resources/config-migration.json
+++ b/Towny/src/main/resources/config-migration.json
@@ -959,5 +959,15 @@
         "value": ",END_PORTAL_FRAME"
       }
     ]
-  }
+  },
+  {
+    "version": "0.103.3.0",
+    "changes": [
+      {
+        "type": "TOWNYPERMS_ADD",
+        "path": "nomad",
+        "value": "towny.command.resident.trustlist"
+      }
+    ]
+  },
 ]

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -2557,6 +2557,7 @@ msg_err_name_validation_used_in_command_structure: "%s is used in the command st
 msg_town_being_deleted_because_no_residents: "%s is being deleted because it lost its last resident."
 
 outlawed_in: "Outlawed in"
+trusted_in: "Trusted in"
 
 msg_warning_town_deposit_hint: "To put money in your town bank use /town deposit [amount]."
 

--- a/Towny/src/main/resources/plugin.yml
+++ b/Towny/src/main/resources/plugin.yml
@@ -664,6 +664,7 @@ permissions:
             towny.command.resident.list: true
             towny.command.resident.plotlist: true
             towny.command.resident.outlawlist: true
+            towny.command.resident.trustlist: true
             towny.command.resident.set.*: true
             towny.command.resident.otherresident: true
             towny.command.resident.tax: true

--- a/Towny/src/main/resources/townyperms.yml
+++ b/Towny/src/main/resources/townyperms.yml
@@ -31,6 +31,7 @@ nomad:
     - towny.command.resident.set.about
     - towny.command.resident.jail
     - towny.command.resident.outlawlist
+    - towny.command.resident.trustlist
     - towny.command.town.allylist
     - towny.command.town.enemylist
 


### PR DESCRIPTION
#### Description: 
Adds a command to see what towns a player is trusted in
____
#### New Nodes/Commands/ConfigOptions: 
/res trustlist [player] - leaving player empty defaults to sender player
towny.command.resident.trustlist - granted by default, same as outlawlist.
____
#### Relevant Towny Issue ticket:
N/A

____

#### Attestations

- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.

In making this pull request, I declare that I have not used an AI toolset to design or code this pull request, and that I am a human who coded this without any influence from an LLM.