### PR TITLE
Protect players from hostile mobs in claims

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -2096,6 +2096,13 @@ public enum ConfigNodes {
 			"",
 			"# Setting this to false will allow block projectile sources, namely dispensers, to harm the above protected mobs (using potions, arrows, etc.), if they're in the same townblock and PvP is enabled."
 	),
+	PROT_PREVENT_MONSTER_DAMAGE_TO_PLAYERS_IN_MOBLESS_AREAS(
+			"protection.prevent_monster_damage_to_players_in_mobless_areas",
+			"false",
+			"",
+			"# When set to true, players will be protected from monster damage in locations where mobs are disabled.",
+			"# Warning: This allows players to abuse mob farms while being invulnerable in a nearby chunk where mob spawns are disabled."
+	),
 	PROT_POTION_TYPES(
 			"protection.potion_types",
 			"BLINDNESS,NAUSEA,INSTANT_DAMAGE,HUNGER,POISON,SLOWNESS,MINING_FATIGUE,WEAKNESS,WITHER,WIND_CHARGED,WEAVING,INFESTED,OOZING",

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -4097,6 +4097,10 @@ public class TownySettings {
 	public static boolean areProtectedEntitiesProtectedAgainstBlockProjectileSource() {
 		return getBoolean(ConfigNodes.PROT_MOB_TYPES_MOB_VS_BLOCK_PROJECTILE_SOURCE_BYPASS);
 	}
+
+	public static boolean isMonsterDamageBlockedInMoblessAreas() {
+		return getBoolean(ConfigNodes.PROT_PREVENT_MONSTER_DAMAGE_TO_PLAYERS_IN_MOBLESS_AREAS);
+	}
 	
 	public static String getBossBarNotificationColor() {
 		return getString(ConfigNodes.NOTIFICATION_BOSSBARS_COLOR);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/CombatUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/CombatUtil.java
@@ -30,6 +30,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.LightningStrike;
+import org.bukkit.entity.Monster;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.entity.Wolf;
@@ -236,6 +237,9 @@ public class CombatUtil {
 			 * If Defender is a player, Attacker is not.
 			 */
 			if (defendingPlayer != null) {
+				if (attackingEntity instanceof Monster && !TownyAPI.getInstance().areMobsEnabled(defendingPlayer.getLocation())) {
+					return true;
+				}
 
 				/*
 				 * If attackingEntity is a tamed Wolf and...

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/CombatUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/CombatUtil.java
@@ -237,7 +237,12 @@ public class CombatUtil {
 			 * If Defender is a player, Attacker is not.
 			 */
 			if (defendingPlayer != null) {
-				if (attackingEntity instanceof Monster && !TownyAPI.getInstance().areMobsEnabled(defendingPlayer.getLocation())) {
+				/*
+				 * Protects players against monster damage when mobs spawns are not allowed.
+				 */
+				if (TownySettings.isMonsterDamageBlockedInMoblessAreas()
+					&& attackingEntity instanceof Monster
+					&& !TownyAPI.getInstance().areMobsEnabled(defendingPlayer.getLocation())) {
 					return true;
 				}
 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
Add protection for players against hostile mobs when they are standing in a plot where mobs aren't allowed. Currently, players take damage when they are e.g. afk inside claims. This fixes that issue and prevents damage dealt.
**Notes:**
- If needed, this can be locked behind a config option.
- Only monsters are blocked, this means that players still take damage from tamed wolves ect.

____

#### Attestations

- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.

In making this pull request, I declare that I have not used an AI toolset to design or code this pull request, and that I am a human who coded this without any influence from an LLM.
