### PR TITLE
Add config to prevent town ruins from clearing town permissions

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -3526,10 +3526,16 @@ public enum ConfigNodes {
 			"false",
 			"",
 			"# If this is true, when a town becomes a ruin, and they are a member of a nation, any money in the town bank will be deposited to the nation bank."),
+	TOWN_RUINING_TOWN_PERMISSIONS_ALLOW_ALL(
+			"town_ruining.town_ruins.do_town_permissions_change_to_allow_all",
+			"true",
+			"",
+			"# If this is true, when a town becomes a ruin, its permissions will be changed to allow all."),
 	TOWN_RUINING_TOWN_PLOTS_PERMISSIONS_OPEN_UP_PROGRESSIVELY(
 			"town_ruining.town_ruins.do_plots_permissions_change_to_allow_all",
 			"false",
 			"",
+			"# This setting has no effect when do_town_permissions_change_to_allow_all is false.",
 			"# If this is true, when a town becomes a ruin, every hour more and more of their plots will have their permissions turned to allow",
 			"# build, destroy, switch, itemuse to on. This will affect the newest claims first and progress until the first claims made are opened up",
 			"# right before the max_duration_hours have passed. When a town has more claims than max_duration_hours, multiple plots will be opened up",

--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -3526,16 +3526,17 @@ public enum ConfigNodes {
 			"false",
 			"",
 			"# If this is true, when a town becomes a ruin, and they are a member of a nation, any money in the town bank will be deposited to the nation bank."),
-	TOWN_RUINING_TOWN_PERMISSIONS_ALLOW_ALL(
-			"town_ruining.town_ruins.do_town_permissions_change_to_allow_all",
+	TOWN_RUINING_PERMISSIONS_ALLOW_ALL(
+			"town_ruining.town_ruins.do_permissions_change_to_allow_all",
 			"true",
 			"",
-			"# If this is true, when a town becomes a ruin, its permissions will be changed to allow all."),
+			"# If this is true, when a town becomes a ruin, its permissions will be changed to allow all.",
+			"# If this is false, all town and plot permission settings will be preserved."),
 	TOWN_RUINING_TOWN_PLOTS_PERMISSIONS_OPEN_UP_PROGRESSIVELY(
 			"town_ruining.town_ruins.do_plots_permissions_change_to_allow_all",
 			"false",
 			"",
-			"# This setting has no effect when do_town_permissions_change_to_allow_all is false.",
+			"# This setting has no effect when do_permissions_change_to_allow_all is false.",
 			"# If this is true, when a town becomes a ruin, every hour more and more of their plots will have their permissions turned to allow",
 			"# build, destroy, switch, itemuse to on. This will affect the newest claims first and progress until the first claims made are opened up",
 			"# right before the max_duration_hours have passed. When a town has more claims than max_duration_hours, multiple plots will be opened up",

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -3933,6 +3933,10 @@ public class TownySettings {
 		return getBoolean(ConfigNodes.TOWN_RUINING_TOWN_DEPOSITS_BANK_TO_NATION);
 	}
 
+	public static boolean doRuinsTownPermissionsAllowAll() {
+		return getBoolean(ConfigNodes.TOWN_RUINING_TOWN_PERMISSIONS_ALLOW_ALL);
+	}
+
 	public static boolean doRuinsPlotPermissionsProgressivelyAllowAll() {
 		return getBoolean(ConfigNodes.TOWN_RUINING_TOWN_PLOTS_PERMISSIONS_OPEN_UP_PROGRESSIVELY);
 	}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -3933,8 +3933,8 @@ public class TownySettings {
 		return getBoolean(ConfigNodes.TOWN_RUINING_TOWN_DEPOSITS_BANK_TO_NATION);
 	}
 
-	public static boolean doRuinsTownPermissionsAllowAll() {
-		return getBoolean(ConfigNodes.TOWN_RUINING_TOWN_PERMISSIONS_ALLOW_ALL);
+	public static boolean doRuinsPermissionsAllowAll() {
+		return getBoolean(ConfigNodes.TOWN_RUINING_PERMISSIONS_ALLOW_ALL);
 	}
 
 	public static boolean doRuinsPlotPermissionsProgressivelyAllowAll() {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/TownRuinUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/TownRuinUtil.java
@@ -112,7 +112,8 @@ public class TownRuinUtil {
 		town.setRuinedTime(System.currentTimeMillis());
 		town.setPublic(TownySettings.areRuinsMadePublic());
 		town.setOpen(TownySettings.areRuinsMadeOpen());
-		town.getPermissions().setAll(true);
+		if (TownySettings.doRuinsTownPermissionsAllowAll())
+			town.getPermissions().setAll(true);
 
 		//Return town blocks to the basic, unowned, type
 		for(TownBlock townBlock: town.getTownBlocks()) {
@@ -284,7 +285,7 @@ public class TownRuinUtil {
 				continue;
 			}
 
-			if (TownySettings.doRuinsPlotPermissionsProgressivelyAllowAll()) {
+			if (TownySettings.doRuinsTownPermissionsAllowAll() && TownySettings.doRuinsPlotPermissionsProgressivelyAllowAll()) {
 				final Town finalTown = town;
 				// We are configured to slowly open up plots' permissions while a town is ruined.
 				Towny.getPlugin().getScheduler().runAsync(() -> allowPermissionsOnRuinedTownBlocks(finalTown));

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/TownRuinUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/TownRuinUtil.java
@@ -112,42 +112,50 @@ public class TownRuinUtil {
 		town.setRuinedTime(System.currentTimeMillis());
 		town.setPublic(TownySettings.areRuinsMadePublic());
 		town.setOpen(TownySettings.areRuinsMadeOpen());
-		if (TownySettings.doRuinsTownPermissionsAllowAll())
+		// Get the config setting for if all permissions should be allowed in ruined towns
+		final boolean setPermissionsAllowAll = TownySettings.doRuinsPermissionsAllowAll();
+		if (setPermissionsAllowAll)
 			town.getPermissions().setAll(true);
 
 		//Return town blocks to the basic, unowned, type
 		for(TownBlock townBlock: town.getTownBlocks()) {
-			if (townBlock.hasResident())
-				townBlock.removeResident();               // Removes any personal ownership.
-			townBlock.setType(TownBlockType.RESIDENTIAL); // Sets the townblock's perm line to the Town's perm line set above.
-			townBlock.setPlotPrice(-1);                   // Makes the plot not for sale.
-			townBlock.removePlotObjectGroup();            // Removes plotgroup if it were present.
-			townBlock.removeDistrict();                   // Removes district if it were present.
-			townBlock.setPermissionOverrides(null);       // Removes all permission overrides from the plot.
-			townBlock.setTrustedResidents(null);          // Removes all trusted residents.
+			// Don't change townblock if config specifies not to
+			if (setPermissionsAllowAll) {
+				if (townBlock.hasResident())
+					townBlock.removeResident();               // Removes any personal ownership.
+				townBlock.setType(TownBlockType.RESIDENTIAL); // Sets the townblock's perm line to the Town's perm line set above.
+				townBlock.removePlotObjectGroup();            // Removes plotgroup if it were present.
+				townBlock.removeDistrict();                   // Removes district if it were present.
+				townBlock.setPermissionOverrides(null);       // Removes all permission overrides from the plot.
+				townBlock.setTrustedResidents(null);          // Removes all trusted residents.
+			}
+			townBlock.setPlotPrice(-1);   // Makes the plot not for sale.
 			townBlock.save();
 		}
 		
-		// Unregister the now empty plotgroups.
-		if (town.getPlotGroups() != null) {
-			for (PlotGroup group : new ArrayList<>(town.getPlotGroups())) {
-				new PlotGroupDeletedEvent(group, null, PlotGroupDeletedEvent.Cause.TOWN_DELETED).callEvent();
-				TownyUniverse.getInstance().getDataSource().removePlotGroup(group);
+		// Perform ruin cleanup if we are setting permissions to AllowAll
+		if (setPermissionsAllowAll) {
+			// Unregister the now empty plotgroups.
+			if (town.getPlotGroups() != null) {
+				for (PlotGroup group : new ArrayList<>(town.getPlotGroups())) {
+					new PlotGroupDeletedEvent(group, null, PlotGroupDeletedEvent.Cause.TOWN_DELETED).callEvent();
+					TownyUniverse.getInstance().getDataSource().removePlotGroup(group);
+				}
 			}
+
+			// Unregister the now empty districts.
+			if (town.getDistricts() != null) {
+				for (District district : new ArrayList<>(town.getDistricts())) {
+					new DistrictDeletedEvent(district, null, DistrictDeletedEvent.Cause.TOWN_DELETED).callEvent();
+					TownyUniverse.getInstance().getDataSource().removeDistrict(district);
+				}
+			}
+
+			// Check if Town has more residents than it should be allowed (if it were the capital of a nation.)
+			if (TownySettings.getMaxResidentsPerTown() > 0)
+				ResidentUtil.reduceResidentCountToFitTownMaxPop(town);
 		}
 
-		// Unregister the now empty districts.
-		if (town.getDistricts() != null) {
-			for (District district : new ArrayList<>(town.getDistricts())) {
-				new DistrictDeletedEvent(district, null, DistrictDeletedEvent.Cause.TOWN_DELETED).callEvent();
-				TownyUniverse.getInstance().getDataSource().removeDistrict(district);
-			}
-		}
-		
-		// Check if Town has more residents than it should be allowed (if it were the capital of a nation.)
-		if (TownySettings.getMaxResidentsPerTown() > 0)
-			ResidentUtil.reduceResidentCountToFitTownMaxPop(town);
-		
 		town.setForSale(false);
 		
 		town.save();
@@ -229,12 +237,15 @@ public class TownRuinUtil {
 		if (!resident.equals(town.getMayor()))
 			setMayor(town, resident); //Set player as mayor (and remove npc)
 
-		// Set permission line to the config's default settings.
-		town.getPermissions().loadDefault(town);
-		for (TownBlock townBlock : town.getTownBlocks()) {
-			townBlock.getPermissions().loadDefault(town);
-			townBlock.setChanged(false);
-			townBlock.save();
+		// Don't reset plot permissions if they were never changed
+		if (TownySettings.doRuinsPermissionsAllowAll()) {
+			// Set permission line to the config's default settings.
+			town.getPermissions().loadDefault(town);
+			for (TownBlock townBlock : town.getTownBlocks()) {
+				townBlock.getPermissions().loadDefault(town);
+				townBlock.setChanged(false);
+				townBlock.save();
+			}
 		}
 		
 		town.save();
@@ -285,7 +296,7 @@ public class TownRuinUtil {
 				continue;
 			}
 
-			if (TownySettings.doRuinsTownPermissionsAllowAll() && TownySettings.doRuinsPlotPermissionsProgressivelyAllowAll()) {
+			if (TownySettings.doRuinsPermissionsAllowAll() && TownySettings.doRuinsPlotPermissionsProgressivelyAllowAll()) {
 				final Town finalTown = town;
 				// We are configured to slowly open up plots' permissions while a town is ruined.
 				Towny.getPlugin().getScheduler().runAsync(() -> allowPermissionsOnRuinedTownBlocks(finalTown));


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Currently when a town becomes a ruin, it always gets all of its town and plot permissions set to true. There is an existing config `do_plots_permissions_change_to_allow_all`, however this only determines if all plots are changed instantly or if the changes happen slowly over time. 

The new config added in this pr: `do_permissions_change_to_allow_all` would allow server owners to have more control over how town ruins work on their server. Its job would be to disable the permissions of a town being changed when entering ruin state entirely. This would allow a servers to use ruin states as a way for town members to safely reclaim a town whos mayor no longer plays without the possibility of items being looted and without permissions being reset entirely. 
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
New Config Options:
```yaml
    # If this is true, when a town becomes a ruin, its permissions will be changed to allow all.
    # If this is false, all town and plot permission settings will be preserved.
    do_permissions_change_to_allow_all: 'false'
```
This is default to true which keeps existing functionality

Updated Config descriptions:
```diff
+   # This setting has no effect when do_permissions_change_to_allow_all is false.
    # If this is true, when a town becomes a ruin, every hour more and more of their plots will have their permissions turned to allow
    # build, destroy, switch, itemuse to on. This will affect the newest claims first and progress until the first claims made are opened up
    # right before the max_duration_hours have passed. When a town has more claims than max_duration_hours, multiple plots will be opened up
    # each hour, ie: 500 claims and 72 max hours = 7 claims per hour.
    # If a Town has less claims than max_duration hours, those claims' permissions are opened up much more slowly with hours passing between
    # plots opening up, ie: 36 claims and 72 max hours = 1 claim every 2 hours.
    # This system is meant to give players across many time zones the chance to loot a town when it falls into ruin.
    do_plots_permissions_change_to_allow_all: 'false'
```
There were no changes to this config option other than a note to say that it no longer does anything when `do_permissions_change_to_allow_all` is `false`

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____

#### Attestations
- [x] I have tested this pull request for defects on a server. 
`do_permissions_change_to_allow_all` set to `true`
This mimics what happens in the current release of towny and would be the new default config value
https://streamable.com/z6cv61
`do_permissions_change_to_allow_all` set to `false`
https://streamable.com/624mme
Checking plot permissions being preserved:
https://streamable.com/p7lu9y

<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.

In making this pull request, I declare that I have not used an AI toolset to design or code this pull request, and that I am a human who coded this without any influence from an LLM.
> While I did previously use an LLM which created [this PR](https://github.com/TownyAdvanced/Towny/pull/8274), as I stated in the original PR, it was meant to be a quick local test with codex to see if something like this would be reasonable to do and work like I thought it would and I did not mean for it to even open a PR. 

> In this PR, I did not use any LLMs and instead took a much simpler approach even then what the LLM suggested originally and took the time to test and document what each config value would do on a development server. 