### PR TITLE
Fix resident toggle reset/clear behavior

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/HelpMenu.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/HelpMenu.java
@@ -833,7 +833,7 @@ public enum HelpMenu {
 				.add("spy", Translatable.of("res_toggle_help_11"))
 				.add("infotool", Translatable.of("res_toggle_help_15"))
 				.add("adminbypass", Translatable.of("res_toggle_help_16"))
-				.add("Eg: /resident set mode map townclaim town nation general");
+				.add("Eg: /resident set mode map plotborder");
 		}
 	},
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/ResidentCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/ResidentCommand.java
@@ -10,6 +10,7 @@ import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.TownyCommandAddonAPI.CommandType;
 import com.palmergames.bukkit.towny.confirmations.Confirmation;
+import com.palmergames.bukkit.towny.exceptions.NoPermissionException;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.SpawnType;
@@ -96,13 +97,13 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 	private static final List<String> residentToggleModeTabCompletes = ResidentModeHandler.getValidModeNames();
 
 	private static final List<String> residentSetModeTabCompletesWithClearAndReset = Stream.concat(
-		Arrays.asList("reset", "clear").stream(),
+		Stream.of("reset", "clear"),
 		new ArrayList<>(residentToggleModeTabCompletes).stream()
 	).collect(Collectors.toList());
 
 	private static final List<String> residentCompleteToggleChoices = Stream.concat(
 		new ArrayList<>(residentToggleChoices).stream(),
-		new ArrayList<>(residentToggleModeTabCompletes).stream()
+		new ArrayList<>(residentSetModeTabCompletesWithClearAndReset).stream()
 	).collect(Collectors.toList());
 
 	public ResidentCommand(Towny instance) {
@@ -397,17 +398,10 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 			return;
 		}
 
-		// Check if we're reseting before trying for nodes.
-		if (newSplit[0].equalsIgnoreCase("clear")) {
-			checkPermOrThrow(resident.getPlayer(), PermissionNodes.TOWNY_COMMAND_RESIDENT_SET_MODE_CLEAR.getNode());
-			ResidentModeHandler.clearModes(resident, false);
+		// Check if we're resetting before trying for nodes.
+		if (clearResidentModes(resident, newSplit))
 			return;
-		}
 
-		if (newSplit[0].equalsIgnoreCase("reset")) {
-			ResidentModeHandler.resetModes(resident, false);
-			return;
-		}
 		TownyPermission perm = resident.getPermissions();
 		
 		Optional<Boolean> choice = Optional.empty();
@@ -531,18 +525,24 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 			return;
 		}
 
+		if (clearResidentModes(resident, split))
+			return;
+
+		ResidentModeHandler.toggleModes(resident, split, true, false);
+	}
+
+	private boolean clearResidentModes(Resident resident, String[] split) throws NoPermissionException {
 		if (split[0].equalsIgnoreCase("clear")) {
 			checkPermOrThrow(resident.getPlayer(), PermissionNodes.TOWNY_COMMAND_RESIDENT_SET_MODE_CLEAR.getNode());
 			ResidentModeHandler.clearModes(resident, true);
-			return;
+			return true;
 		}
 
 		if (split[0].equalsIgnoreCase("reset")) {
 			ResidentModeHandler.resetModes(resident, true);
-			return;
+			return true;
 		}
-
-		ResidentModeHandler.toggleModes(resident, split, true, false);
+		return false;
 	}
 
 	private void setAbout(Player player, String about, Resident resident) throws TownyException {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/ResidentCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/ResidentCommand.java
@@ -399,7 +399,7 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 		}
 
 		// Check if we're resetting before trying for nodes.
-		if (clearResidentModes(resident, newSplit))
+		if (clearOrResetResidentModes(resident, newSplit))
 			return;
 
 		TownyPermission perm = resident.getPermissions();
@@ -525,13 +525,13 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 			return;
 		}
 
-		if (clearResidentModes(resident, split))
+		if (clearOrResetResidentModes(resident, split))
 			return;
 
 		ResidentModeHandler.toggleModes(resident, split, true, false);
 	}
 
-	private boolean clearResidentModes(Resident resident, String[] split) throws NoPermissionException {
+	private boolean clearOrResetResidentModes(Resident resident, String[] split) throws NoPermissionException {
 		if (split[0].equalsIgnoreCase("clear")) {
 			checkPermOrThrow(resident.getPlayer(), PermissionNodes.TOWNY_COMMAND_RESIDENT_SET_MODE_CLEAR.getNode());
 			ResidentModeHandler.clearModes(resident, true);


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This PR fixes the `/resident toggle` command to include tab completions for "clear" and "reset" as well as notifying the player of the resident modes that are active after the command, to replicate the functionality of `/resident set mode clear|reset`.

The help for the `/resident set mode` has been updated to not include channels, because they no longer work for resident modes, and to only include non-destructive resident modes, so blindly following the help command example does not result in permanent consequences, such as town land claim which can cost money.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____

#### Attestations

- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.

In making this pull request, I declare that I have not used an AI toolset to design or code this pull request, and that I am a human who coded this without any influence from an LLM.
