### PR TITLE
Bring parity to District and Plotgroup metadata methods

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/District.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/District.java
@@ -2,6 +2,9 @@ package com.palmergames.bukkit.towny.object;
 
 import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.TownyUniverse;
+import com.palmergames.bukkit.towny.object.metadata.CustomDataField;
+import org.jetbrains.annotations.NotNull;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -124,6 +127,16 @@ public class District extends ObjectGroup implements Nameable, Savable {
 
 	public boolean hasTownBlock(TownBlock townBlock) {
 		return townBlocks.contains(townBlock);
+	}
+
+	@Override
+	public void addMetaData(@NotNull CustomDataField<?> md) {
+		this.addMetaData(md, true);
+	}
+
+	@Override
+	public void removeMetaData(@NotNull CustomDataField<?> md) {
+		this.removeMetaData(md, true);
 	}
 
 	@Override

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/PlotGroup.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/PlotGroup.java
@@ -2,6 +2,10 @@ package com.palmergames.bukkit.towny.object;
 
 import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.TownyUniverse;
+import com.palmergames.bukkit.towny.object.metadata.CustomDataField;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -11,8 +15,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-
-import org.jetbrains.annotations.Nullable;
 
 /**
  * @author Suneet Tipirneni (Siris)
@@ -249,5 +251,15 @@ public class PlotGroup extends ObjectGroup implements TownBlockOwner, Savable {
 
 	public int getMaxTownMembershipDays() {
 		return hasTownBlocks() ? townBlocks.get(0).getMaxTownMembershipDays() : -1;
+	}
+
+	@Override
+	public void addMetaData(@NotNull CustomDataField<?> md) {
+		this.addMetaData(md, true);
+	}
+
+	@Override
+	public void removeMetaData(@NotNull CustomDataField<?> md) {
+		this.removeMetaData(md, true);
 	}
 }


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This PR adds overridden methods for adding and removing metadata for districts and plot groups to bring parity with the other Towny objects, because the inherited methods do not default to saving the metadata when they are called. This differs to all other Towny objects with metadata, which override the methods to save the metadata by default. This disparity in the implementation could cause confusion for developers due the difference in behaviour between the Towny objects.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____

#### Attestations

- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.

In making this pull request, I declare that I have not used an AI toolset to design or code this pull request, and that I am a human who coded this without any influence from an LLM.
