### PR TITLE
Check if a town can bypass the adjacent chunk check per-world

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/config/ConfigNodes.java
@@ -1310,6 +1310,11 @@ public enum ConfigNodes {
 			"# The amount of residents a town needs to claim an outpost,",
 			"# Setting this value to 0, means a town can claim outposts no matter how many residents.",
 			"# This setting is ignored when limit_outposts_using_town_and_nation_levels is set to true."),
+	CLAIMING_LIMIT_OUTPOSTS_PER_WORLD(
+		"claiming.outposts.limit_outposts_per_world",
+		"false",
+		"",
+		"# Setting this value to true will only allow towns to claim outposts in worlds they don't have claims in"),
 
 	CLAIMING_OVERCLAIMING_ROOT("claiming.overclaiming", "", "", ""),
 	CLAIMING_OVER_ALLOWED_CLAIM_LIMITS_ALLOWS_STEALING_LAND(

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -3450,6 +3450,10 @@ public class TownySettings {
 	public static int getAmountOfResidentsForOutpost() {
 		return getInt(ConfigNodes.CLAIMING_MINIMUM_AMOUNT_RESIDENTS_FOR_OUTPOSTS);
 	}
+	
+	public static boolean getOutpostsLimitedPerWorld() {
+		return getBoolean(ConfigNodes.CLAIMING_LIMIT_OUTPOSTS_PER_WORLD);
+	}
 
 	public static int getMaximumInvitesSentTown() {
 		return getInt(ConfigNodes.INVITE_SYSTEM_MAXIMUM_INVITES_SENT_TOWN);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -3731,6 +3731,10 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		// attached to a claimed plot.
 		if (!outpost && !isEdgeBlock(town, selection) && !town.getTownBlocks().isEmpty())
 			throw new TownyException(Translatable.of("msg_err_not_attached_edge"));
+		TownyWorld world = selection.getFirst().getTownyWorld();
+		if (outpost && TownySettings.getOutpostsLimitedPerWorld() && world != null && !town.getTownBlocksInWorld(world).isEmpty()) {
+			throw new TownyException(Translatable.of("msg_err_cannot_claim_outpost_in_claimed_world"));
+		}
 	}
 
 	private static void fireTownPreClaimEventOrThrow(Player player, Town town, boolean outpost, List<WorldCoord> selection) throws TownyException {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Town.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Town.java
@@ -165,6 +165,16 @@ public class Town extends Government implements TownBlockOwner {
 	public Collection<TownBlock> getTownBlocks() {
 		return Collections.unmodifiableCollection(townBlocks.values());
 	}
+	
+	public Collection<TownBlock> getTownBlocksInWorld(@NotNull TownyWorld world) {
+		List<TownBlock> list = new ArrayList<>();
+		for (Map.Entry<WorldCoord, TownBlock> entry : townBlocks.entrySet()) {
+			if (world.getName().equals(entry.getKey().getWorldName())) {
+				list.add(entry.getValue());
+			}
+		}
+		return Collections.unmodifiableCollection(list);
+	}
 
 	public int getNumTownBlocks() {
 		return getTownBlocks().size();

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/ProximityUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/ProximityUtil.java
@@ -104,7 +104,7 @@ public class ProximityUtil {
 	}
 
 	public static void testAdjacentClaimsRulesOrThrow(WorldCoord townBlockToClaim, Town town, boolean outpost, int minAdjacentBlocks) throws TownyException {
-		if (!outpost && minAdjacentBlocks > 0 && townHasClaimedEnoughLandToBeRestrictedByAdjacentClaims(town, minAdjacentBlocks)) {
+		if (!outpost && minAdjacentBlocks > 0 && townHasClaimedEnoughLandToBeRestrictedByAdjacentClaims(town, minAdjacentBlocks, townBlockToClaim)) {
 			// Only consider the first worldCoord, larger selection-claims will automatically "bubble" anyways.
 			int numAdjacent = numAdjacentTownOwnedTownBlocks(town, townBlockToClaim);
 			// The number of adjacent TBs is not enough and there is not a nearby outpost.
@@ -113,11 +113,13 @@ public class ProximityUtil {
 		}
 	}
 
-	private static boolean townHasClaimedEnoughLandToBeRestrictedByAdjacentClaims(Town town, int minAdjacentBlocks) {
-		if (minAdjacentBlocks == 3 && town.getTownBlocks().size() < 5)
+	private static boolean townHasClaimedEnoughLandToBeRestrictedByAdjacentClaims(Town town, int minAdjacentBlocks, WorldCoord worldCoord) {
+		TownyWorld world = worldCoord.getTownyWorld();
+		int claimedTownBlocks = world != null ? town.getTownBlocksInWorld(world).size() : town.getNumTownBlocks();
+		if (minAdjacentBlocks == 3 && claimedTownBlocks < 5)
 			// Special rule that makes sure a town can claim a fifth plot after claiming a 2x2 square.
 			return false;
-		return town.getTownBlocks().size() > minAdjacentBlocks;
+		return claimedTownBlocks > minAdjacentBlocks;
 	}
 
 	private static int numAdjacentTownOwnedTownBlocks(Town town, WorldCoord worldCoord) {
@@ -181,7 +183,7 @@ public class ProximityUtil {
 	
 	public static void testAdjacentUnclaimsRulesOrThrow(WorldCoord townBlockToUnclaim, Town town, int minAdjacentBlocks) throws TownyException {
 		// Prevent unclaiming land that would reduce the number of adjacent claims of neighbouring plots below the threshold.
-		if (minAdjacentBlocks > 0 && townHasClaimedEnoughLandToBeRestrictedByAdjacentClaims(town, minAdjacentBlocks)) {
+		if (minAdjacentBlocks > 0 && townHasClaimedEnoughLandToBeRestrictedByAdjacentClaims(town, minAdjacentBlocks, townBlockToUnclaim)) {
 
 			// Outposts cannot be unclaimed when there are any connected townblocks.
 			if (townBlockToUnclaim.getTownBlockOrNull().isOutpost() && numAdjacentTownOwnedTownBlocks(town, townBlockToUnclaim) > 0)
@@ -213,7 +215,7 @@ public class ProximityUtil {
 	 */
 
 	public static void testAdjacentAddDistrictRulesOrThrow(WorldCoord townBlockToClaim, Town town, District district, int minAdjacentBlocks) throws TownyException {
-		if (minAdjacentBlocks > 0 && townHasClaimedEnoughLandToBeRestrictedByAdjacentClaims(town, minAdjacentBlocks)) {
+		if (minAdjacentBlocks > 0 && townHasClaimedEnoughLandToBeRestrictedByAdjacentClaims(town, minAdjacentBlocks, townBlockToClaim)) {
 			int numAdjacent = numAdjacentDistrictTownBlocks(town, district, townBlockToClaim);
 			// The number of adjacement TBs with the same District is not enough.
 			if (numAdjacent < minAdjacentBlocks)
@@ -231,7 +233,7 @@ public class ProximityUtil {
 
 	public static void testAdjacentRemoveDistrictRulesOrThrow(WorldCoord districtCoordBeingRemoved, Town town, District district, int minAdjacentBlocks) throws TownyException {
 		// Prevent removing parts of Districts that would cause a district to split into two sections.
-		if (minAdjacentBlocks > 0 && townHasClaimedEnoughLandToBeRestrictedByAdjacentClaims(town, minAdjacentBlocks)) {
+		if (minAdjacentBlocks > 0 && townHasClaimedEnoughLandToBeRestrictedByAdjacentClaims(town, minAdjacentBlocks, districtCoordBeingRemoved)) {
 			List<WorldCoord> allAdjacentDistrictWorldCoords = getAdjacentDistrictWorldCoords(town, district, districtCoordBeingRemoved, false);
 			int districtPlots = allAdjacentDistrictWorldCoords.size();
 

--- a/Towny/src/main/resources/lang/en-US.yml
+++ b/Towny/src/main/resources/lang/en-US.yml
@@ -2731,3 +2731,5 @@ msg_list_plotgroups_trustlist_component: " (Group of %s plots)"
 msg_list_trusted_hover: "Trusts: %s"
 
 msg_err_no_ruined_town_here: "You must be standing in a ruined town to reclaim it when you're not a resident."
+
+msg_err_cannot_claim_outpost_in_claimed_world: "You cannot claim an outpost in this world, as your town already has claims here."


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This updates the ProximityUtil check for if a town is large enough to enforce adjacent chunk rules, to keep in mind the TownyWorld the check is happening for
____

#### Attestations

- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.

In making this pull request, I declare that I have not used an AI toolset to design or code this pull request, and that I am a human who coded this without any influence from an LLM.
