### PR TITLE
Ensure ChunkNotificationEvent is always thrown

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/ChunkNotification.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/ChunkNotification.java
@@ -130,11 +130,11 @@ public class ChunkNotification {
 	public String getNotificationString(Resident resident) {
 
 		if (notificationFormat.length() == 0)
-			return null;
+			return "";
 		viewerResident = resident;
 		List<String> outputContent = getNotificationContent(resident);
 		if (outputContent.size() == 0)
-			return null;
+			return "";
 		return String.format(notificationFormat, StringMgmt.join(outputContent, notificationSplitter));
 	}
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/ChunkNotificationUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/ChunkNotificationUtil.java
@@ -30,7 +30,7 @@ public class ChunkNotificationUtil {
 	private final static Map<UUID, BossBar> playerBossBarMap = new HashMap<>();
 
 	public static void showChunkNotification(Player player, Resident resident, WorldCoord to, WorldCoord from) {
-		String msg = null;
+		String msg = "";
 		try {
 			ChunkNotification chunkNotifier = new ChunkNotification(from, to);
 			msg = chunkNotifier.getNotificationString(resident);
@@ -38,8 +38,6 @@ public class ChunkNotificationUtil {
 			Towny.getPlugin().getLogger().log(Level.WARNING, "ChunkNotifier generated an NPE, this is harmless but if you'd like to report it the following information will be useful: " + System.lineSeparator() +
 				"  Player: " + player.getName() + "  To: " + to.getWorldName() + "," + to.getX() + "," + to.getZ() + "  From: " + from.getWorldName() + "," + from.getX() + "," + from.getZ(), e);
 		}
-		if (msg == null)
-			return;
 
 		ChunkNotificationEvent cne = new ChunkNotificationEvent(player, msg, to, from);
 		BukkitTools.fireEvent(cne);


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This PR fixes the ChunkNotificationEvent not being thrown when the notification message from Towny is empty. This now allows add-on plugins to modify the notification message to be sent to players in all cases, even when Towny itself would not have sent a notification message.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____

#### Attestations

- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.

In making this pull request, I declare that I have not used an AI toolset to design or code this pull request, and that I am a human who coded this without any influence from an LLM.
